### PR TITLE
CI - Uses `replenish_program_cache()` in `core_bpf_migration` tests

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -503,7 +503,7 @@ pub(crate) mod tests {
             bank::{
                 Bank, SlotLeader,
                 test_utils::goto_end_of_slot,
-                tests::{create_genesis_config, create_simple_test_bank},
+                tests::{create_genesis_config, create_simple_test_arc_bank},
             },
             genesis_utils::{GenesisConfigInfo, create_genesis_config_with_leader},
             runtime_config::RuntimeConfig,
@@ -808,7 +808,7 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_migrate_builtin(upgrade_authority_address: Option<Pubkey>) {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -880,7 +880,7 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_migrate_stateless_builtin(upgrade_authority_address: Option<Pubkey>) {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -944,7 +944,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_fail_authority_mismatch() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -994,7 +994,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_fail_verified_build_mismatch() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1044,7 +1044,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_none_authority_with_some_buffer_authority() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1169,7 +1169,7 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_upgrade_core_bpf_program(upgrade_authority_address: Option<Pubkey>) {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let core_bpf_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1217,7 +1217,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_fail_authority_mismatch() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1246,7 +1246,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_none_authority_with_some_buffer_authority() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1849,7 +1849,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_loader_v2_program_with_loader_v3_program() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1926,7 +1926,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_loader_v2_program_with_loader_v3_program_fail_invalid_buffer() {
-        let bank = create_simple_test_bank(0);
+        let (bank, _bank_forks) = create_simple_test_arc_bank(0);
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -2138,7 +2138,8 @@ pub(crate) mod tests {
         let leader_id = Pubkey::new_unique();
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(0, &leader_id, LAMPORTS_PER_SOL);
-        let bank = Bank::new_for_tests(&genesis_config);
+        let (bank, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -2229,6 +2230,7 @@ pub(crate) mod tests {
             Arc::default(),
         )
         .unwrap();
+        let (roundtrip_bank, _bank_forks) = roundtrip_bank.wrap_with_bank_forks_for_tests();
 
         // Load the migrated program to the cache and run checks.
         let entry = roundtrip_bank

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -222,7 +222,7 @@ impl Bank {
     }
 
     pub(crate) fn migrate_builtin_to_core_bpf(
-        &mut self,
+        &self,
         builtin_program_id: &Pubkey,
         config: &CoreBpfMigrationConfig,
         allow_prefunded: bool,
@@ -323,7 +323,7 @@ impl Bank {
     /// ```
     // #[expect(dead_code)] // Only used when an upgrade is configured.
     pub(crate) fn upgrade_core_bpf_program(
-        &mut self,
+        &self,
         core_bpf_program_address: &Pubkey,
         source_buffer_address: &Pubkey,
         datapoint_name: &'static str,
@@ -401,7 +401,7 @@ impl Bank {
     /// (state equal to [`UpgradeableLoaderState::Buffer`]).
     // #[expect(dead_code)] // Only used when an upgrade is configured.
     pub(crate) fn upgrade_loader_v2_program_with_loader_v3_program(
-        &mut self,
+        &self,
         loader_v2_bpf_program_address: &Pubkey,
         source_buffer_address: &Pubkey,
         allow_prefunded: bool,
@@ -475,7 +475,7 @@ impl Bank {
     }
 
     fn update_captalization(
-        &mut self,
+        &self,
         lamports_to_burn: u64,
         lamports_to_fund: u64,
     ) -> Result<(), CoreBpfMigrationError> {
@@ -808,7 +808,7 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_migrate_builtin(upgrade_authority_address: Option<Pubkey>) {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -880,7 +880,7 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_migrate_stateless_builtin(upgrade_authority_address: Option<Pubkey>) {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -944,7 +944,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_fail_authority_mismatch() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -994,7 +994,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_fail_verified_build_mismatch() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1044,7 +1044,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_migrate_none_authority_with_some_buffer_authority() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let builtin_id = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1111,7 +1111,7 @@ pub(crate) mod tests {
     }
 
     fn set_up_test_core_bpf_program(
-        bank: &mut Bank,
+        bank: &Bank,
         program_address: &Pubkey,
         upgrade_authority_address: Option<Pubkey>,
     ) {
@@ -1169,16 +1169,12 @@ pub(crate) mod tests {
     #[test_case(Some(Pubkey::new_unique()); "with_upgrade_authority")]
     #[test_case(None; "without_upgrade_authority")]
     fn test_upgrade_core_bpf_program(upgrade_authority_address: Option<Pubkey>) {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let core_bpf_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
 
-        set_up_test_core_bpf_program(
-            &mut bank,
-            &core_bpf_program_address,
-            upgrade_authority_address,
-        );
+        set_up_test_core_bpf_program(&bank, &core_bpf_program_address, upgrade_authority_address);
 
         let test_context = TestContext::new(
             &bank,
@@ -1221,14 +1217,14 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_fail_authority_mismatch() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
 
         let upgrade_authority_address = Some(Pubkey::new_unique());
 
-        set_up_test_core_bpf_program(&mut bank, &program_address, upgrade_authority_address);
+        set_up_test_core_bpf_program(&bank, &program_address, upgrade_authority_address);
 
         let _test_context = TestContext::new(
             &bank,
@@ -1250,12 +1246,12 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_none_authority_with_some_buffer_authority() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
 
-        set_up_test_core_bpf_program(&mut bank, &program_address, None);
+        set_up_test_core_bpf_program(&bank, &program_address, None);
 
         let _test_context = TestContext::new(
             &bank,
@@ -1853,7 +1849,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_loader_v2_program_with_loader_v3_program() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -1930,7 +1926,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_upgrade_loader_v2_program_with_loader_v3_program_fail_invalid_buffer() {
-        let mut bank = create_simple_test_bank(0);
+        let bank = create_simple_test_bank(0);
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();
@@ -2142,7 +2138,7 @@ pub(crate) mod tests {
         let leader_id = Pubkey::new_unique();
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(0, &leader_id, LAMPORTS_PER_SOL);
-        let mut bank = Bank::new_for_tests(&genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
 
         let bpf_loader_v2_program_address = Pubkey::new_unique();
         let source_buffer_address = Pubkey::new_unique();

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -529,6 +529,7 @@ pub(crate) mod tests {
         solana_message::Message,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::{
+            loaded_programs::ProgramToLoad,
             program_cache_entry::{
                 ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             },
@@ -537,6 +538,8 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
         solana_signer::Signer,
+        solana_svm::account_loader::AccountLoader,
+        solana_svm_timings::ExecuteTimings,
         solana_transaction::Transaction,
         solana_transaction_error::TransactionError,
         std::{fs::File, io::Read, sync::Arc},
@@ -758,27 +761,46 @@ pub(crate) mod tests {
             );
 
             // The cache should contain the target program.
-            let program_cache = bank
-                .transaction_processor
-                .global_program_cache
-                .read()
-                .unwrap();
-            let entries = program_cache.get_flattened_entries_for_tests();
-            let target_entry = entries
-                .iter()
-                .rfind(|(program_id, _entry)| program_id == &self.target_program_address)
-                .map(|(_program_id, entry)| entry)
+            let feature_set = bank.feature_set.runtime_features();
+            let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
+                None, // account_overrides
+                bank,
+                &feature_set,
+                1,
+            );
+            let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(bank.slot());
+            let mut execute_timings = ExecuteTimings::default();
+            bank.transaction_processor.replenish_program_cache(
+                &account_loader,
+                vec![ProgramToLoad {
+                    program_id: &self.target_program_address,
+                    loader: ProgramCacheEntryOwner::LoaderV3,
+                    deployment_slot: migration_or_upgrade_slot,
+                    last_modification_slot: migration_or_upgrade_slot,
+                }],
+                &bank.transaction_processor.program_runtime_environment,
+                &mut program_cache_for_tx_batch,
+                &mut execute_timings,
+                false, // limit_to_load_programs
+                true,  // increment_usage_counter
+            );
+            let target_entry = program_cache_for_tx_batch
+                .find(&self.target_program_address)
                 .unwrap();
 
             // The target program entry should be updated.
             assert_eq!(target_entry.deployment_slot, migration_or_upgrade_slot);
-            assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
+            if let ProgramCacheEntryType::Loaded(..) = &target_entry.program {
+                assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
+            } else {
+                assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot);
+            }
 
             // The target program entry should be a loader v3 BPF program.
             assert_eq!(target_entry.account_owner, ProgramCacheEntryOwner::LoaderV3);
             assert_matches!(
                 target_entry.program,
-                ProgramCacheEntryType::Unloaded(..) | ProgramCacheEntryType::Loaded(..)
+                ProgramCacheEntryType::DelayVisibility | ProgramCacheEntryType::Loaded(..)
             );
         }
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -790,18 +790,14 @@ pub(crate) mod tests {
 
             // The target program entry should be updated.
             assert_eq!(target_entry.deployment_slot, migration_or_upgrade_slot);
-            if let ProgramCacheEntryType::Loaded(..) = &target_entry.program {
-                assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
-            } else {
-                assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot);
-            }
 
             // The target program entry should be a loader v3 BPF program.
             assert_eq!(target_entry.account_owner, ProgramCacheEntryOwner::LoaderV3);
-            assert_matches!(
-                target_entry.program,
-                ProgramCacheEntryType::DelayVisibility | ProgramCacheEntryType::Loaded(..)
-            );
+            if bank.slot() == migration_or_upgrade_slot {
+                assert_matches!(target_entry.program, ProgramCacheEntryType::DelayVisibility);
+            } else {
+                assert_matches!(target_entry.program, ProgramCacheEntryType::Loaded(..));
+            }
         }
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -354,7 +354,7 @@ pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {
     Bank::new_for_tests(&genesis_config)
 }
 
-fn create_simple_test_arc_bank(lamports: u64) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
+pub(crate) fn create_simple_test_arc_bank(lamports: u64) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
     let bank = create_simple_test_bank(lamports);
     bank.wrap_with_bank_forks_for_tests()
 }


### PR DESCRIPTION
#### Problem

Preparation for #14639. Same as #14834 but for `core_bpf_migration` tests.

#### Summary of Changes

- Uses `replenish_program_cache()` in `TestContext::run_program_checks()`.

#### Testing

The method is used in all `core_bpf_migration` tests.