### PR TITLE
validator: remove deprecated --experimental-retransmit-xdp-* flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Release channels have their own copy of this changelog:
 * Banking trace is now disabled by default. To enable, provide `--enable-banking-trace <max bytes>`.
 * Previously deprecated `--tpu-connection-pool-size` has been removed. The connection pool size is fixed at the previous default of 1.
 * scheduler-bindings version has been increased to 5. Connecting external schedulers must be updated.
+* Previously deprecated `--experimental-retransmit-xdp-interface`, `--experimental-retransmit-xdp-cpu-cores`
+  and `--experimental-retransmit-xdp-zero-copy` have been removed. Use `--xdp-interface`, `--xdp-cpu-cores`
+  and `--xdp-zero-copy` instead.
 #### Deprecations
 * `--disable-banking-trace` is now deprecated and a no-op (banking trace is disabled by
   default). The flag is still accepted for backward compatibility.

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -18,7 +18,6 @@ use {
         hidden_unless_forced,
         input_validators::{
             is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot, is_url_or_moniker,
-            validate_cpu_ranges,
         },
     },
     solana_clock::Slot,
@@ -190,41 +189,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .validator(is_parsable::<usize>)
             .help("Specify which CPU core PoH is pinned to. Use --poh-pinned-cpu-core instead"),
         replaced_by: "poh-pinned-cpu-core",
-    );
-    add_arg!(
-        // deprecated in v4.1.0
-        Arg::with_name("experimental_retransmit_xdp_cpu_cores")
-            .long("experimental-retransmit-xdp-cpu-cores")
-            .takes_value(true)
-            .value_name("CPU_LIST")
-            .conflicts_with("xdp_cpu_cores")
-            .conflicts_with("no_xdp")
-            .validator(|value| {
-                validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
-            })
-            .help("CPU cores to reserve for XDP. Use --xdp-cpu-cores instead"),
-        replaced_by: "xdp-cpu-cores",
-    );
-    add_arg!(
-        // deprecated in v4.1.0
-        Arg::with_name("experimental_retransmit_xdp_interface")
-            .long("experimental-retransmit-xdp-interface")
-            .takes_value(true)
-            .value_name("INTERFACE")
-            .conflicts_with("xdp_interface")
-            .conflicts_with("no_xdp")
-            .help("Network interface to use for XDP. Use --xdp-interface instead"),
-        replaced_by: "xdp-interface",
-    );
-    add_arg!(
-        // deprecated in v4.1.0
-        Arg::with_name("experimental_retransmit_xdp_zero_copy")
-            .long("experimental-retransmit-xdp-zero-copy")
-            .takes_value(false)
-            .conflicts_with("xdp_zero_copy")
-            .conflicts_with("no_xdp")
-            .help("Enable XDP zero copy. Use --xdp-zero-copy instead"),
-        replaced_by: "xdp-zero-copy",
     );
     add_arg!(
         // deprecated in v4.3.0

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1411,17 +1411,12 @@ fn build_xdp_config(
             "XDP cannot be used in a multihoming context; pass --no-xdp to disable XDP".to_string(),
         );
     }
-    let xdp_interface = matches
-        .value_of("xdp_interface")
-        .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
-    let xdp_zero_copy = matches.is_present("xdp_zero_copy")
-        || matches.is_present("experimental_retransmit_xdp_zero_copy");
+    let xdp_interface = matches.value_of("xdp_interface");
+    let xdp_zero_copy = matches.is_present("xdp_zero_copy");
     let poh_pinned_cpu_core = value_of(matches, "poh_pinned_cpu_core")
         .or_else(|| value_of(matches, "experimental_poh_pinned_cpu_core"))
         .or(poh_service::DEFAULT_PINNED_CPU_CORE);
-    let xdp_cpu_cores = matches
-        .value_of("xdp_cpu_cores")
-        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"));
+    let xdp_cpu_cores = matches.value_of("xdp_cpu_cores");
     let cpus = if let Some(cpu_str) = xdp_cpu_cores {
         let parsed =
             parse_cpu_ranges(cpu_str).expect("clap validator already accepted this CPU list");


### PR DESCRIPTION
Remove --experimental-retransmit-xdp-* flags deprecated in v4.1.0. Replaced by:

--xdp-interface
--xdp-cpu-cores
--xdp-zero-copy