### PR TITLE
chore(deps): bump base64 from 0.22.1 to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6793,7 +6799,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "bv",
@@ -6836,7 +6842,7 @@ dependencies = [
 name = "solana-account-decoder-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "serde",
  "serde_json",
@@ -7522,7 +7528,7 @@ dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitvec",
  "chrono",
  "clap 2.33.3",
@@ -8381,7 +8387,7 @@ dependencies = [
  "agave-feature-set",
  "agave-logger",
  "agave-snapshots",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "clap 2.33.3",
@@ -8798,7 +8804,7 @@ dependencies = [
 name = "solana-lattice-hash"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "bs58",
  "bytemuck",
@@ -9498,7 +9504,7 @@ name = "solana-program-runtime"
 version = "4.4.0-alpha.1"
 dependencies = [
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
  "itertools 0.14.0",
@@ -9562,7 +9568,7 @@ dependencies = [
  "agave-logger",
  "assert_matches",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "chrono-humanize",
  "log",
@@ -9767,7 +9773,7 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-snapshots",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "crossbeam-channel",
  "dashmap",
@@ -9872,7 +9878,7 @@ dependencies = [
  "agave-votor-messages",
  "assert_matches",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -9968,7 +9974,7 @@ dependencies = [
 name = "solana-rpc-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "const_format",
  "semver 1.0.28",
@@ -10041,7 +10047,7 @@ dependencies = [
  "arc-swap",
  "arrayref",
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bitvec",
  "bytemuck",
@@ -10570,7 +10576,7 @@ name = "solana-storage-bigtable"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bzip2",
  "flate2",
@@ -11000,7 +11006,7 @@ dependencies = [
  "agave-snapshots",
  "agave-votor-messages",
  "arc-swap",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "crossbeam-channel",
  "log",
@@ -11253,7 +11259,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bencher",
  "bincode",
  "borsh",
@@ -11298,7 +11304,7 @@ dependencies = [
 name = "solana-transaction-status-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ async-lock = "3.4.2"
 async-trait = "0.1.92"
 aya = "0.14"
 aya-ebpf = "0.2.1"
-base64 = "0.22.1"
+base64 = "0.23.1"
 bencher = "0.1.5"
 bincode = "1.3.3"
 bip39 = { version = "2.2.2", features = ["rand", "all-languages"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -976,6 +976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5588,7 +5594,7 @@ name = "solana-account-decoder"
 version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "bv",
@@ -5630,7 +5636,7 @@ dependencies = [
 name = "solana-account-decoder-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "serde",
  "serde_json",
@@ -5992,7 +5998,7 @@ dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitvec",
  "chrono",
  "clap 2.34.0",
@@ -6926,7 +6932,7 @@ dependencies = [
 name = "solana-lattice-hash"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "bs58",
  "bytemuck",
@@ -7410,7 +7416,7 @@ dependencies = [
 name = "solana-program-runtime"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
  "itertools 0.14.0",
@@ -7579,7 +7585,7 @@ dependencies = [
  "agave-feature-set",
  "agave-snapshots",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "crossbeam-channel",
  "dashmap",
@@ -7661,7 +7667,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "agave-votor-messages",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "futures 0.3.34",
@@ -7734,7 +7740,7 @@ dependencies = [
 name = "solana-rpc-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "semver",
  "serde",
@@ -7769,7 +7775,7 @@ dependencies = [
  "arc-swap",
  "arrayref",
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bitvec",
  "bytemuck",
@@ -8220,7 +8226,7 @@ name = "solana-storage-bigtable"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bzip2",
  "flate2",
@@ -8742,7 +8748,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "borsh",
  "bs58",
@@ -8783,7 +8789,7 @@ dependencies = [
 name = "solana-transaction-status-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "serde",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -965,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5600,7 +5606,7 @@ name = "solana-account-decoder"
 version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "bv",
@@ -5642,7 +5648,7 @@ dependencies = [
 name = "solana-account-decoder-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "serde",
  "serde_json",
@@ -6084,7 +6090,7 @@ dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitvec",
  "chrono",
  "clap",
@@ -7053,7 +7059,7 @@ dependencies = [
 name = "solana-lattice-hash"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "bs58",
  "bytemuck",
@@ -7585,7 +7591,7 @@ dependencies = [
 name = "solana-program-runtime"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
  "itertools 0.14.0",
@@ -7635,7 +7641,7 @@ dependencies = [
  "agave-logger",
  "assert_matches",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "chrono-humanize",
  "log",
@@ -7816,7 +7822,7 @@ dependencies = [
  "agave-feature-set",
  "agave-snapshots",
  "agave-votor-messages",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "crossbeam-channel",
  "dashmap",
@@ -7897,7 +7903,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "agave-votor-messages",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "futures 0.3.34",
@@ -7970,7 +7976,7 @@ dependencies = [
 name = "solana-rpc-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "semver",
  "serde",
@@ -8005,7 +8011,7 @@ dependencies = [
  "arc-swap",
  "arrayref",
  "assert_matches",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bitvec",
  "bytemuck",
@@ -9184,7 +9190,7 @@ name = "solana-storage-bigtable"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bzip2",
  "flate2",
@@ -9547,7 +9553,7 @@ dependencies = [
  "agave-snapshots",
  "agave-votor-messages",
  "arc-swap",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "crossbeam-channel",
  "log",
@@ -9729,7 +9735,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "borsh",
  "bs58",
@@ -9770,7 +9776,7 @@ dependencies = [
 name = "solana-transaction-status-client-types"
 version = "4.4.0-alpha.1"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bincode",
  "bs58",
  "serde",

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -9339,11 +9339,10 @@ pub mod tests {
         );
 
         tx64.push('!');
-        assert_eq!(
-            decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
-                .unwrap_err(),
-            Error::invalid_params("invalid base64 encoding: InvalidByte(1640, 33)".to_string())
-        );
+        let err = decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(err.message.starts_with("invalid base64 encoding:"));
 
         let mut tx58 = bs58::encode(&tx_ser).into_string();
         let err =


### PR DESCRIPTION
#### Problem

we tried to bump it here: https://github.com/anza-xyz/agave/pull/14550, but it encountered a test failure which is an error assertion

#### Summary of Changes

- bump base64 from 0.22.1 to 0.23.1
- get our test to rely on our own error types and msgs instead of the lib's