### PR TITLE
Remove ref count from bucket map

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -198,7 +198,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     Self::update_stat(&self.stats().load_disk_missing_count, 1);
                 }
             }
-            entry_disk.map(|(slot_list, _ref_count)| slot_list)
+            entry_disk
         })
     }
 
@@ -450,7 +450,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> u64 {
         let mut grow_us = 0u64;
         loop {
-            match disk.try_write(pubkey, (disk_entry, 1)) {
+            match disk.try_write(pubkey, disk_entry) {
                 Ok(_) => break,
                 Err(err) => {
                     let m = Measure::start("flush_grow");
@@ -1597,7 +1597,7 @@ mod tests {
         let slot = 0;
 
         // Simulate an entry on disk
-        let disk_entry: (&[(u64, u64)], u64) = (&[(0u64, 42u64)], 1u64);
+        let disk_entry = &[(0u64, 42u64)];
         accounts_index
             .bucket
             .as_ref()

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -463,7 +463,7 @@ impl Stats {
                     disk.map(|disk| disk
                         .stats
                         .index
-                        .index_uses_uncommon_slot_list_len_or_refcount
+                        .index_uses_uncommon_slot_list_len
                         .load(Ordering::Relaxed))
                         .unwrap_or_default(),
                     i64

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -402,8 +402,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                     OccupyIfMatches::SuccessfulInit => {}
                     OccupyIfMatches::FoundDuplicate => {
                         // pubkey is same, and it is occupied, so we found a duplicate
-                        let v_existing =
-                            elem.read_value(index, data_buckets);
+                        let v_existing = elem.read_value(index, data_buckets);
                         // someone is already allocated with this pubkey, so we found a duplicate
                         duplicates.push((ix, *v_existing.first().unwrap()));
                     }
@@ -479,8 +478,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                 } else {
                     // occupied, see if the key already exists here
                     if elem.key(index) == k {
-                        let v_existing =
-                            elem.read_value(index, data_buckets);
+                        let v_existing = elem.read_value(index, data_buckets);
                         duplicates.push((i, *v_existing.first().unwrap()));
                         continue 'outer; // this 'insertion' is completed: found a duplicate entry
                     }
@@ -541,7 +539,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                 } else {
                     self.stats
                         .index
-                        .index_uses_uncommon_slot_list_len_or_refcount
+                        .index_uses_uncommon_slot_list_len
                         .store(true, Ordering::Relaxed);
                     OccupiedEnum::ZeroSlots
                 },
@@ -561,7 +559,6 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
             let elem_loc = multiple_slots.data_loc(current_bucket);
 
             if best_fit_bucket == bucket_ix as u64 {
-
                 // write data
                 assert!(!current_bucket.is_free(elem_loc));
                 let slice: &mut [T] = current_bucket.get_slice_mut(
@@ -635,7 +632,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                 );
                 self.stats
                     .index
-                    .index_uses_uncommon_slot_list_len_or_refcount
+                    .index_uses_uncommon_slot_list_len
                     .store(true, Ordering::Relaxed);
                 success = true;
                 break;

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -2,7 +2,7 @@
 use crate::bucket_item::BucketItem;
 use {
     crate::{
-        MaxSearch, RefCount,
+        MaxSearch,
         bucket_map::BucketMapError,
         bucket_stats::BucketMapStats,
         bucket_storage::{
@@ -199,10 +199,9 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
             }
             let ix = IndexEntryPlaceInBucket::new(ii);
             let key = ix.key(&self.index);
-            let (v, ref_count) = ix.read_value(&self.index, &self.data);
+            let v = ix.read_value(&self.index, &self.data);
             result.push(BucketItem {
                 pubkey: *key,
-                ref_count,
                 slot_list: v.to_vec(),
             });
         }
@@ -296,7 +295,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         Err(BucketMapError::IndexNoSpace(index.contents.capacity()))
     }
 
-    pub(crate) fn read_value(&self, key: &Pubkey) -> Option<(&[T], RefCount)> {
+    pub(crate) fn read_value(&self, key: &Pubkey) -> Option<&[T]> {
         //debug!("READ_VALUE: {:?}", key);
         let (elem, _) = self.find_index_entry(key)?;
         Some(elem.read_value(&self.index, &self.data))
@@ -314,7 +313,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         inserts
     }
 
-    /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
+    /// batch insert of `items`. Assumption is a single slot list element
     /// For any pubkeys that already exist, the index in `items` of the failed insertion and the existing data (previously put in the index) are returned.
     pub(crate) fn batch_insert_non_duplicates(&mut self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
         assert!(
@@ -403,7 +402,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                     OccupyIfMatches::SuccessfulInit => {}
                     OccupyIfMatches::FoundDuplicate => {
                         // pubkey is same, and it is occupied, so we found a duplicate
-                        let (v_existing, _ref_count_existing) =
+                        let v_existing =
                             elem.read_value(index, data_buckets);
                         // someone is already allocated with this pubkey, so we found a duplicate
                         duplicates.push((ix, *v_existing.first().unwrap()));
@@ -480,7 +479,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                 } else {
                     // occupied, see if the key already exists here
                     if elem.key(index) == k {
-                        let (v_existing, _ref_count_existing) =
+                        let v_existing =
                             elem.read_value(index, data_buckets);
                         duplicates.push((i, *v_existing.first().unwrap()));
                         continue 'outer; // this 'insertion' is completed: found a duplicate entry
@@ -501,12 +500,11 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         key: &Pubkey,
         mut data: impl Iterator<Item = &'b T>,
         data_len: usize,
-        ref_count: RefCount,
     ) -> Result<(), BucketMapError> {
         let num_slots = data_len as u64;
         let best_fit_bucket = MultipleSlots::data_bucket_from_num_slots(data_len as u64);
         // num_slots > 1 because we can store num_slots = 0 or num_slots = 1 in the index entry
-        let requires_data_bucket = num_slots > 1 || ref_count != 1;
+        let requires_data_bucket = num_slots > 1;
         if requires_data_bucket && self.data.get(best_fit_bucket as usize).is_none() {
             // fail early if the data bucket we need doesn't exist - we don't want the index entry partially allocated
             return Err(BucketMapError::DataNoSpace((best_fit_bucket, 0)));
@@ -563,8 +561,6 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
             let elem_loc = multiple_slots.data_loc(current_bucket);
 
             if best_fit_bucket == bucket_ix as u64 {
-                // in place update in same data file
-                MultipleSlots::set_ref_count(current_bucket, elem_loc, ref_count);
 
                 // write data
                 assert!(!current_bucket.is_free(elem_loc));
@@ -611,7 +607,6 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
                 multiple_slots
                     .set_storage_capacity_when_created_pow2(best_bucket.contents.capacity_pow2());
                 multiple_slots.set_num_slots(num_slots);
-                MultipleSlots::set_ref_count(best_bucket, ix, ref_count);
 
                 //debug!(                        "DATA ALLOC {:?} {} {} {}",                        key, elem.data_location, best_bucket.capacity, elem_uid                    );
                 let best_bucket = &mut self.data[best_fit_bucket as usize];
@@ -858,10 +853,9 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
         }
     }
 
-    pub fn insert(&mut self, key: &Pubkey, value: (&[T], RefCount)) {
-        let (new, refct) = value;
+    pub fn insert(&mut self, key: &Pubkey, value: &[T]) {
         loop {
-            let Err(err) = self.try_write(key, new.iter(), new.len(), refct) else {
+            let Err(err) = self.try_write(key, value.iter(), value.len()) else {
                 return;
             };
             self.grow(err);
@@ -871,7 +865,7 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
 
     pub fn update<F>(&mut self, key: &Pubkey, mut updatefn: F)
     where
-        F: FnMut(Option<(&[T], RefCount)>) -> Option<(Vec<T>, RefCount)>,
+        F: FnMut(Option<&[T]>) -> Option<Vec<T>>,
     {
         let current = self.read_value(key);
         let new = updatefn(current);
@@ -879,8 +873,8 @@ impl<'b, T: Clone + Copy + PartialEq + std::fmt::Debug + 'static> Bucket<T> {
             self.delete_key(key);
             return;
         }
-        let (new, refct) = new.unwrap();
-        self.insert(key, (&new, refct));
+        let new = new.unwrap();
+        self.insert(key, &new);
     }
 }
 
@@ -1318,8 +1312,7 @@ mod tests {
                     let elem = IndexEntryPlaceInBucket::new(
                         single_hashed_raw_inserted.0 % index.capacity(),
                     );
-                    let (value, ref_count) = elem.read_value(&index, &data_buckets);
-                    assert_eq!(ref_count, 1);
+                    let value = elem.read_value(&index, &data_buckets);
                     assert_eq!(value, &[raw[single_hashed_raw_inserted.1].1]);
                     let expected_duplicates = hashed_raw
                         .iter()
@@ -1371,8 +1364,7 @@ mod tests {
                     (0..len).for_each(|i| {
                         let raw2 = hashed_raw[i];
                         let elem = IndexEntryPlaceInBucket::new(raw2.0 % index.capacity());
-                        let (value, ref_count) = elem.read_value(&index, &data_buckets);
-                        assert_eq!(ref_count, 1);
+                        let value = elem.read_value(&index, &data_buckets);
                         assert_eq!(value, &[raw[hashed_raw[i].1].1]);
                     });
                 }
@@ -1440,8 +1432,7 @@ mod tests {
                                 let elem = IndexEntryPlaceInBucket::new(
                                     (raw2.0 + search_required) % index.capacity(),
                                 );
-                                let (value, ref_count) = elem.read_value(&index, &data_buckets);
-                                assert_eq!(ref_count, 1);
+                                let value = elem.read_value(&index, &data_buckets);
                                 assert_eq!(value, &[raw[hashed_raw[i].1].1]);
                             }
                         });
@@ -1578,7 +1569,7 @@ mod tests {
         let key = Pubkey::new_unique();
         assert_eq!(bucket.read_value(&key), None);
 
-        bucket.update(&key, |_| Some((vec![0], 0)));
+        bucket.update(&key, |_| Some(vec![0]));
         bucket.delete_key(&key);
 
         bucket.batch_insert_non_duplicates(&[]);

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -2,8 +2,8 @@
 use crate::bucket_item::BucketItem;
 use {
     crate::{
-        MaxSearch, bucket::Bucket, bucket_map::BucketMapError,
-        bucket_stats::BucketMapStats, restart::RestartableBucket,
+        MaxSearch, bucket::Bucket, bucket_map::BucketMapError, bucket_stats::BucketMapStats,
+        restart::RestartableBucket,
     },
     solana_pubkey::Pubkey,
     std::{
@@ -69,11 +69,11 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
 
     /// Get the values for Pubkey `key`
     pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<C> {
-        self.bucket.read().unwrap().as_ref().and_then(|bucket| {
-            bucket
-                .read_value(key)
-                .map(|value| C::from(value))
-        })
+        self.bucket
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(|bucket| bucket.read_value(key).map(|value| C::from(value)))
     }
 
     pub fn bucket_len(&self) -> u64 {
@@ -145,11 +145,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
         bucket.as_mut().unwrap().update(key, updatefn)
     }
 
-    pub fn try_write(
-        &self,
-        pubkey: &Pubkey,
-        value: &[T],
-    ) -> Result<(), BucketMapError> {
+    pub fn try_write(&self, pubkey: &Pubkey, value: &[T]) -> Result<(), BucketMapError> {
         let mut bucket = self.get_write_bucket();
         bucket
             .as_mut()

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -2,7 +2,7 @@
 use crate::bucket_item::BucketItem;
 use {
     crate::{
-        MaxSearch, RefCount, bucket::Bucket, bucket_map::BucketMapError,
+        MaxSearch, bucket::Bucket, bucket_map::BucketMapError,
         bucket_stats::BucketMapStats, restart::RestartableBucket,
     },
     solana_pubkey::Pubkey,
@@ -68,11 +68,11 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     }
 
     /// Get the values for Pubkey `key`
-    pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<(C, RefCount)> {
+    pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<C> {
         self.bucket.read().unwrap().as_ref().and_then(|bucket| {
             bucket
                 .read_value(key)
-                .map(|(value, ref_count)| (C::from(value), ref_count))
+                .map(|value| C::from(value))
         })
     }
 
@@ -110,7 +110,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
         bucket
     }
 
-    pub fn insert(&self, pubkey: &Pubkey, value: (&[T], RefCount)) {
+    pub fn insert(&self, pubkey: &Pubkey, value: &[T]) {
         let mut bucket = self.get_write_bucket();
         bucket.as_mut().unwrap().insert(pubkey, value)
     }
@@ -130,7 +130,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
         bucket.as_mut().unwrap().set_anticipated_count(count);
     }
 
-    /// batch insert of `items`. Assumption is a single slot list element and ref_count == 1.
+    /// batch insert of `items`. Assumption is a single slot list element
     /// For any pubkeys that already exist, the index in `items` of the failed insertion and the existing data (previously put in the index) are returned.
     pub fn batch_insert_non_duplicates(&self, items: &[(Pubkey, T)]) -> Vec<(usize, T)> {
         let mut bucket = self.get_write_bucket();
@@ -139,7 +139,7 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
 
     pub fn update<F>(&self, key: &Pubkey, updatefn: F)
     where
-        F: FnMut(Option<(&[T], RefCount)>) -> Option<(Vec<T>, RefCount)>,
+        F: FnMut(Option<&[T]>) -> Option<Vec<T>>,
     {
         let mut bucket = self.get_write_bucket();
         bucket.as_mut().unwrap().update(key, updatefn)
@@ -148,12 +148,12 @@ impl<T: Clone + Copy + PartialEq + std::fmt::Debug> BucketApi<T> {
     pub fn try_write(
         &self,
         pubkey: &Pubkey,
-        value: (&[T], RefCount),
+        value: &[T],
     ) -> Result<(), BucketMapError> {
         let mut bucket = self.get_write_bucket();
         bucket
             .as_mut()
             .unwrap()
-            .try_write(pubkey, value.0.iter(), value.0.len(), value.1)
+            .try_write(pubkey, value.iter(), value.len())
     }
 }

--- a/bucket_map/src/bucket_item.rs
+++ b/bucket_map/src/bucket_item.rs
@@ -1,9 +1,8 @@
 #![cfg(feature = "dev-context-only-utils")]
-use {crate::RefCount, solana_pubkey::Pubkey};
+use solana_pubkey::Pubkey;
 
 #[derive(Debug, Default, Clone)]
 pub struct BucketItem<T> {
     pub pubkey: Pubkey,
-    pub ref_count: RefCount,
     pub slot_list: Vec<T>,
 }

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -1,9 +1,7 @@
 //! BucketMap is a mostly contention free concurrent map backed by MmapMut
 
 use {
-    crate::{
-        MaxSearch, bucket_api::BucketApi, bucket_stats::BucketMapStats, restart::Restart,
-    },
+    crate::{MaxSearch, bucket_api::BucketApi, bucket_stats::BucketMapStats, restart::Restart},
     solana_pubkey::Pubkey,
     std::{
         convert::TryInto,
@@ -402,10 +400,9 @@ mod tests {
 
             let gen_rand_value = || {
                 let count = rng().random_range(0..max_slot_list_len);
-                let v = (0..count)
+                (0..count)
                     .map(|x| (x as usize, x as usize /*rng().random::<usize>()*/))
-                    .collect::<Vec<_>>();
-                v
+                    .collect::<Vec<_>>()
             };
 
             let get_key = || {

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        MaxSearch, RefCount, bucket_api::BucketApi, bucket_stats::BucketMapStats, restart::Restart,
+        MaxSearch, bucket_api::BucketApi, bucket_stats::BucketMapStats, restart::Restart,
     },
     solana_pubkey::Pubkey,
     std::{
@@ -154,7 +154,7 @@ impl<T: Clone + Copy + Debug + PartialEq> BucketMap<T> {
     }
 
     /// Get the values for Pubkey `key`
-    pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<(C, RefCount)> {
+    pub fn read_value<C: for<'a> From<&'a [T]>>(&self, key: &Pubkey) -> Option<C> {
         self.get_bucket(key).read_value(key)
     }
 
@@ -164,19 +164,19 @@ impl<T: Clone + Copy + Debug + PartialEq> BucketMap<T> {
     }
 
     /// Update Pubkey `key`'s value with 'value'
-    pub fn insert(&self, key: &Pubkey, value: (&[T], RefCount)) {
+    pub fn insert(&self, key: &Pubkey, value: &[T]) {
         self.get_bucket(key).insert(key, value)
     }
 
     /// Update Pubkey `key`'s value with 'value'
-    pub fn try_insert(&self, key: &Pubkey, value: (&[T], RefCount)) -> Result<(), BucketMapError> {
+    pub fn try_insert(&self, key: &Pubkey, value: &[T]) -> Result<(), BucketMapError> {
         self.get_bucket(key).try_write(key, value)
     }
 
     /// Update Pubkey `key`'s value with function `updatefn`
     pub fn update<F>(&self, key: &Pubkey, updatefn: F)
     where
-        F: FnMut(Option<(&[T], RefCount)>) -> Option<(Vec<T>, RefCount)>,
+        F: FnMut(Option<&[T]>) -> Option<Vec<T>>,
     {
         self.get_bucket(key).update(key, updatefn)
     }
@@ -210,7 +210,6 @@ fn read_be_u64(input: &[u8]) -> u64 {
 mod tests {
     use {
         super::*,
-        crate::index_entry::MAX_LEGAL_REFCOUNT,
         rand::{Rng, rng},
         std::{collections::HashMap, sync::RwLock},
     };
@@ -220,8 +219,8 @@ mod tests {
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
-        index.update(&key, |_| Some((vec![0], 1)));
-        assert_eq!(index.read_value(&key), Some((vec![0], 1)));
+        index.update(&key, |_| Some(vec![0]));
+        assert_eq!(index.read_value(&key), Some(vec![0]));
     }
 
     #[test]
@@ -231,23 +230,24 @@ mod tests {
             let config = BucketMapConfig::new(1 << 1);
             let index = BucketMap::new(config);
             let bucket = index.get_bucket(&key);
+            // 2 slots require a data bucket, which does not exist until we grow
             if pass == 0 {
-                index.insert(&key, (&[0], 0));
+                index.insert(&key, &[0, 1]);
             } else {
-                let result = index.try_insert(&key, (&[0], 0));
+                let result = index.try_insert(&key, &[0, 1]);
                 assert!(result.is_err());
                 assert_eq!(index.read_value::<Vec<_>>(&key), None);
                 if pass == 2 {
                     // another call to try insert again - should still return an error
-                    let result = index.try_insert(&key, (&[0], 0));
+                    let result = index.try_insert(&key, &[0, 1]);
                     assert!(result.is_err());
                     assert_eq!(index.read_value::<Vec<_>>(&key), None);
                 }
                 bucket.grow(result.unwrap_err());
-                let result = index.try_insert(&key, (&[0], 0));
+                let result = index.try_insert(&key, &[0, 1]);
                 assert!(result.is_ok());
             }
-            assert_eq!(index.read_value(&key), Some((vec![0], 0)));
+            assert_eq!(index.read_value(&key), Some(vec![0, 1]));
         }
     }
 
@@ -256,10 +256,10 @@ mod tests {
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
-        index.insert(&key, (&[0], 1));
-        assert_eq!(index.read_value(&key), Some((vec![0], 1)));
-        index.insert(&key, (&[1], 1));
-        assert_eq!(index.read_value(&key), Some((vec![1], 1)));
+        index.insert(&key, &[0]);
+        assert_eq!(index.read_value(&key), Some(vec![0]));
+        index.insert(&key, &[1]);
+        assert_eq!(index.read_value(&key), Some(vec![1]));
     }
 
     #[test]
@@ -267,10 +267,10 @@ mod tests {
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
-        index.update(&key, |_| Some((vec![0], 1)));
-        assert_eq!(index.read_value(&key), Some((vec![0], 1)));
-        index.update(&key, |_| Some((vec![1], 1)));
-        assert_eq!(index.read_value(&key), Some((vec![1], 1)));
+        index.update(&key, |_| Some(vec![0]));
+        assert_eq!(index.read_value(&key), Some(vec![0]));
+        index.update(&key, |_| Some(vec![1]));
+        assert_eq!(index.read_value(&key), Some(vec![1]));
     }
 
     #[test]
@@ -278,17 +278,17 @@ mod tests {
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
-        index.update(&key, |_| Some((vec![0], 1)));
-        assert_eq!(index.read_value(&key), Some((vec![0], 1)));
+        index.update(&key, |_| Some(vec![0]));
+        assert_eq!(index.read_value(&key), Some(vec![0]));
         // sets len to 0, updates in place
-        index.update(&key, |_| Some((vec![], 1)));
-        assert_eq!(index.read_value(&key), Some((vec![], 1)));
+        index.update(&key, |_| Some(vec![]));
+        assert_eq!(index.read_value(&key), Some(vec![]));
         // sets len to 0, doesn't update in place - finds a new place, which causes us to no longer have an allocation in data
-        index.update(&key, |_| Some((vec![], 2)));
-        assert_eq!(index.read_value(&key), Some((vec![], 2)));
+        index.update(&key, |_| Some(vec![]));
+        assert_eq!(index.read_value(&key), Some(vec![]));
         // sets len to 1, doesn't update in place - finds a new place
-        index.update(&key, |_| Some((vec![1], 2)));
-        assert_eq!(index.read_value(&key), Some((vec![1], 2)));
+        index.update(&key, |_| Some(vec![1]));
+        assert_eq!(index.read_value(&key), Some(vec![1]));
     }
 
     #[test]
@@ -299,14 +299,14 @@ mod tests {
             let key = Pubkey::new_unique();
             assert_eq!(index.read_value::<Vec<_>>(&key), None);
 
-            index.update(&key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(&key), Some((vec![i], 1)));
+            index.update(&key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(&key), Some(vec![i]));
 
             index.delete_key(&key);
             assert_eq!(index.read_value::<Vec<_>>(&key), None);
 
-            index.update(&key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(&key), Some((vec![i], 1)));
+            index.update(&key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(&key), Some(vec![i]));
             index.delete_key(&key);
         }
     }
@@ -319,14 +319,14 @@ mod tests {
             let key = Pubkey::new_unique();
             assert_eq!(index.read_value::<Vec<_>>(&key), None);
 
-            index.update(&key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(&key), Some((vec![i], 1)));
+            index.update(&key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(&key), Some(vec![i]));
 
             index.delete_key(&key);
             assert_eq!(index.read_value::<Vec<_>>(&key), None);
 
-            index.update(&key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(&key), Some((vec![i], 1)));
+            index.update(&key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(&key), Some(vec![i]));
             index.delete_key(&key);
         }
     }
@@ -337,8 +337,8 @@ mod tests {
         let index = BucketMap::new(config);
         for i in 0..100 {
             let key = Pubkey::new_unique();
-            index.update(&key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(&key), Some((vec![i], 1)));
+            index.update(&key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(&key), Some(vec![i]));
         }
     }
     #[test]
@@ -349,12 +349,12 @@ mod tests {
         for k in 0..keys.len() {
             let key = &keys[k];
             let i = read_be_u64(key.as_ref());
-            index.update(key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(key), Some((vec![i], 1)));
+            index.update(key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(key), Some(vec![i]));
             for (ix, key) in keys.iter().enumerate() {
                 let i = read_be_u64(key.as_ref());
                 //debug!("READ: {:?} {}", key, i);
-                let expected = if ix <= k { Some((vec![i], 1)) } else { None };
+                let expected = if ix <= k { Some(vec![i]) } else { None };
                 assert_eq!(index.read_value(key), expected);
             }
         }
@@ -367,13 +367,13 @@ mod tests {
         let keys: Vec<Pubkey> = (0..20).map(|_| Pubkey::new_unique()).collect();
         for key in keys.iter() {
             let i = read_be_u64(key.as_ref());
-            index.update(key, |_| Some((vec![i], 1)));
-            assert_eq!(index.read_value(key), Some((vec![i], 1)));
+            index.update(key, |_| Some(vec![i]));
+            assert_eq!(index.read_value(key), Some(vec![i]));
         }
         for key in keys.iter() {
             let i = read_be_u64(key.as_ref());
             //debug!("READ: {:?} {}", key, i);
-            assert_eq!(index.read_value(key), Some((vec![i], 1)));
+            assert_eq!(index.read_value(key), Some(vec![i]));
         }
         for k in 0..keys.len() {
             let key = &keys[k];
@@ -381,7 +381,7 @@ mod tests {
             assert_eq!(index.read_value::<Vec<_>>(key), None);
             for key in keys.iter().skip(k + 1) {
                 let i = read_be_u64(key.as_ref());
-                assert_eq!(index.read_value(key), Some((vec![i], 1)));
+                assert_eq!(index.read_value(key), Some(vec![i]));
             }
         }
     }
@@ -396,7 +396,7 @@ mod tests {
                     BucketMap::new(config)
                 })
                 .collect::<Vec<_>>();
-            let hash_map = RwLock::new(HashMap::<Pubkey, (Vec<(usize, usize)>, RefCount)>::new());
+            let hash_map = RwLock::new(HashMap::<Pubkey, Vec<(usize, usize)>>::new());
             let max_slot_list_len = 5;
             let all_keys = Mutex::new(vec![]);
 
@@ -405,19 +405,7 @@ mod tests {
                 let v = (0..count)
                     .map(|x| (x as usize, x as usize /*rng().random::<usize>()*/))
                     .collect::<Vec<_>>();
-                let range = rng().random_range(0..100);
-                // pick ref counts that are useful and common
-                let rc = if range < 50 {
-                    1
-                } else if range < 60 {
-                    0
-                } else if range < 70 {
-                    2
-                } else {
-                    rng().random_range(0..MAX_LEGAL_REFCOUNT)
-                };
-
-                (v, rc)
+                v
             };
 
             let get_key = || {
@@ -454,8 +442,7 @@ mod tests {
                     for map in maps.iter_mut() {
                         for i in 0..map.len() {
                             if k == &map[i].pubkey {
-                                assert_eq!(map[i].slot_list, v.0);
-                                assert_eq!(map[i].ref_count, v.1);
+                                assert_eq!(&map[i].slot_list, v);
                                 map.remove(i);
                                 break;
                             }
@@ -489,16 +476,14 @@ mod tests {
                             let k = solana_pubkey::new_rand();
                             let mut v = gen_rand_value();
                             if use_batch_insert {
-                                // refcount has to be 1 to use batch insert
-                                v.1 = 1;
                                 // len has to be 1 to use batch insert
-                                if v.0.len() > 1 {
-                                    v.0.truncate(1);
-                                } else if v.0.is_empty() {
+                                if v.len() > 1 {
+                                    v.truncate(1);
+                                } else if v.is_empty() {
                                     loop {
                                         let mut new_v = gen_rand_value();
-                                        if !new_v.0.is_empty() {
-                                            v.0 = vec![new_v.0.pop().unwrap()];
+                                        if !new_v.is_empty() {
+                                            v = vec![new_v.pop().unwrap()];
                                             break;
                                         }
                                     }
@@ -523,7 +508,7 @@ mod tests {
                             let mut batch_additions = additions
                                 .clone()
                                 .into_iter()
-                                .map(|(k, mut v)| (k, v.0.pop().unwrap()))
+                                .map(|(k, mut v)| (k, v.pop().unwrap()))
                                 .collect::<Vec<_>>();
                             let mut duplicates = 0;
                             if batch_additions.len() > 1 && rng().random_range(0..2) == 0 {
@@ -547,7 +532,7 @@ mod tests {
                         } else {
                             additions.clone().into_iter().for_each(|(k, v)| {
                                 if insert {
-                                    map.insert(&k, (&v.0, v.1))
+                                    map.insert(&k, &v)
                                 } else {
                                     map.update(&k, |current| {
                                         assert!(current.is_none());
@@ -572,21 +557,21 @@ mod tests {
                     // update
                     if let Some(k) = get_key() {
                         let hm = hash_map.read().unwrap();
-                        let (v, rc) = gen_rand_value();
+                        let v = gen_rand_value();
                         let v_old = hm.get(&k);
                         let insert = rng().random_range(0..2) == 0;
                         maps.iter().for_each(|map| {
                             if insert {
-                                map.insert(&k, (&v, rc))
+                                map.insert(&k, &v)
                             } else {
                                 map.update(&k, |current| {
-                                    assert_eq!(current, v_old.map(|(v, rc)| (&v[..], *rc)), "{k}");
-                                    Some((v.clone(), rc))
+                                    assert_eq!(current, v_old.map(|v| &**v), "{k}");
+                                    Some(v.clone())
                                 })
                             }
                         });
                         drop(hm);
-                        hash_map.write().unwrap().insert(k, (v, rc));
+                        hash_map.write().unwrap().insert(k, v);
                         return_key(k);
                     }
                 }
@@ -603,17 +588,11 @@ mod tests {
                 if rng().random_range(0..10) == 0 {
                     // add/unref
                     if let Some(k) = get_key() {
-                        let mut inc = rng().random_range(0..2) == 0;
                         let mut hm = hash_map.write().unwrap();
-                        let (v, mut rc) = hm.get(&k).map(|(v, rc)| (v.to_vec(), *rc)).unwrap();
-                        if !inc && rc == 0 {
-                            // can't decrement rc=0
-                            inc = true;
-                        }
-                        rc = if inc { rc + 1 } else { rc - 1 };
-                        hm.insert(k, (v.to_vec(), rc));
+                        let v = hm.get(&k).map(|v| v.to_vec()).unwrap();
+                        hm.insert(k, v.to_vec());
                         maps.iter().for_each(|map| {
-                            map.update(&k, |current| Some((current.unwrap().0.to_vec(), rc)))
+                            map.update(&k, |current| Some(current.unwrap().to_vec()))
                         });
 
                         return_key(k);

--- a/bucket_map/src/bucket_stats.rs
+++ b/bucket_map/src/bucket_stats.rs
@@ -21,7 +21,7 @@ pub struct BucketStats {
     pub file_count: AtomicU64,
     pub total_file_size: AtomicU64,
     pub startup: StartupBucketStats,
-    pub index_uses_uncommon_slot_list_len_or_refcount: AtomicBool,
+    pub index_uses_uncommon_slot_list_len: AtomicBool,
 }
 
 impl BucketStats {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -318,18 +318,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
             }
     }
 
-    pub(crate) fn get_header<T>(&self, ix: u64) -> &T {
-        let slice = self.get_slice::<T>(ix, 1, IncludeHeader::Header);
-        // SAFETY: `get_cell_slice` ensures there's at least one element in the slice
-        unsafe { slice.get_unchecked(0) }
-    }
-
-    pub(crate) fn get_header_mut<T>(&mut self, ix: u64) -> &mut T {
-        let slice = self.get_slice_mut::<T>(ix, 1, IncludeHeader::Header);
-        // SAFETY: `get_mut_cell_slice` ensures there's at least one element in the slice
-        unsafe { slice.get_unchecked_mut(0) }
-    }
-
     pub(crate) fn get<T>(&self, ix: u64) -> &T {
         let slice = self.get_slice::<T>(ix, 1, IncludeHeader::NoHeader);
         // SAFETY: `get_cell_slice` ensures there's at least one element in the slice

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::{
-        RefCount,
         bucket_storage::{BucketCapacity, BucketOccupied, BucketStorage, Capacity, IncludeHeader},
     },
     bv::BitVec,
@@ -32,8 +31,7 @@ impl BucketCapacity for BucketWithHeader {
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct DataBucketRefCountOccupiedHeader {
-    /// stores `ref_count` and
-    /// occupied = OCCUPIED_OCCUPIED or OCCUPIED_FREE
+    /// stores occupied = OCCUPIED_OCCUPIED or OCCUPIED_FREE
     packed_ref_count: PackedRefCount,
 }
 
@@ -195,9 +193,6 @@ pub struct IndexEntry<T: Clone + Copy> {
     contents: SingleElementOrMultipleSlots<T>,
 }
 
-/// 63 bits available for ref count
-pub(crate) const MAX_LEGAL_REFCOUNT: RefCount = RefCount::MAX >> 1;
-
 /// hold a big `RefCount` while leaving room for extra bits to be used for things like 'Occupied'
 #[bitfield(bits = 64)]
 #[repr(C)]
@@ -205,8 +200,8 @@ pub(crate) const MAX_LEGAL_REFCOUNT: RefCount = RefCount::MAX >> 1;
 pub(crate) struct PackedRefCount {
     /// whether this entry in the data file is occupied or not
     pub(crate) occupied: B1,
-    /// ref_count of this entry. We don't need any where near 63 bits for this value
-    pub(crate) ref_count: B63,
+    /// Unused
+    pub(crate) unused: B63,
 }
 
 /// required fields when an index element references the data file
@@ -273,26 +268,6 @@ impl MultipleSlots {
     pub(crate) fn data_loc(&self, storage: &BucketStorage<DataBucket>) -> u64 {
         self.storage_offset()
             << (storage.contents.capacity_pow2() - self.storage_capacity_when_created_pow2())
-    }
-
-    /// ref_count is stored in the header per cell, in `packed_ref_count`
-    pub fn set_ref_count(
-        data_bucket: &mut BucketStorage<DataBucket>,
-        data_ix: u64,
-        ref_count: RefCount,
-    ) {
-        data_bucket
-            .get_header_mut::<DataBucketRefCountOccupiedHeader>(data_ix)
-            .packed_ref_count
-            .set_ref_count(ref_count);
-    }
-
-    /// ref_count is stored in the header per cell, in `packed_ref_count`
-    pub fn ref_count(data_bucket: &BucketStorage<DataBucket>, data_ix: u64) -> RefCount {
-        data_bucket
-            .get_header::<DataBucketRefCountOccupiedHeader>(data_ix)
-            .packed_ref_count
-            .ref_count()
     }
 }
 
@@ -443,11 +418,10 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
         &self,
         index_bucket: &'a BucketStorage<IndexBucket<T>>,
         data_buckets: &'a [BucketStorage<DataBucket>],
-    ) -> (&'a [T], RefCount) {
-        let mut ref_count = 1;
+    ) -> &'a [T] {
         let slot_list = match self.get_slot_count_enum(index_bucket) {
             OccupiedEnum::ZeroSlots => {
-                // num_slots is 0. This means empty slot list and ref_count=1
+                // num_slots is 0. This means empty slot list
                 &[]
             }
             OccupiedEnum::OneSlotInIndex(single_element) => {
@@ -455,21 +429,20 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
                 std::slice::from_ref(single_element)
             }
             OccupiedEnum::MultipleSlots(multiple_slots) => {
-                // slot list and ref_count are in data file
+                // slot list is in the data file
                 let data_bucket_ix =
                     MultipleSlots::data_bucket_from_num_slots(multiple_slots.num_slots);
                 let data_bucket = &data_buckets[data_bucket_ix as usize];
                 let loc = multiple_slots.data_loc(data_bucket);
                 assert!(!data_bucket.is_free(loc));
 
-                ref_count = MultipleSlots::ref_count(data_bucket, loc);
                 data_bucket.get_slice::<T>(loc, multiple_slots.num_slots, IncludeHeader::NoHeader)
             }
             _ => {
                 panic!("trying to read data from a free entry");
             }
         };
-        (slot_list, ref_count)
+        slot_list
     }
 
     pub fn new(ix: u64) -> Self {

--- a/bucket_map/src/index_entry.rs
+++ b/bucket_map/src/index_entry.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
 use {
-    crate::{
-        bucket_storage::{BucketCapacity, BucketOccupied, BucketStorage, Capacity, IncludeHeader},
+    crate::bucket_storage::{
+        BucketCapacity, BucketOccupied, BucketStorage, Capacity, IncludeHeader,
     },
     bv::BitVec,
     modular_bitfield::prelude::*,
@@ -30,9 +30,9 @@ impl BucketCapacity for BucketWithHeader {
 /// needs to be multiple of size_of::<u64>()
 #[derive(Copy, Clone)]
 #[repr(C)]
-struct DataBucketRefCountOccupiedHeader {
+struct DataBucketOccupiedHeader {
     /// stores occupied = OCCUPIED_OCCUPIED or OCCUPIED_FREE
-    packed_ref_count: PackedRefCount,
+    packed_header: PackedHeader,
 }
 
 #[derive(Debug, PartialEq)]
@@ -55,20 +55,20 @@ pub struct BucketWithHeader {
 impl BucketOccupied for BucketWithHeader {
     fn occupy(&mut self, element: &mut [u8], ix: usize) {
         assert!(self.is_free(element, ix));
-        let entry = get_mut_from_bytes::<DataBucketRefCountOccupiedHeader>(element);
-        entry.packed_ref_count.set_occupied(OCCUPIED_OCCUPIED);
+        let entry = get_mut_from_bytes::<DataBucketOccupiedHeader>(element);
+        entry.packed_header.set_occupied(OCCUPIED_OCCUPIED);
     }
     fn free(&mut self, element: &mut [u8], ix: usize) {
         assert!(!self.is_free(element, ix));
-        let entry = get_mut_from_bytes::<DataBucketRefCountOccupiedHeader>(element);
-        entry.packed_ref_count.set_occupied(OCCUPIED_FREE);
+        let entry = get_mut_from_bytes::<DataBucketOccupiedHeader>(element);
+        entry.packed_header.set_occupied(OCCUPIED_FREE);
     }
     fn is_free(&self, element: &[u8], _ix: usize) -> bool {
-        let entry = get_from_bytes::<DataBucketRefCountOccupiedHeader>(element);
-        entry.packed_ref_count.occupied() == OCCUPIED_FREE
+        let entry = get_from_bytes::<DataBucketOccupiedHeader>(element);
+        entry.packed_header.occupied() == OCCUPIED_FREE
     }
     fn offset_to_first_data() -> usize {
-        std::mem::size_of::<DataBucketRefCountOccupiedHeader>()
+        std::mem::size_of::<DataBucketOccupiedHeader>()
     }
     fn new(capacity: Capacity) -> Self {
         assert!(matches!(capacity, Capacity::Pow2(_)));
@@ -189,19 +189,19 @@ pub struct IndexEntryPlaceInBucket<T: 'static> {
 /// stored in the index bucket
 pub struct IndexEntry<T: Clone + Copy> {
     pub(crate) key: Pubkey, // can this be smaller if we have reduced the keys into buckets already?
-    /// depends on the contents of ref_count.slot_count_enum
     contents: SingleElementOrMultipleSlots<T>,
 }
 
-/// hold a big `RefCount` while leaving room for extra bits to be used for things like 'Occupied'
+/// store extra bits for tracking metadata such as 'Occupied'
 #[bitfield(bits = 64)]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-pub(crate) struct PackedRefCount {
+struct PackedHeader {
     /// whether this entry in the data file is occupied or not
-    pub(crate) occupied: B1,
+    occupied: B1,
     /// Unused
-    pub(crate) unused: B63,
+    #[skip]
+    __: B63,
 }
 
 /// required fields when an index element references the data file
@@ -419,7 +419,7 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
         index_bucket: &'a BucketStorage<IndexBucket<T>>,
         data_buckets: &'a [BucketStorage<DataBucket>],
     ) -> &'a [T] {
-        let slot_list = match self.get_slot_count_enum(index_bucket) {
+        match self.get_slot_count_enum(index_bucket) {
             OccupiedEnum::ZeroSlots => {
                 // num_slots is 0. This means empty slot list
                 &[]
@@ -441,8 +441,7 @@ impl<T: Copy + PartialEq + 'static> IndexEntryPlaceInBucket<T> {
             _ => {
                 panic!("trying to read data from a free entry");
             }
-        };
-        slot_list
+        }
     }
 
     pub fn new(ix: u64) -> Self {

--- a/bucket_map/src/lib.rs
+++ b/bucket_map/src/lib.rs
@@ -9,4 +9,3 @@ mod bucket_storage;
 mod index_entry;
 mod restart;
 pub type MaxSearch = u8;
-pub type RefCount = u64;


### PR DESCRIPTION
#### Problem
Refcount has been removed from the index

#### Summary of Changes
- Remove all references to refCount from bucketmap

#### Testing


Fixes #
