### PR TITLE
chore(deps): bump array-bytes from 1.4.1 to 9.3.0 in /programs/sbf

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -758,9 +758,13 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "1.4.1"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad284aeb45c13f2fb4f084de4a420ebf447423bdf9386c0540ce33cb3ef4b8c"
+checksum = "27d55334c98d756b32dcceb60248647ab34f027690f87f9a362fd292676ee927"
+dependencies = [
+ "smallvec",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "arrayref"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -106,7 +106,7 @@ agave-feature-set = { path = "../../feature-set", version = "=4.4.0-alpha.1" }
 agave-logger = { path = "../../logger", version = "=4.4.0-alpha.1" }
 agave-reserved-account-keys = { path = "../../reserved-account-keys", version = "=4.4.0-alpha.1" }
 agave-validator = { path = "../../validator", version = "=4.4.0-alpha.1" }
-array-bytes = "=1.4.1"
+array-bytes = "9.3.0"
 bincode = { version = "1.1.4", default-features = false }
 blake3 = "1.0.0"
 borsh = "1.5.1"

--- a/programs/sbf/rust/big_mod_exp/src/lib.rs
+++ b/programs/sbf/rust/big_mod_exp/src/lib.rs
@@ -1,7 +1,7 @@
 //! Big_mod_exp Syscall tests
 
 use {
-    solana_big_mod_exp::big_mod_exp, solana_msg::msg,
+    array_bytes::Dehexify, solana_big_mod_exp::big_mod_exp, solana_msg::msg,
     solana_program_entrypoint::custom_panic_default,
 };
 
@@ -67,10 +67,10 @@ fn big_mod_exp_test() {
     test_cases
         .iter()
         .for_each(|(base, exponent, modulus, expected)| {
-            let mut base = array_bytes::hex2bytes_unchecked(base);
-            let mut exponent = array_bytes::hex2bytes_unchecked(exponent);
-            let mut modulus = array_bytes::hex2bytes_unchecked(modulus);
-            let mut expected = array_bytes::hex2bytes_unchecked(expected);
+            let mut base = Vec::<u8>::dehexify(base).unwrap();
+            let mut exponent = Vec::<u8>::dehexify(exponent).unwrap();
+            let mut modulus = Vec::<u8>::dehexify(modulus).unwrap();
+            let mut expected = Vec::<u8>::dehexify(expected).unwrap();
             base.reverse();
             exponent.reverse();
             modulus.reverse();


### PR DESCRIPTION
#### Problem

no one has touched this dep for a very long time, and it is unclear why the version was pinned.

it's introduced here: https://github.com/solana-labs/solana/pull/27961/changes#diff-17993526f2503f30ec4bf11db79d039377c16f4bbdb2fcf0cb87630c6f1e2713R12 and removed. it's now only used by https://github.com/anza-xyz/agave/blob/0fa0bbe2c9a40b7565389181960376f5bda9d577/programs/sbf/rust/big_mod_exp/Cargo.toml#L15

#### Summary of Changes

not sure if it's fine to just bump and replace it. it looks like a test 🤔 
