### PR TITLE
blockstore: keep the duplicate proof when switching alternate blocks

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -126,8 +126,9 @@ impl Blockstore {
         self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ true)
     }
 
-    /// Like `purge_slot_cleanup_chaining` but preserves alternate block columns.
-    /// Used when switching from an alternate block to allow repair data to be retained.
+    /// Like `purge_slot_cleanup_chaining` but preserves alternate block columns and the duplicate
+    /// proof. Used when switching from an alternate block to allow repair data and the historical
+    /// equivocation evidence to be retained.
     pub(crate) fn purge_slot_cleanup_chaining_keep_alt(&self, slot: Slot) -> Result<()> {
         self.do_purge_slot_cleanup_chaining(slot, /* purge_alt_columns */ false)
     }
@@ -261,8 +262,6 @@ impl Blockstore {
             .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.dead_slots_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
-        self.duplicate_slots_cf
-            .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.erasure_meta_cf
             .delete_range_in_batch(write_batch, from_slot, to_slot);
         self.orphans_cf
@@ -296,6 +295,11 @@ impl Blockstore {
             // columns. When `purge_alt_columns` is specified we delete the
             // entire column.
             self.double_merkle_meta_cf
+                .delete_range_in_batch(write_batch, from_slot, to_slot);
+            // This column stores the proof that the leader was malicious and
+            // equivocated. We do not want to purge this unless we are in cleanup,
+            // as this information can be used to slash leaders in the future.
+            self.duplicate_slots_cf
                 .delete_range_in_batch(write_batch, from_slot, to_slot);
         } else {
             // This column stores information for both the original and alternate
@@ -1269,9 +1273,14 @@ pub mod tests {
         blockstore.insert_shreds(slot_11, false).unwrap();
         let (slot_12, _) = make_slot_entries(12, 5, 5);
         blockstore.insert_shreds(slot_12, false).unwrap();
+        blockstore
+            .store_duplicate_slot(5, vec![1], vec![2])
+            .unwrap();
+        assert!(blockstore.has_duplicate_shreds_in_slot(5));
 
         blockstore.purge_slot_cleanup_chaining(5).unwrap();
 
+        assert!(!blockstore.has_duplicate_shreds_in_slot(5));
         let slot_meta = blockstore.meta(5).unwrap().unwrap();
         let expected_slot_meta = SlotMeta {
             slot: 5,

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6778,11 +6778,22 @@ fn test_block_id_reads_remain_consistent_after_switch() {
         insert_test_block_at_location(&blockstore, slot, parent_slot, temporary_alternate_location);
 
     assert_ne!(original_block_id, alternate_block_id);
+    blockstore
+        .store_duplicate_slot(
+            slot,
+            original_shreds[0].payload().clone(),
+            alternate_shreds[0].payload().clone(),
+        )
+        .unwrap();
+    assert!(blockstore.has_duplicate_shreds_in_slot(slot));
 
     blockstore
         .switch_block_from_alternate(slot, temporary_alternate_location)
         .unwrap();
 
+    let duplicate_proof = blockstore.get_duplicate_slot(slot).unwrap();
+    assert_eq!(duplicate_proof.shred1, *original_shreds[0].payload());
+    assert_eq!(duplicate_proof.shred2, *alternate_shreds[0].payload());
     assert_eq!(
         blockstore
             .get_double_merkle_root(slot, BlockLocation::Original)


### PR DESCRIPTION
#### Problem
In Alpenglow when we receive a duplicate block we store a duplicate proof.
If later a version gets enough support, we repair the valid version and switch it into the original column for replay.

When we do this we purge the original column and also purge the duplicate proof.

The duplicate proof is unused in Alpenglow, but it is useful as proof of the malicious leader and in the future can be used for slashing.

#### Summary of Changes
Preserve the duplicate proof when switching out blocks. The proof is still cleaned up during normal blockstore cleanup.

#### Testing
Unit Test