### PR TITLE
alpenglow: activate feature by default

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -574,9 +574,7 @@ mod tests {
         solana_runtime::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         solana_signer::Signer,
         solana_signer_store::encode_base2,
@@ -641,7 +639,7 @@ mod tests {
             let stakes_vec = (0..validator_keypairs.len())
                 .map(|i| 1_000u64.saturating_sub(i as u64))
                 .collect::<Vec<_>>();
-            let mut genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            let mut genesis = create_genesis_config_with_vote_accounts(
                 1_000_000_000,
                 &validator_keypairs,
                 stakes_vec,
@@ -1641,7 +1639,7 @@ mod tests {
         let stakes_vec = (0..validator_keypairs.len())
             .map(|i| 1_000 - i as u64)
             .collect::<Vec<_>>();
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+        let genesis = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             stakes_vec,

--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -132,9 +132,7 @@ mod tests {
         solana_pubkey::Pubkey,
         solana_runtime::{
             bank::{Bank, SlotLeader},
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         solana_signer_store::{Decoded, decode},
         std::{collections::HashMap, num::NonZero},
@@ -214,12 +212,9 @@ mod tests {
                 )
             })
             .collect::<HashMap<_, _>>();
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            stakes,
-        )
-        .genesis_config;
+        let mut genesis_config =
+            create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes)
+                .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::without_warmup();
         let (bank, bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1517,7 +1517,7 @@ mod tests {
             bank_forks,
             validator_voting_keypairs,
             subscriptions,
-        } = setup();
+        } = setup_with_tower();
         let migration_status = bank_forks.read().unwrap().migration_status();
         let (votes_sender, votes_receiver) = bounded(1024);
         let (replay_votes_sender, replay_votes_receiver) = bounded(1024);
@@ -2200,14 +2200,29 @@ mod tests {
     }
 
     fn setup() -> SetupComponents {
+        setup_with_consensus(false)
+    }
+
+    fn setup_with_tower() -> SetupComponents {
+        setup_with_consensus(true)
+    }
+
+    fn setup_with_consensus(use_tower: bool) -> SetupComponents {
         let validator_voting_keypairs: Vec<_> =
             (0..10).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
-        let GenesisConfigInfo { genesis_config, .. } =
+        let GenesisConfigInfo { genesis_config, .. } = if use_tower {
+            genesis_utils::create_genesis_config_with_tower_vote_accounts(
+                10_000,
+                &validator_voting_keypairs,
+                vec![100; validator_voting_keypairs.len()],
+            )
+        } else {
             genesis_utils::create_genesis_config_with_vote_accounts(
                 10_000,
                 &validator_voting_keypairs,
                 vec![100; validator_voting_keypairs.len()],
-            );
+            )
+        };
         let bank = Bank::new_for_tests(&genesis_config);
         let vote_tracker = VoteTracker::default();
         let exit = Arc::new(AtomicBool::new(false));

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -332,7 +332,9 @@ mod tests {
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
         solana_pubkey::Pubkey,
         solana_runtime::{
-            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
+            genesis_utils::{
+                ValidatorVoteKeypairs, create_genesis_config_with_tower_vote_accounts,
+            },
             stake_utils,
         },
         solana_signer::Signer,
@@ -641,11 +643,12 @@ mod tests {
 
         let validator_vote_keypairs = ValidatorVoteKeypairs::new_rand();
         let validator_keypairs = vec![&validator_vote_keypairs];
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            vec![100; 1],
-        );
+        let GenesisConfigInfo { genesis_config, .. } =
+            create_genesis_config_with_tower_vote_accounts(
+                1_000_000_000,
+                &validator_keypairs,
+                vec![100; 1],
+            );
 
         let (_bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2925,11 +2925,6 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        bank_forks
-            .read()
-            .unwrap()
-            .migration_status()
-            .enable_alpenglow_for_tests();
 
         let staked_nodes = bank_forks
             .read()
@@ -2976,11 +2971,6 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank);
-        bank_forks
-            .read()
-            .unwrap()
-            .migration_status()
-            .enable_alpenglow_for_tests();
 
         let slot = 1;
         let cluster_slots = Arc::new(ClusterSlots::default_for_tests());

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -62,7 +62,10 @@ use {
         bank::BankTestConfig,
         block_component_processor::BlockComponentProcessorError,
         commitment::{BlockCommitment, VOTE_THRESHOLD_SIZE},
-        genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs},
+        genesis_utils::{
+            GenesisConfigInfo, ValidatorVoteKeypairs, bootstrap_validator_stake_lamports,
+            create_genesis_config_with_tower_leader,
+        },
     },
     solana_sha256_hasher::hash,
     solana_shred_version::compute_shred_version,
@@ -6586,7 +6589,11 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
     agave_logger::setup();
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = create_genesis_config(123);
+    } = create_genesis_config_with_tower_leader(
+        123,
+        &Pubkey::new_unique(),
+        bootstrap_validator_stake_lamports(),
+    );
 
     let ticks_per_slot = 1;
     genesis_config.ticks_per_slot = ticks_per_slot;

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -27,7 +27,8 @@ use {
         bank::{Bank, BankTestConfig},
         bank_forks::BankForks,
         genesis_utils::{
-            GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
+            GenesisConfigInfo, ValidatorVoteKeypairs,
+            create_genesis_config_with_tower_vote_accounts,
         },
     },
     solana_signer::Signer,
@@ -413,7 +414,7 @@ pub fn initialize_state_with(
         mut genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_vote_accounts(
+    } = create_genesis_config_with_tower_vote_accounts(
         1_000_000_000,
         &validator_keypairs,
         vec![stake; validator_keypairs.len()],

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -526,12 +526,17 @@ mod test {
         solana_keypair::Keypair,
         solana_ledger::{
             blockstore::{Blockstore, make_many_slot_entries},
-            genesis_utils::create_genesis_config,
             get_tmp_ledger_path_auto_delete,
             shred::{ProcessShredsStats, Shredder},
         },
         solana_net_utils::SocketAddrSpace,
-        solana_runtime::bank::Bank,
+        solana_pubkey::Pubkey,
+        solana_runtime::{
+            bank::Bank,
+            genesis_utils::{
+                bootstrap_validator_stake_lamports, create_genesis_config_with_tower_leader,
+            },
+        },
         solana_signer::Signer,
         solana_time_utils::timestamp,
     };
@@ -575,7 +580,12 @@ mod test {
     #[test]
     fn test_run_check_duplicate() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let genesis_config = create_genesis_config(10_000).genesis_config;
+        let genesis_config = create_genesis_config_with_tower_leader(
+            10_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        )
+        .genesis_config;
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let (sender, receiver) = bounded(1024);
@@ -666,7 +676,12 @@ mod test {
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
         ));
-        let genesis_config = create_genesis_config(10_000).genesis_config;
+        let genesis_config = create_genesis_config_with_tower_leader(
+            10_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        )
+        .genesis_config;
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
 
         // Start duplicate thread receiving and inserting duplicates

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -837,7 +837,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     add_genesis_epoch_rewards_account(&mut genesis_config);
 
     if is_alpenglow {
-        solana_runtime::genesis_utils::activate_all_features_alpenglow(&mut genesis_config);
+        solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
     } else {
         solana_runtime::genesis_utils::activate_all_features_tower(&mut genesis_config);
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -839,7 +839,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     if is_alpenglow {
         solana_runtime::genesis_utils::activate_all_features_alpenglow(&mut genesis_config);
     } else {
-        solana_runtime::genesis_utils::activate_all_features(&mut genesis_config);
+        solana_runtime::genesis_utils::activate_all_features_tower(&mut genesis_config);
     }
 
     if !features_to_deactivate.is_empty() {

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -235,13 +235,12 @@ mod tests {
         itertools::Itertools,
         solana_keypair::Keypair,
         solana_ledger::{
-            genesis_utils::{GenesisConfigInfo, create_genesis_config_with_leader},
-            get_tmp_ledger_path_auto_delete,
-            shred::Shredder,
+            genesis_utils::GenesisConfigInfo, get_tmp_ledger_path_auto_delete, shred::Shredder,
         },
         solana_runtime::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
+            genesis_utils::create_genesis_config_with_tower_leader,
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -296,7 +295,8 @@ mod tests {
         let my_keypair = Arc::new(Keypair::new());
         let my_pubkey = my_keypair.pubkey();
         let shred_version = 0;
-        let genesis_config_info = create_genesis_config_with_leader(10_000, &my_pubkey, 10_000);
+        let genesis_config_info =
+            create_genesis_config_with_tower_leader(10_000, &my_pubkey, 10_000);
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks_arc = BankForks::new_rw_arc(bank);
@@ -420,7 +420,8 @@ mod tests {
         let my_keypair = Arc::new(Keypair::new());
         let my_pubkey = my_keypair.pubkey();
         let shred_version = 0;
-        let genesis_config_info = create_genesis_config_with_leader(10_000, &my_pubkey, 10_000);
+        let genesis_config_info =
+            create_genesis_config_with_tower_leader(10_000, &my_pubkey, 10_000);
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
         let bank = Bank::new_for_tests(&genesis_config);
         let bank_forks_arc = BankForks::new_rw_arc(bank);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2488,7 +2488,8 @@ pub mod tests {
         crate::{
             blockstore_options::{AccessType, BlockstoreOptions},
             genesis_utils::{
-                GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
+                GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
+                create_genesis_config_with_leader,
             },
             shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
@@ -2523,7 +2524,8 @@ pub mod tests {
         solana_runtime::{
             bank::bank_hash_details::SlotDetails,
             genesis_utils::{
-                self, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
+                self, ValidatorVoteKeypairs, create_genesis_config_with_tower_leader,
+                create_genesis_config_with_tower_vote_accounts,
             },
             installed_scheduler_pool::{
                 InstalledSchedulerPool, MockInstalledScheduler, MockUninstalledScheduler,
@@ -2551,6 +2553,14 @@ pub mod tests {
         test_case::test_case,
         trees::tr,
     };
+
+    fn create_tower_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
+        create_genesis_config_with_tower_leader(
+            mint_lamports,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        )
+    }
 
     /// Generate a dummy alpenglow genesis certificate
     fn genesis_certificate(block: Block) -> Arc<GenesisCert> {
@@ -2772,7 +2782,7 @@ pub mod tests {
     fn test_process_blockstore_with_invalid_slot_tick_count() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
@@ -2881,7 +2891,7 @@ pub mod tests {
     fn test_process_blockstore_with_incomplete_slot() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         /*
@@ -2964,7 +2974,7 @@ pub mod tests {
     fn test_process_blockstore_with_two_forks_and_squash() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
@@ -3044,7 +3054,7 @@ pub mod tests {
     fn test_process_blockstore_with_two_forks() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
@@ -3133,7 +3143,7 @@ pub mod tests {
     fn test_process_blockstore_with_dead_slot() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
         let (ledger_path, blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         debug!("ledger_path: {ledger_path:?}");
@@ -3176,7 +3186,7 @@ pub mod tests {
     fn test_process_blockstore_with_dead_child() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
         let (ledger_path, blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
         debug!("ledger_path: {ledger_path:?}");
@@ -3261,7 +3271,7 @@ pub mod tests {
     fn test_process_blockstore_epoch_boundary_root() {
         agave_logger::setup();
 
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let GenesisConfigInfo { genesis_config, .. } = create_tower_genesis_config(10_000);
         let ticks_per_slot = genesis_config.ticks_per_slot;
 
         // Create a new ledger with slot 0 full of ticks
@@ -3356,7 +3366,7 @@ pub mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(mint, &leader_pubkey, 50);
+        } = create_genesis_config_with_tower_leader(mint, &leader_pubkey, 50);
         genesis_config.poh_config.hashes_per_tick = Some(hashes_per_tick_genesis);
         let (ledger_path, mut last_entry_hash) =
             create_new_tmp_ledger_auto_delete!(&genesis_config);
@@ -4389,7 +4399,7 @@ pub mod tests {
     fn test_process_blockstore_from_root() {
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = create_genesis_config(123);
+        } = create_tower_genesis_config(123);
 
         let ticks_per_slot = 1;
         genesis_config.ticks_per_slot = ticks_per_slot;
@@ -4637,11 +4647,12 @@ pub mod tests {
     fn test_replay_vote_sender() {
         let validator_keypairs: Vec<_> =
             (0..10).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            vec![100; validator_keypairs.len()],
-        );
+        let GenesisConfigInfo { genesis_config, .. } =
+            create_genesis_config_with_tower_vote_accounts(
+                1_000_000_000,
+                &validator_keypairs,
+                vec![100; validator_keypairs.len()],
+            );
         let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         bank0.freeze();
 
@@ -4802,7 +4813,7 @@ pub mod tests {
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / main_fork);
         let validator_keypairs = ValidatorVoteKeypairs::new_rand();
         let GenesisConfigInfo { genesis_config, .. } =
-            genesis_utils::create_genesis_config_with_vote_accounts(
+            create_genesis_config_with_tower_vote_accounts(
                 10_000,
                 &[&validator_keypairs],
                 vec![100],
@@ -5660,16 +5671,13 @@ pub mod tests {
 
     fn confirm_slot_with_block_markers_common(
         footer_before_alpentick: bool,
+        mut genesis_config: GenesisConfig,
     ) -> (
         Blockstore,
         GenesisConfig,
         tempfile::TempDir,
         ReplayVerificationWorkerPool,
     ) {
-        let GenesisConfigInfo {
-            mut genesis_config, ..
-        } = create_genesis_config(100 * LAMPORTS_PER_SOL);
-
         let ticks_per_slot = 1;
         genesis_config.ticks_per_slot = ticks_per_slot;
 
@@ -5805,8 +5813,9 @@ pub mod tests {
 
     #[test]
     fn test_confirm_slot_block_with_markers_fails_without_alpenglow() {
+        let genesis_config = create_tower_genesis_config(100 * LAMPORTS_PER_SOL).genesis_config;
         let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
-            confirm_slot_with_block_markers_common(true);
+            confirm_slot_with_block_markers_common(true, genesis_config);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
@@ -5837,8 +5846,9 @@ pub mod tests {
 
     #[test]
     fn test_confirm_slot_block_with_markers_succeeds_with_alpenglow() {
+        let genesis_config = create_genesis_config(100 * LAMPORTS_PER_SOL).genesis_config;
         let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
-            confirm_slot_with_block_markers_common(true);
+            confirm_slot_with_block_markers_common(true, genesis_config);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
@@ -5916,8 +5926,9 @@ pub mod tests {
 
     #[test]
     fn test_confirm_slot_rejects_alpentick_before_footer() {
+        let genesis_config = create_genesis_config(100 * LAMPORTS_PER_SOL).genesis_config;
         let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
-            confirm_slot_with_block_markers_common(false);
+            confirm_slot_with_block_markers_common(false, genesis_config);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
@@ -6191,7 +6202,7 @@ pub mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000);
+        } = create_tower_genesis_config(10_000);
         let ticks_per_slot = 1;
         genesis_config.ticks_per_slot = ticks_per_slot;
         genesis_utils::activate_feature(&mut genesis_config, agave_feature_set::alpenglow::id());

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -510,9 +510,9 @@ pub fn run_cluster_partition<C>(
     );
 
     let mut cluster = if is_alpenglow {
-        LocalCluster::new_alpenglow(&mut config, SocketAddrSpace::Unspecified)
-    } else {
         LocalCluster::new(&mut config, SocketAddrSpace::Unspecified)
+    } else {
+        LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified)
     };
 
     info!("PARTITION_TEST spend_and_verify_all_nodes(), ensure all nodes are caught up");
@@ -646,7 +646,7 @@ pub fn test_faulty_node(
         ..ClusterConfig::default()
     };
 
-    let cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
+    let cluster = LocalCluster::new_tower(&mut cluster_config, SocketAddrSpace::Unspecified);
     let validator_keys: Vec<ValidatorKeys> =
         validator_keys.into_iter().map(|(keys, _)| keys).collect();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -203,12 +203,16 @@ impl LocalCluster {
     }
 
     pub fn new(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
-        Self::init(config, socket_addr_space, AlpenglowMode::Disabled)
+        Self::new_alpenglow(config, socket_addr_space)
     }
 
     pub fn new_alpenglow(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
         config.poh_config.hashes_per_tick = None;
         Self::init(config, socket_addr_space, AlpenglowMode::Enabled)
+    }
+
+    pub fn new_tower(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
+        Self::init(config, socket_addr_space, AlpenglowMode::Disabled)
     }
 
     pub fn init(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -282,7 +282,10 @@ impl LocalCluster {
         let leader_pubkey = leader_keypair.pubkey();
         let leader_node = Node::new_localhost_with_pubkey(&leader_pubkey);
 
-        let feature_set = FeatureSet::all_enabled();
+        let mut feature_set = FeatureSet::all_enabled();
+        if alpenglow_mode != AlpenglowMode::Enabled {
+            feature_set.deactivate(&agave_feature_set::alpenglow::id());
+        }
 
         let stakes_in_genesis_for_funding = stakes_in_genesis.clone();
         let GenesisConfigInfo {
@@ -294,8 +297,7 @@ impl LocalCluster {
             &keys_in_genesis,
             stakes_in_genesis,
             config.cluster_type,
-            &feature_set,
-            matches!(alpenglow_mode, AlpenglowMode::Enabled), /* is_alpenglow */
+            feature_set,
         );
 
         // In-genesis validators only receive the generic validator account funding from the

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -203,10 +203,6 @@ impl LocalCluster {
     }
 
     pub fn new(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
-        Self::new_alpenglow(config, socket_addr_space)
-    }
-
-    pub fn new_alpenglow(config: &mut ClusterConfig, socket_addr_space: SocketAddrSpace) -> Self {
         config.poh_config.hashes_per_tick = None;
         Self::init(config, socket_addr_space, AlpenglowMode::Enabled)
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -284,7 +284,7 @@ fn test_two_unbalanced_stakes() {
     let num_ticks_per_slot = 16;
     let num_slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH;
 
-    let mut cluster = LocalCluster::new(
+    let mut cluster = LocalCluster::new_tower(
         &mut ClusterConfig {
             node_stakes: vec![DEFAULT_NODE_STAKE * 100, DEFAULT_NODE_STAKE],
             mint_lamports: DEFAULT_MINT_LAMPORTS + DEFAULT_NODE_STAKE * 100,
@@ -1249,7 +1249,7 @@ fn test_snapshot_restart_tower() {
         ..ClusterConfig::default()
     };
 
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     // Let the nodes run for a while, then stop one of the validators
     sleep(Duration::from_millis(5000));
@@ -1509,7 +1509,7 @@ fn test_no_voting() {
         validator_configs: vec![validator_config],
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
     let rpc_client = cluster
         .build_rpc_client(cluster.entry_point_info.pubkey())
         .unwrap();
@@ -1568,7 +1568,7 @@ fn test_optimistic_confirmation_violation_detection() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
     // Let the nodes run for a while. Wait for validators to vote on slot `S`
     // so that the vote on `S-1` is definitely in gossip and optimistic confirmation is
     // detected on slot `S-1` for sure, then stop the heavier of the two
@@ -1782,7 +1782,7 @@ fn test_validator_saves_tower() {
         validator_keys: Some(vec![(validator_keys.clone(), true)]),
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let rpc_client = cluster.build_rpc_client(&validator_id).unwrap();
 
@@ -1939,7 +1939,7 @@ fn do_test_future_tower(cluster_mode: ClusterMode) {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let val_a_ledger_path = cluster.ledger_path(&validator_a_pubkey);
     let root_before_restart;
@@ -2108,7 +2108,7 @@ fn test_hard_fork_invalidates_tower() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let cluster = std::sync::Arc::new(std::sync::Mutex::new(LocalCluster::new(
+    let cluster = std::sync::Arc::new(std::sync::Mutex::new(LocalCluster::new_tower(
         &mut config,
         SocketAddrSpace::Unspecified,
     )));
@@ -2295,7 +2295,7 @@ fn test_hard_fork_with_gap_in_roots() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let cluster = std::sync::Arc::new(std::sync::Mutex::new(LocalCluster::new(
+    let cluster = std::sync::Arc::new(std::sync::Mutex::new(LocalCluster::new_tower(
         &mut config,
         SocketAddrSpace::Unspecified,
     )));
@@ -2454,7 +2454,7 @@ fn test_restart_tower_rollback() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let val_b_ledger_path = cluster.ledger_path(&b_pubkey);
 
@@ -2586,7 +2586,7 @@ fn test_run_test_load_program_accounts_partition_root() {
         None,
         false,
         additional_accounts,
-        false,
+        true,
     );
 }
 
@@ -2634,7 +2634,7 @@ fn test_oc_bad_signatures() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     // 2) Kill our node and start up a thread to simulate votes to control our voting behavior
     let our_info = cluster.exit_node(&our_id);
@@ -3185,7 +3185,7 @@ fn do_test_lockout_violation_with_or_without_tower(with_tower: bool) {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let val_a_ledger_path = cluster.ledger_path(&validator_a_pubkey);
     let val_b_ledger_path = cluster.ledger_path(&validator_b_pubkey);
@@ -4442,7 +4442,7 @@ fn test_slot_hash_expiry() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let mut common_ancestor_slot = 8;
 
@@ -4678,7 +4678,7 @@ fn test_duplicate_with_pruned_ancestor() {
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new_tower(&mut config, SocketAddrSpace::Unspecified);
 
     let majority_ledger_path = cluster.ledger_path(&majority_pubkey);
     let minority_ledger_path = cluster.ledger_path(&minority_pubkey);
@@ -5011,17 +5011,17 @@ fn test_boot_from_local_state() {
     );
     info!("Waiting for validator3 to create snapshots... DONE");
 
-    // Ensure that all validators have the correct state by comparing snapshots.
+    // Ensure that all validators have the correct state by comparing full snapshots.
     // Since validator1 has been running the longest, if may be ahead of the others,
     // so use it as the comparison for others.
     // - wait for validator1 to take new snapshots
     // - wait for the other validators to have high enough snapshots
     // - ensure the other validators' full snapshots match validator1's
     //
-    // NOTE: There's a chance validator 2 or 3 has crossed the next full snapshot past what
-    // validator 1 has.  If that happens, validator 2 or 3 may have purged the snapshots needed
-    // to compare with validator 1, and thus assert.  If that happens, the full snapshot interval
-    // may need to be adjusted larger.
+    // Incremental snapshots are validated by the boot chain above: validator2 boots from
+    // validator1's full and incremental snapshots, then validator3 boots from the snapshots
+    // validator2 created after fastboot.  Validators are not guaranteed to independently create
+    // incremental snapshots at the same slot, so only full snapshot hashes are compared here.
 
     info!("Waiting for validator1 to create snapshots...");
     let (incremental_snapshot_archive, full_snapshot_archive) =
@@ -5739,7 +5739,7 @@ fn test_invalid_forks_persisted_on_restart() {
     // Majority shouldn't duplicate confirm anything
     validator_configs[1].voting_disabled = true;
 
-    let mut cluster = LocalCluster::new(
+    let mut cluster = LocalCluster::new_tower(
         &mut ClusterConfig {
             mint_lamports: DEFAULT_MINT_LAMPORTS + node_stakes.iter().sum::<u64>(),
             validator_configs,
@@ -5883,7 +5883,7 @@ fn test_alpenglow_nodes_basic(num_nodes: usize, num_offline_nodes: usize) {
         },
         ..ClusterConfig::default()
     };
-    let mut cluster = LocalCluster::new_alpenglow(&mut config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
     assert_eq!(cluster.validators.len(), num_nodes);
 
     // Check transactions land
@@ -5949,7 +5949,7 @@ fn test_restart_node_alpenglow() {
     let slots_per_epoch = MINIMUM_SLOTS_PER_EPOCH * 2;
     let ticks_per_slot = 16;
     let validator_config = ValidatorConfig::default_for_test();
-    let mut cluster = LocalCluster::new_alpenglow(
+    let mut cluster = LocalCluster::new(
         &mut ClusterConfig {
             node_stakes: vec![DEFAULT_NODE_STAKE],
             validator_configs: vec![safe_clone_config(&validator_config)],
@@ -6050,8 +6050,7 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
     };
 
     // Create local cluster
-    let mut cluster =
-        LocalCluster::new_alpenglow(&mut cluster_config, SocketAddrSpace::Unspecified);
+    let mut cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
 
     // Ensure all nodes are voting
     cluster.check_for_new_processed(
@@ -6146,7 +6145,7 @@ fn test_alpenglow_basic_equivocation() {
     };
 
     // Create local cluster
-    let cluster = LocalCluster::new_alpenglow(&mut cluster_config, SocketAddrSpace::Unspecified);
+    let cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
     let node_b_pubkey = validator_keys[1].node_keypair.pubkey();
 
     // Check to make sure the low staked node observes duplicate blocks
@@ -6243,7 +6242,7 @@ fn test_alpenglow_migration(
     ));
 
     // Create local cluster with alpenglow accounts but feature not activated
-    let cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
+    let cluster = LocalCluster::new_tower(&mut cluster_config, SocketAddrSpace::Unspecified);
 
     let validator_keys: Vec<Arc<Keypair>> =
         keys.iter().map(|keys| keys.node_keypair.clone()).collect();

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -264,8 +264,8 @@ async fn stake_merge_immediately_after_activation() {
         setup_stake(&mut context, &user_keypair, &vote_address, stake_lamports).await;
     // the new stake is at the right value
     check_credits_observed(&mut context.banks_client, absorbed_stake_address, 200).await;
-    // the base stake hasn't been moved forward because no rewards were earned
-    check_credits_observed(&mut context.banks_client, base_stake_address, 100).await;
+    // Credits advance even when no rewards were earned.
+    check_credits_observed(&mut context.banks_client, base_stake_address, 200).await;
 
     context.increment_vote_account_credits(&vote_address, 100);
     current_slot += slots_per_epoch;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4647,6 +4647,9 @@ pub mod tests {
         solana_runtime::{
             bank::{BankTestConfig, SlotLeader},
             commitment::{BlockCommitment, CommitmentSlots},
+            genesis_utils::{
+                bootstrap_validator_stake_lamports, create_genesis_config_with_tower_leader,
+            },
             non_circulating_supply::non_circulating_accounts,
         },
         solana_sdk_ids::bpf_loader_upgradeable,
@@ -4658,7 +4661,6 @@ pub mod tests {
         solana_system_interface::{instruction as system_instruction, program as system_program},
         solana_system_transaction as system_transaction,
         solana_sysvar::slot_hashes::SlotHashes,
-        solana_time_utils::slot_duration_from_slots_per_year,
         solana_transaction::{Transaction, versioned::TransactionVersion},
         solana_transaction_error::TransactionError,
         solana_transaction_status::{
@@ -4859,14 +4861,38 @@ pub mod tests {
             })
         }
 
+        fn start_tower() -> Self {
+            let config = JsonRpcConfig {
+                enable_rpc_transaction_history: true,
+                ..JsonRpcConfig::default()
+            };
+            let genesis_config_info = create_genesis_config_with_tower_leader(
+                TEST_MINT_LAMPORTS,
+                &Pubkey::new_unique(),
+                bootstrap_validator_stake_lamports(),
+            );
+            Self::start_with_config_and_genesis(config, genesis_config_info)
+        }
+
         fn start_with_config(config: JsonRpcConfig) -> Self {
+            let genesis_config_info = create_genesis_config(TEST_MINT_LAMPORTS);
+            Self::start_with_config_and_genesis(config, genesis_config_info)
+        }
+
+        fn start_with_config_and_genesis(
+            config: JsonRpcConfig,
+            genesis_config_info: GenesisConfigInfo,
+        ) -> Self {
             let (bank_forks, mint_keypair, leader_vote_keypair) =
-                new_bank_forks_with_config(BankTestConfig {
-                    accounts_db_config: AccountsDbConfig {
-                        account_indexes: Some(config.account_indexes.clone()),
-                        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+                new_bank_forks_with_config_and_genesis(
+                    BankTestConfig {
+                        accounts_db_config: AccountsDbConfig {
+                            account_indexes: Some(config.account_indexes.clone()),
+                            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+                        },
                     },
-                });
+                    genesis_config_info,
+                );
 
             let ledger_path = get_tmp_ledger_path!();
             let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
@@ -6022,6 +6048,7 @@ pub mod tests {
         assert_eq!(result, expected);
 
         // Set up nonce accounts to test filters
+        let nonce_account_owner = Pubkey::new_unique();
         let nonce_authorities = (0..2)
             .map(|_| {
                 let pubkey = Pubkey::new_unique();
@@ -6033,7 +6060,7 @@ pub mod tests {
                         DurableNonce::default(),
                         1000,
                     )),
-                    &system_program::id(),
+                    &nonce_account_owner,
                 )
                 .unwrap();
                 bank.store_account(&pubkey, &account);
@@ -6045,7 +6072,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{
                     "memcmp": {
                         "offset": 4,
@@ -6060,7 +6087,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{
                     "memcmp": {
                         "offset": 4,
@@ -6076,7 +6103,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{"dataSize": nonce::state::State::size()}]},
             ])),
         );
@@ -6086,7 +6113,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{"dataSize": 1}]},
             ])),
         );
@@ -6097,7 +6124,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{
                     "memcmp": {
                         "offset": 4,
@@ -6117,7 +6144,7 @@ pub mod tests {
         let request = create_test_request(
             "getProgramAccounts",
             Some(json!([
-                system_program::id().to_string(),
+                nonce_account_owner.to_string(),
                 {"filters": [{
                     "memcmp": {
                         "offset": 4,
@@ -7224,12 +7251,19 @@ pub mod tests {
     fn new_bank_forks_with_config(
         config: BankTestConfig,
     ) -> (Arc<RwLock<BankForks>>, Keypair, Arc<Keypair>) {
+        new_bank_forks_with_config_and_genesis(config, create_genesis_config(TEST_MINT_LAMPORTS))
+    }
+
+    fn new_bank_forks_with_config_and_genesis(
+        config: BankTestConfig,
+        genesis_config_info: GenesisConfigInfo,
+    ) -> (Arc<RwLock<BankForks>>, Keypair, Arc<Keypair>) {
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
             voting_keypair,
             ..
-        } = create_genesis_config(TEST_MINT_LAMPORTS);
+        } = genesis_config_info;
 
         genesis_config.rent.lamports_per_byte = 100;
         genesis_config.epoch_schedule =
@@ -7770,28 +7804,35 @@ pub mod tests {
         let rpc = RpcHandler::start();
         rpc.add_roots_to_blockstore(vec![1, 2, 3, 4, 5, 6, 7]);
 
-        let base_timestamp = rpc
-            .bank_forks
-            .read()
-            .unwrap()
-            .get(0)
-            .unwrap()
-            .unix_timestamp_from_genesis();
         rpc.block_commitment_cache
             .write()
             .unwrap()
             .set_highest_super_majority_root(7);
 
-        let slot_duration = slot_duration_from_slots_per_year(rpc.working_bank().slots_per_year());
-
         let request = create_test_request("getBlockTime", Some(json!([2u64])));
         let result: Option<UnixTimestamp> = parse_success_result(rpc.handle_request_sync(request));
-        let expected = Some(base_timestamp);
+        let expected = Some(
+            rpc.bank_forks
+                .read()
+                .unwrap()
+                .get(2)
+                .unwrap()
+                .clock()
+                .unix_timestamp,
+        );
         assert_eq!(result, expected);
 
         let request = create_test_request("getBlockTime", Some(json!([7u64])));
         let result: Option<UnixTimestamp> = parse_success_result(rpc.handle_request_sync(request));
-        let expected = Some(base_timestamp + (7 * slot_duration).as_secs() as i64);
+        let expected = Some(
+            rpc.bank_forks
+                .read()
+                .unwrap()
+                .get(7)
+                .unwrap()
+                .clock()
+                .unix_timestamp,
+        );
         assert_eq!(result, expected);
 
         let request = create_test_request("getBlockTime", Some(json!([12345u64])));
@@ -7805,7 +7846,7 @@ pub mod tests {
 
     #[test]
     fn test_get_vote_accounts() {
-        let rpc = RpcHandler::start();
+        let rpc = RpcHandler::start_tower();
         let mut bank = rpc.working_bank();
         let RpcHandler {
             ref io,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1255,7 +1255,9 @@ mod tests {
             stakes::{Stakes, tests::create_staked_node_accounts},
         },
         agave_feature_set::{FeatureSet, delay_commission_updates},
-        agave_votor_messages::consensus_message::BLS_KEYPAIR_DERIVE_SEED,
+        agave_votor_messages::{
+            consensus_message::BLS_KEYPAIR_DERIVE_SEED, migration::AG_MIGRATION_EPOCH_CREDIT,
+        },
         proptest::prelude::*,
         rand::Rng,
         rayon::ThreadPoolBuilder,
@@ -1694,15 +1696,16 @@ mod tests {
     #[derive(Default)]
     struct VoteOperations {
         expect_reward: bool,
-        // Additional lamport amount to ignore in collector account, used for
-        // VAT burns in Alpenglow when the incinerator is an inflation collector
-        extra_reward_lamport_amount: Option<u64>,
         // ops to perform before epoch ends
         create_with_balance: Option<u64>,
         delegate_stake_amount: Option<u64>,
         new_commission: Option<u8>,
         earned_credits: Option<u64>,
         new_inflation_rewards_collector: Option<Pubkey>,
+    }
+
+    fn vote_account_balance_for_tests() -> u64 {
+        genesis_utils::minimum_vote_account_balance_for_vat(100)
     }
 
     fn recalculate_reward_commissions_for_tests(bank: &Bank) -> RewardCommissions {
@@ -1722,6 +1725,9 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let ag_epoch_type = AlpenglowEpochType::get(bank, rewarded_epoch, || {
+            RewardEpochDelegatedStakes::get(bank)
+        });
 
         let (reward_commissions, ..) = bank.calculate_stake_rewards_and_commissions(
             &stake_history,
@@ -1729,7 +1735,7 @@ mod tests {
             cached_vote_accounts,
             rewarded_epoch,
             point_value,
-            &AlpenglowEpochType::Tower,
+            &ag_epoch_type,
             &thread_pool,
             null_tracer(),
             &mut RewardsMetrics::default(), // This is required, but not reporting anything at the moment
@@ -1813,7 +1819,7 @@ mod tests {
         assert_eq!(bank.epoch(), op.epoch);
         for (vote_address, vote_op) in &op.vote_operations {
             if let Some(balance) = &vote_op.create_with_balance {
-                // Create a BLS pubkey so the vote account passes VAT filtering
+                // Create a BLS pubkey so the vote account passes VAT filtering.
                 let identity = Keypair::new();
                 let bls_keypair =
                     BLSKeypair::derive_from_signer(&identity, BLS_KEYPAIR_DERIVE_SEED).unwrap();
@@ -1883,7 +1889,9 @@ mod tests {
                 modify_vote_state(&|vote_state: &mut VoteStateV4| {
                     let last_credits = vote_state
                         .epoch_credits
-                        .last()
+                        .iter()
+                        .rev()
+                        .find(|entry| **entry != AG_MIGRATION_EPOCH_CREDIT)
                         .map(|(_epoch, credits, _)| *credits)
                         .unwrap_or(0);
                     vote_state.epoch_credits.push((
@@ -1891,6 +1899,20 @@ mod tests {
                         last_credits + earned_credits,
                         last_credits,
                     ));
+                    // Slot 0 is the only Tower slot in the default test genesis, so credits
+                    // synthesized there precede the migration marker. Later credits are AG.
+                    let is_migration_epoch =
+                        bank.get_alpenglow_migration_slot()
+                            .is_some_and(|migration_slot| {
+                                bank.epoch_schedule().get_epoch(migration_slot) == bank.epoch()
+                            });
+                    if is_migration_epoch
+                        && !vote_state
+                            .epoch_credits
+                            .contains(&AG_MIGRATION_EPOCH_CREDIT)
+                    {
+                        vote_state.epoch_credits.push(AG_MIGRATION_EPOCH_CREDIT);
+                    }
                 });
             }
         }
@@ -1928,9 +1950,37 @@ mod tests {
             let collector_balance = bank.get_balance(&collector_address);
 
             if vote_op.expect_reward {
-                let reward_lamports = collector_balance
+                let leader_schedule_epoch = prev_bank
+                    .epoch_schedule()
+                    .get_leader_schedule_epoch(bank.slot());
+                let (collector_vat_burn, vat_transferred_to_collector) =
+                    if bank.feature_set.snapshot().alpenglow
+                        && prev_bank.epoch_stakes(leader_schedule_epoch).is_none()
+                    {
+                        let vote_accounts = bank
+                            .epoch_stakes(leader_schedule_epoch)
+                            .unwrap()
+                            .stakes()
+                            .vote_accounts();
+                        let vat = bank.vat_to_burn_per_epoch();
+                        (
+                            if vote_accounts.get(&collector_address).is_some() {
+                                vat
+                            } else {
+                                0
+                            },
+                            if collector_address == incinerator::id() {
+                                vat * vote_accounts.len() as u64
+                            } else {
+                                0
+                            },
+                        )
+                    } else {
+                        (0, 0)
+                    };
+                let reward_lamports = collector_balance + collector_vat_burn
                     - prev_collector_balance
-                    - vote_op.extra_reward_lamport_amount.unwrap_or(0);
+                    - vat_transferred_to_collector;
                 let expected_vote_reward = RewardInfo {
                     reward_type: RewardType::Voting,
                     lamports: reward_lamports as i64,
@@ -1941,8 +1991,13 @@ mod tests {
                 assert_eq!(
                     vote_reward,
                     Some(expected_vote_reward),
-                    "epoch {}: unexpected reward info",
-                    op.epoch
+                    "epoch {}: unexpected reward info; previous collector balance: {}, collector \
+                     balance: {}, collector VAT burn: {}, VAT transferred to collector: {}",
+                    op.epoch,
+                    prev_collector_balance,
+                    collector_balance,
+                    collector_vat_burn,
+                    vat_transferred_to_collector,
                 );
 
                 assert_eq!(
@@ -2001,7 +2056,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(1),
                         earned_credits: Some(1000),
                         delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -2091,7 +2146,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(1),
                         earned_credits: Some(1000),
                         expect_reward: true,
@@ -2785,7 +2840,7 @@ mod tests {
         let validator_keypairs = vec![genesis_utils::ValidatorVoteKeypairs::new_rand()];
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+        } = genesis_utils::create_genesis_config_with_vote_accounts(
             1_000_000_000 * LAMPORTS_PER_SOL,
             &validator_keypairs,
             vec![stake_lamports],
@@ -2905,7 +2960,7 @@ mod tests {
         let validator_keypairs = vec![genesis_utils::ValidatorVoteKeypairs::new_rand()];
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+        } = genesis_utils::create_genesis_config_with_vote_accounts(
             1_000_000_000 * LAMPORTS_PER_SOL,
             &validator_keypairs,
             vec![100 * LAMPORTS_PER_SOL],
@@ -3005,7 +3060,7 @@ mod tests {
             .pubkey();
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+        } = genesis_utils::create_genesis_config_with_vote_accounts(
             1_000_000_000 * LAMPORTS_PER_SOL,
             &validator_keypairs,
             stakes,
@@ -3860,7 +3915,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(1),
                         earned_credits: Some(1000),
                         delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -3961,7 +4016,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(100),
                         earned_credits: Some(1000),
                         delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -3982,7 +4037,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        earned_credits: Some(1),
+                        earned_credits: Some(1_000_000),
                         expect_reward: true,
                         ..VoteOperations::default()
                     },
@@ -4020,7 +4075,7 @@ mod tests {
                     (
                         vote1_address,
                         VoteOperations {
-                            create_with_balance: Some(LAMPORTS_PER_SOL),
+                            create_with_balance: Some(vote_account_balance_for_tests()),
                             new_commission: Some(50),
                             earned_credits: Some(1000),
                             delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -4031,7 +4086,7 @@ mod tests {
                     (
                         vote2_address,
                         VoteOperations {
-                            create_with_balance: Some(LAMPORTS_PER_SOL),
+                            create_with_balance: Some(vote_account_balance_for_tests()),
                             new_commission: Some(100),
                             earned_credits: Some(1000),
                             delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -4054,7 +4109,7 @@ mod tests {
                     (
                         vote1_address,
                         VoteOperations {
-                            earned_credits: Some(1),
+                            earned_credits: Some(1_000_000),
                             expect_reward: true,
                             ..VoteOperations::default()
                         },
@@ -4062,7 +4117,7 @@ mod tests {
                     (
                         vote2_address,
                         VoteOperations {
-                            earned_credits: Some(1),
+                            earned_credits: Some(1_000_000),
                             expect_reward: true,
                             ..VoteOperations::default()
                         },
@@ -4100,7 +4155,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(100),
                         earned_credits: Some(1000),
                         delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -4137,14 +4192,18 @@ mod tests {
         );
 
         let epoch_rewards = bank.get_epoch_rewards_sysvar();
+        let reward_commissions = recalculate_reward_commissions_for_tests(&bank);
+        let reward_commission = reward_commissions.get(&invalid_collector).unwrap();
+        let expected_distributed_rewards =
+            reward_commission.commission_lamports + reward_commission.burned_lamports;
 
-        // The burned commission lamports must be reflected in the epoch rewards
-        // sysvar. Since this test uses 100% commission, all calculated rewards
-        // went through the invalid collector path.
-        assert!(epoch_rewards.total_rewards > 0);
+        // The burned commission lamports must be reflected in the epoch rewards sysvar. Under
+        // Alpenglow, total rewards is the epoch budget while distributed rewards tracks the
+        // credits actually earned, including rewards burned by an invalid collector.
+        assert!(epoch_rewards.total_rewards > epoch_rewards.distributed_rewards);
         assert_eq!(
-            epoch_rewards.total_rewards,
-            epoch_rewards.distributed_rewards
+            epoch_rewards.distributed_rewards,
+            expected_distributed_rewards
         );
     }
 
@@ -4206,7 +4265,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        create_with_balance: Some(LAMPORTS_PER_SOL),
+                        create_with_balance: Some(vote_account_balance_for_tests()),
                         new_commission: Some(100),
                         earned_credits: Some(1000),
                         delegate_stake_amount: Some(LAMPORTS_PER_SOL),
@@ -4230,7 +4289,7 @@ mod tests {
                 vote_operations: vec![(
                     vote_address,
                     VoteOperations {
-                        earned_credits: Some(1000),
+                        earned_credits: Some(1_000_000),
                         expect_reward: true,
                         ..VoteOperations::default()
                     },
@@ -4240,8 +4299,7 @@ mod tests {
         let pre_balance = bank.get_balance(&collector_into_vote_address);
         assert_ne!(pre_balance, 0);
         // Fund the converted vote account enough to pass VAT filtering.
-        let pre_balance =
-            pre_balance.max(bank.get_minimum_balance_for_rent_exemption(VoteStateV4::size_of()));
+        let pre_balance = pre_balance.max(vote_account_balance_for_tests());
 
         // Transform the collector into a vote account, see that all rewards
         // are burned for this epoch
@@ -4283,8 +4341,9 @@ mod tests {
             .unwrap();
         assert_eq!(vote_reward.lamports, 0);
 
-        let unchanged_balance = bank.get_balance(&collector_into_vote_address);
-        assert_eq!(unchanged_balance, pre_balance);
+        let balance_after_conversion = bank.get_balance(&collector_into_vote_address);
+        let vat = bank.vat_to_burn_per_epoch();
+        assert_eq!(balance_after_conversion + vat, pre_balance);
 
         // `collector_into_vote_address` receives its rewards, but `vote_address`
         // has its rewards burned
@@ -4316,7 +4375,7 @@ mod tests {
 
         // Some rewards were distributed
         let post_balance = bank.get_balance(&collector_into_vote_address);
-        assert!(post_balance > pre_balance);
+        assert!(post_balance + vat > balance_after_conversion);
 
         // They're reflected in the reported rewards
         let vote_reward = bank
@@ -4327,7 +4386,10 @@ mod tests {
             .find(|(address, _reward)| *address == collector_into_vote_address)
             .map(|(_address, reward)| *reward)
             .unwrap();
-        assert_eq!(vote_reward.lamports as u64, post_balance - pre_balance);
+        assert_eq!(
+            vote_reward.lamports as u64,
+            post_balance + vat - balance_after_conversion
+        );
 
         // Some lamports were burned
         let reward_commissions = recalculate_reward_commissions_for_tests(&bank);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1491,9 +1491,10 @@ mod tests {
         assert_eq!(0, total_reward_commissions);
     }
 
-    #[test]
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
     /// Test rewards computation and partitioned rewards distribution at the epoch boundary
-    fn test_rewards_computation() {
+    fn test_rewards_computation_via_onchain_votes(is_alpenglow: bool) {
         agave_logger::setup();
 
         // Delegations to get rewards (2 SOL).
@@ -1503,6 +1504,7 @@ mod tests {
             stakes,
             PartitionedEpochRewardsConfig::default().stake_account_stores_per_block,
             SLOTS_PER_EPOCH,
+            is_alpenglow,
         )
         .0
         .bank;
@@ -1519,13 +1521,15 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes::get(&bank)
+            .unwrap_or_else(|| reward_epoch_delegated_stakes_for_tests(rewarded_epoch));
         let calculated_rewards = bank.calculate_validator_rewards(
             &stake_history,
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
             expected_rewards,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+            reward_epoch_delegated_stakes,
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -1542,10 +1546,17 @@ mod tests {
             .map(|rc| rc.commission_lamports)
             .sum();
 
+        // An Alpenglow genesis starts with one Tower slot in its migration epoch (slot 0).
+        // This test processes vote txs which are disabled in AG, so in AG only the slot 0 will get rewards.
+        let expected_distributed_rewards = if is_alpenglow {
+            expected_rewards / SLOTS_PER_EPOCH
+        } else {
+            expected_rewards
+        };
         // assert that total rewards matches the sum of reward commissions and stake rewards
         assert_eq!(
             stake_rewards.total_stake_rewards_lamports + total_reward_commissions,
-            expected_rewards
+            expected_distributed_rewards
         );
 
         // assert that number of stake rewards matches
@@ -1558,7 +1569,7 @@ mod tests {
 
         let expected_num_delegations = 100;
         let RewardBank { bank, .. } =
-            create_default_reward_bank(expected_num_delegations, SLOTS_PER_EPOCH).0;
+            create_default_reward_bank(expected_num_delegations, SLOTS_PER_EPOCH, true).0;
 
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let rewards_metrics = RewardsMetrics::default();
@@ -1571,13 +1582,16 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let ag_epoch_type = AlpenglowEpochType::get(&bank, rewarded_epoch, || {
+            RewardEpochDelegatedStakes::get(&bank)
+        });
 
         let point_value = bank.calculate_reward_points_partitioned(
             &stake_history,
             &stake_delegations,
             &cached_vote_accounts,
             expected_rewards,
-            &AlpenglowEpochType::Tower,
+            &ag_epoch_type,
             &thread_pool,
             &rewards_metrics,
         );
@@ -2486,8 +2500,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_calculate_stake_vote_rewards() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_calculate_stake_vote_rewards_via_on_chain_votes(is_alpenglow: bool) {
         agave_logger::setup();
 
         let expected_num_delegations = 1;
@@ -2495,7 +2510,7 @@ mod tests {
             bank,
             voters,
             stakers,
-        } = create_default_reward_bank(expected_num_delegations, SLOTS_PER_EPOCH).0;
+        } = create_default_reward_bank(expected_num_delegations, SLOTS_PER_EPOCH, is_alpenglow).0;
 
         let vote_pubkey = voters.first().unwrap();
         let stake_pubkey = *stakers.first().unwrap();
@@ -2513,13 +2528,16 @@ mod tests {
         };
         let tracer = |_event: &RewardCalculationEvent| {};
         let reward_calc_tracer = Some(tracer);
-        let rewarded_epoch = bank.epoch();
+        let rewarded_epoch = bank.epoch() - 1;
         let stakes: RwLockReadGuard<Stakes<StakeAccount<Delegation>>> = bank.stakes_cache.stakes();
         let EpochRewardCalculateParamInfo {
             stake_history,
             stake_delegations,
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let ag_epoch_type = AlpenglowEpochType::get(&bank, rewarded_epoch, || {
+            RewardEpochDelegatedStakes::get(&bank)
+        });
         let (vote_rewards_accounts, stake_reward_calculation) = bank
             .calculate_stake_rewards_and_commissions(
                 &stake_history,
@@ -2527,7 +2545,7 @@ mod tests {
                 cached_vote_accounts,
                 rewarded_epoch,
                 point_value,
-                &AlpenglowEpochType::Tower,
+                &ag_epoch_type,
                 &thread_pool,
                 reward_calc_tracer,
                 &mut rewards_metrics,
@@ -2548,7 +2566,11 @@ mod tests {
 
         assert_eq!(stake_reward_calculation.stake_rewards.num_rewards(), 1);
         let expected_reward = {
-            let stake_reward = 8_400_000_000_000;
+            let stake_reward = if is_alpenglow {
+                8_400_000_000_000 / SLOTS_PER_EPOCH
+            } else {
+                8_400_000_000_000
+            };
             let stake_state: StakeStateV2 = stake_account.state().unwrap();
             let mut stake = stake_state.stake().unwrap();
             stake.credits_observed = vote_state.credits();
@@ -2696,8 +2718,9 @@ mod tests {
         assert!(!bank.get_epoch_rewards_sysvar().active);
     }
 
-    #[test]
-    fn test_recalculate_partitioned_rewards() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_recalculate_partitioned_rewards_via_onchain_votes(is_alpenglow: bool) {
         let expected_num_delegations = 4;
         let num_rewards_per_block = 2;
         // Distribute 4 rewards over 2 blocks
@@ -2708,6 +2731,7 @@ mod tests {
             stakes,
             num_rewards_per_block,
             SLOTS_PER_EPOCH - 1,
+            is_alpenglow,
         );
         let rewarded_epoch = bank.epoch();
 
@@ -2725,6 +2749,8 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
         } = bank.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes::get(&bank)
+            .unwrap_or_else(|| reward_epoch_delegated_stakes_for_tests(rewarded_epoch));
         let PartitionedRewardsCalculation {
             stake_rewards:
                 StakeRewardCalculation {
@@ -2738,7 +2764,7 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+            reward_epoch_delegated_stakes,
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -2778,6 +2804,9 @@ mod tests {
 
         let sysvar = bank.get_epoch_rewards_sysvar();
         assert_eq!(point_value.rewards, sysvar.total_rewards);
+        if is_alpenglow {
+            assert_eq!(sysvar.total_rewards, 0);
+        }
 
         // Advance to first distribution slot (bank_forks kept in scope so parent has fork_graph)
         let mut bank =
@@ -2810,17 +2839,22 @@ mod tests {
             distribution_starting_block_height
         );
         assert_eq!(expected_stake_rewards.len(), recalculated_rewards.len());
-        // First partition has already been distributed, so recalculation
-        // returns 0 rewards
-        assert_eq!(recalculated_rewards[0].num_rewards(), 0);
-        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
-        let starting_index = (bank.block_height() + 1
-            - epoch_rewards_sysvar.distribution_starting_block_height)
-            as usize;
-        compare_stake_rewards(
-            &expected_stake_rewards[starting_index..],
-            &recalculated_rewards[starting_index..],
-        );
+        if is_alpenglow {
+            // This migration epoch has a zero reward budget and no Alpenglow reward credits, so
+            // the zero-lamport rewards were not stored and remain present during recalculation.
+            compare_stake_rewards(&expected_stake_rewards, &recalculated_rewards);
+        } else {
+            // First partition has already been distributed, so recalculation returns 0 rewards.
+            assert_eq!(recalculated_rewards[0].num_rewards(), 0);
+            let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+            let starting_index = (bank.block_height() + 1
+                - epoch_rewards_sysvar.distribution_starting_block_height)
+                as usize;
+            compare_stake_rewards(
+                &expected_stake_rewards[starting_index..],
+                &recalculated_rewards[starting_index..],
+            );
+        }
 
         // Advance until reward distribution has completed.
         let mut bank = bank;
@@ -3092,8 +3126,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_initialize_after_snapshot_restore() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_initialize_after_snapshot_restore(is_alpenglow: bool) {
         let expected_num_stake_rewards = 4;
         let num_rewards_per_block = 2;
         // Distribute 4 rewards over 2 blocks
@@ -3107,6 +3142,7 @@ mod tests {
             stakes,
             num_rewards_per_block,
             SLOTS_PER_EPOCH - 1,
+            is_alpenglow,
         );
 
         // Advance to next epoch boundary (bank_forks kept in scope so parent has fork_graph)
@@ -3148,8 +3184,9 @@ mod tests {
         let _ = &bank_forks; // Keep in scope so parent banks retain fork_graph
     }
 
-    #[test]
-    fn test_initialize_after_snapshot_restore_preserves_vat_filtered_rewards() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_initialize_after_snapshot_restore_preserves_vat_filtered_rewards(is_alpenglow: bool) {
         let num_validators = crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS + 1;
         let num_rewards_per_block = 64;
         // Use unique stakes so VAT filtering deterministically excludes exactly
@@ -3168,6 +3205,7 @@ mod tests {
             stakes,
             num_rewards_per_block,
             SLOTS_PER_EPOCH - 1,
+            is_alpenglow,
         );
 
         let filtered_vote_pubkey = *voters.last().unwrap();
@@ -3681,8 +3719,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_epoch_boundary() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_epoch_boundary_for_onchain_votes(is_alpenglow: bool) {
         let delegations = 100;
         let stake_lamports = 2_000_000_000;
         let stakes: Vec<_> = (0..delegations).map(|_| stake_lamports).collect();
@@ -3698,6 +3737,7 @@ mod tests {
             stakes,
             PartitionedEpochRewardsConfig::default().stake_account_stores_per_block,
             SLOTS_PER_EPOCH,
+            is_alpenglow,
         );
         let mut voters: HashSet<_> = voters.into_iter().collect();
         let mut stakers: HashSet<_> = stakers.into_iter().collect();
@@ -3708,14 +3748,19 @@ mod tests {
         let epoch_rewards_sysvar_balance = bank1.get_balance(&solana_sysvar::epoch_rewards::id());
         assert_eq!(epoch_rewards_sysvar_balance, 1);
 
+        let (expected_stake_rewards, expected_rewards) = if is_alpenglow {
+            (0, 0)
+        } else {
+            (499500, 499542)
+        };
         assert_cached_rewards(
             &bank1,
-            1,                     // expected_cache_len
-            &voters,               // expected_voters
-            &stakers,              // expected_stakers
-            0,                     // expected_reward_commissions
-            499500,                // expected_stake_rewards
-            499542,                // expected_rewards
+            1,        // expected_cache_len
+            &voters,  // expected_voters
+            &stakers, // expected_stakers
+            0,        // expected_reward_commissions
+            expected_stake_rewards,
+            expected_rewards,
             8_400_000_000_000u128, // expected_points
             None,                  // parent_capitalization
         );
@@ -3729,16 +3774,41 @@ mod tests {
             SLOTS_PER_EPOCH * 2,
         ));
 
+        // This helper synthesizes Tower vote credits, but not Alpenglow reward-certificate
+        // credits. Full Alpenglow epochs therefore retain their reward budget without producing
+        // reward accounts in this fixture.
+        let no_reward_accounts = HashSet::new();
+        let (
+            expected_voters,
+            expected_stakers,
+            expected_reward_commissions,
+            expected_stake_rewards,
+            expected_rewards,
+            expected_points,
+        ) = if is_alpenglow {
+            (&no_reward_accounts, &no_reward_accounts, 0, 0, 499542, 0)
+        } else {
+            (&voters, &stakers, 5555, 494730, 500313, 9_450_000_000_000)
+        };
+        let capitalization_after_vat_burn = if is_alpenglow {
+            let num_vat_burns = RewardEpochDelegatedStakes::get(&bank2)
+                .unwrap()
+                .delegated_stakes
+                .len() as u64;
+            parent_capitalization - bank2.vat_to_burn_per_epoch() * num_vat_burns
+        } else {
+            parent_capitalization
+        };
         assert_cached_rewards(
             &bank2,
-            2,                           // expected_cache_len
-            &voters,                     // expected_voters
-            &stakers,                    // expected_stakers
-            5555,                        // expected_reward_commissions
-            494730,                      // expected_stake_rewards
-            500313,                      // expected_rewards
-            9_450_000_000_000u128,       // expected_points
-            Some(parent_capitalization), // parent_capitalization
+            2, // expected_cache_len
+            expected_voters,
+            expected_stakers,
+            expected_reward_commissions,
+            expected_stake_rewards,
+            expected_rewards,
+            expected_points,
+            Some(capitalization_after_vat_burn),
         );
 
         add_voters_and_populate(&bank2, &mut voters, &mut stakers, 10, 8_000_000_000, 10);
@@ -3750,16 +3820,37 @@ mod tests {
             SLOTS_PER_EPOCH * 3,
         ));
 
+        let (
+            expected_voters,
+            expected_stakers,
+            expected_reward_commissions,
+            expected_stake_rewards,
+            expected_rewards,
+            expected_points,
+        ) = if is_alpenglow {
+            (&no_reward_accounts, &no_reward_accounts, 0, 0, 495380, 0)
+        } else {
+            (&voters, &stakers, 17300, 485365, 502779, 12_810_000_000_000)
+        };
+        let capitalization_after_vat_burn = if is_alpenglow {
+            let num_vat_burns = RewardEpochDelegatedStakes::get(&bank3)
+                .unwrap()
+                .delegated_stakes
+                .len() as u64;
+            parent_capitalization - bank3.vat_to_burn_per_epoch() * num_vat_burns
+        } else {
+            parent_capitalization
+        };
         assert_cached_rewards(
             &bank3,
-            3,                           // expected_cache_len
-            &voters,                     // expected_voters
-            &stakers,                    // expected_stakers
-            17300,                       // expected_reward_commissions
-            485365,                      // expected_stake_rewards
-            502779,                      // expected_rewards
-            12_810_000_000_000u128,      // expected_points
-            Some(parent_capitalization), // parent_capitalization
+            3, // expected_cache_len
+            expected_voters,
+            expected_stakers,
+            expected_reward_commissions,
+            expected_stake_rewards,
+            expected_rewards,
+            expected_points,
+            Some(capitalization_after_vat_burn),
         );
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -442,7 +442,8 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs,
-                create_genesis_config_with_tower_vote_accounts, deactivate_features,
+                create_genesis_config_with_tower_vote_accounts,
+                create_genesis_config_with_vote_accounts, deactivate_features,
             },
             runtime_config::RuntimeConfig,
             stake_utils,
@@ -466,6 +467,7 @@ mod tests {
         solana_vote_interface::state::{MAX_LOCKOUT_HISTORY, VoteStateV4, VoteStateVersions},
         solana_vote_program::vote_state::{self, TowerSync, handler::VoteStateHandler},
         std::sync::{Arc, RwLock},
+        test_case::test_case,
     };
 
     impl PartitionedStakeReward {
@@ -591,11 +593,13 @@ mod tests {
     pub(super) fn create_default_reward_bank(
         expected_num_delegations: usize,
         advance_num_slots: u64,
+        is_alpenglow: bool,
     ) -> (RewardBank, Arc<RwLock<BankForks>>) {
-        create_reward_bank(
-            expected_num_delegations,
+        create_reward_bank_with_specific_stakes(
+            vec![2_000_000_000; expected_num_delegations],
             PartitionedEpochRewardsConfig::default().stake_account_stores_per_block,
             advance_num_slots,
+            is_alpenglow,
         )
     }
 
@@ -608,6 +612,7 @@ mod tests {
             vec![2_000_000_000; expected_num_delegations],
             stake_account_stores_per_block,
             advance_num_slots,
+            false,
         )
     }
 
@@ -615,6 +620,7 @@ mod tests {
         stakes: Vec<u64>,
         stake_account_stores_per_block: u64,
         advance_num_slots: u64,
+        is_alpenglow: bool,
     ) -> (RewardBank, Arc<RwLock<BankForks>>) {
         // Disable slot time reduction features as they will override the custom
         // stores per block provided in this test helper.
@@ -625,11 +631,15 @@ mod tests {
 
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = create_genesis_config_with_tower_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            stakes,
-        );
+        } = if is_alpenglow {
+            create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes)
+        } else {
+            create_genesis_config_with_tower_vote_accounts(
+                1_000_000_000,
+                &validator_keypairs,
+                stakes,
+            )
+        };
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
         deactivate_features(&mut genesis_config, &features_to_deactivate);
 
@@ -855,8 +865,9 @@ mod tests {
         assert_eq!(bank.get_reward_distribution_num_blocks(&rewards), 1);
     }
 
-    #[test]
-    fn test_rewards_computation_and_partitioned_distribution_one_block() {
+    #[test_case(true; "alpenglow")]
+    #[test_case(false; "towerbft")]
+    fn test_rewards_computation_and_partitioned_distribution_one_block(is_alpenglow: bool) {
         agave_logger::setup();
 
         let starting_slot = SLOTS_PER_EPOCH - 1;
@@ -866,17 +877,19 @@ mod tests {
                 ..
             },
             bank_forks,
-        ) = create_default_reward_bank(100, starting_slot - 1);
+        ) = create_default_reward_bank(100, starting_slot - 1, is_alpenglow);
 
         // simulate block progress
         for slot in starting_slot..=(2 * SLOTS_PER_EPOCH) + 2 {
-            let pre_cap = previous_bank.capitalization();
             let curr_bank = Bank::new_from_parent_with_bank_forks(
                 bank_forks.as_ref(),
                 previous_bank.clone(),
                 SlotLeader::default(),
                 slot,
             );
+            // Creating the child freezes its parent, which can burn Alpenglow VAT. Capture the
+            // parent capitalization after that freeze so reward deltas remain the only difference.
+            let pre_cap = previous_bank.capitalization();
             let post_cap = curr_bank.capitalization();
 
             if slot % SLOTS_PER_EPOCH == 0 {
@@ -895,7 +908,9 @@ mod tests {
                         .get_epoch_rewards_from_cache(&curr_bank.parent_hash)
                         .is_some()
                 );
-                assert_eq!(post_cap, pre_cap);
+                if !is_alpenglow {
+                    assert_eq!(post_cap, pre_cap);
+                }
 
                 // Make a root the bank, which is the first bank in the epoch.
                 // This will clear the cache.

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -441,8 +441,8 @@ mod tests {
             bank::{SlotLeader, tests::create_genesis_config},
             bank_forks::BankForks,
             genesis_utils::{
-                GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
-                deactivate_features,
+                GenesisConfigInfo, ValidatorVoteKeypairs,
+                create_genesis_config_with_tower_vote_accounts, deactivate_features,
             },
             runtime_config::RuntimeConfig,
             stake_utils,
@@ -625,7 +625,11 @@ mod tests {
 
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
+        } = create_genesis_config_with_tower_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            stakes,
+        );
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
         deactivate_features(&mut genesis_config, &features_to_deactivate);
 
@@ -1088,7 +1092,7 @@ mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_vote_accounts(
+        } = create_genesis_config_with_tower_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![1_000_000_000; 1],

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -5,9 +5,7 @@ use super::Bank;
 mod tests {
     use {
         super::*,
-        crate::{
-            genesis_utils::activate_all_features_alpenglow, inflation_rewards::points::PointValue,
-        },
+        crate::{genesis_utils::activate_all_features, inflation_rewards::points::PointValue},
         solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
         solana_genesis_config::create_genesis_config,
         solana_leader_schedule::SlotLeader,
@@ -172,7 +170,7 @@ mod tests {
     #[test]
     fn test_alpenglow_clock_cache_updates_before_and_after_footer() {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        activate_all_features_alpenglow(&mut genesis_config);
+        activate_all_features(&mut genesis_config);
         let (bank0, bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
         assert!(bank0.get_alpenglow_genesis_certificate().is_some());
@@ -229,7 +227,7 @@ mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
         genesis_config.epoch_schedule =
             EpochSchedule::custom(MINIMUM_SLOTS_PER_EPOCH, MINIMUM_SLOTS_PER_EPOCH, false);
-        activate_all_features_alpenglow(&mut genesis_config);
+        activate_all_features(&mut genesis_config);
         let (parent, bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13,9 +13,9 @@ use {
         genesis_utils::{
             self, GenesisConfigInfo, ValidatorVoteKeypairs, activate_all_features,
             activate_feature, bootstrap_validator_stake_lamports,
-            create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
-            create_lockup_stake_account, genesis_sysvar_and_builtin_program_lamports,
-            minimum_vote_account_balance_for_vat,
+            create_genesis_config_with_leader, create_genesis_config_with_tower_leader,
+            create_genesis_config_with_vote_accounts, create_lockup_stake_account,
+            genesis_sysvar_and_builtin_program_lamports, minimum_vote_account_balance_for_vat,
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
@@ -148,7 +148,7 @@ use {
     solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote::vote_account::{VoteAccount, VoteAccounts},
-    solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, TowerSync},
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::{
         vote_instruction,
         vote_state::{
@@ -1765,15 +1765,24 @@ fn test_readonly_accounts() {
     bank.transfer(1, &mint_keypair, &authorized_voter.pubkey())
         .unwrap();
 
-    let vote = TowerSync::new_from_slot(bank.parent_slot, bank.parent_hash);
-    let ix0 = vote_instruction::tower_sync(&vote_pubkey0, &authorized_voter.pubkey(), vote.clone());
+    let ix0 = vote_instruction::authorize(
+        &vote_pubkey0,
+        &authorized_voter.pubkey(),
+        &Pubkey::new_unique(),
+        VoteAuthorize::Withdrawer,
+    );
     let tx0 = Transaction::new_signed_with_payer(
         &[ix0],
         Some(&payer0.pubkey()),
         &[&payer0, &authorized_voter],
         bank.last_blockhash(),
     );
-    let ix1 = vote_instruction::tower_sync(&vote_pubkey1, &authorized_voter.pubkey(), vote.clone());
+    let ix1 = vote_instruction::authorize(
+        &vote_pubkey1,
+        &authorized_voter.pubkey(),
+        &Pubkey::new_unique(),
+        VoteAuthorize::Withdrawer,
+    );
     let tx1 = Transaction::new_signed_with_payer(
         &[ix1],
         Some(&payer1.pubkey()),
@@ -1788,7 +1797,12 @@ fn test_readonly_accounts() {
     assert_eq!(results[0], Ok(()));
     assert_eq!(results[1], Ok(()));
 
-    let ix0 = vote_instruction::tower_sync(&vote_pubkey2, &authorized_voter.pubkey(), vote);
+    let ix0 = vote_instruction::authorize(
+        &vote_pubkey2,
+        &authorized_voter.pubkey(),
+        &Pubkey::new_unique(),
+        VoteAuthorize::Withdrawer,
+    );
     let tx0 = Transaction::new_signed_with_payer(
         &[ix0],
         Some(&payer0.pubkey()),
@@ -5585,7 +5599,7 @@ fn test_bank_hash_deterministic_with_stakes_cache() {
         .collect::<Vec<_>>();
     let GenesisConfigInfo {
         mut genesis_config, ..
-    } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+    } = genesis_utils::create_genesis_config_with_vote_accounts(
         1_000_000_000,
         &validator_keypairs,
         vec![STAKE_LAMPORTS; NUM_VALIDATORS],
@@ -7045,7 +7059,7 @@ fn test_reduce_slot_time_hashes_per_tick() {
     );
 
     let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-    genesis_utils::activate_all_features_alpenglow(&mut genesis_config);
+    genesis_utils::activate_all_features(&mut genesis_config);
     assert_eq!(genesis_config.poh_config.hashes_per_tick, None);
     assert_reduced_slot_time_hashes_per_tick(genesis_config, None, None);
 }
@@ -7139,7 +7153,7 @@ fn test_update_clock_slot_range_duration() {
         mut genesis_config,
         voting_keypair,
         ..
-    } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
+    } = create_genesis_config_with_tower_leader(5, &leader_pubkey, 3);
     genesis_config.epoch_schedule = EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
     activate_feature(
         &mut genesis_config,
@@ -7740,7 +7754,7 @@ fn test_timestamp_slow() {
         mut genesis_config,
         voting_keypair,
         ..
-    } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
+    } = create_genesis_config_with_tower_leader(5, &leader_pubkey, 3);
     let slots_in_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
     let (mut bank, _bank_forks) =
@@ -7785,7 +7799,7 @@ fn test_timestamp_fast() {
         mut genesis_config,
         voting_keypair,
         ..
-    } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
+    } = create_genesis_config_with_tower_leader(5, &leader_pubkey, 3);
     let slots_in_epoch = 32;
     genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
     let (mut bank, _bank_forks) =

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6968,8 +6968,7 @@ fn test_vat_burn_slot_params() {
             &validator_keypairs,
             vec![minimum_vote_account_balance_for_vat(100)],
             ClusterType::Development,
-            &FeatureSet::default(),
-            false,
+            FeatureSet::default(),
         );
         activate_feature(&mut genesis_config, feature_set::alpenglow::id());
         if let Some(feature_id) = slot_time_feature_id {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -775,6 +775,7 @@ mod tests {
             block_component_processor::vote_reward::epoch_inflation_account_state::EpochInflationAccountState,
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
+                create_genesis_config_with_tower_leader,
             },
             installed_scheduler_pool::{
                 InstalledScheduler, ResultWithTimings, ScheduleResult, SchedulerId,
@@ -797,6 +798,7 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
+        solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::system_program,
@@ -987,7 +989,7 @@ mod tests {
     ) -> Bank {
         let GenesisConfigInfo {
             mut genesis_config, ..
-        } = create_genesis_config(10_000);
+        } = create_genesis_config_with_tower_leader(10_000, &Pubkey::new_unique(), 0);
         genesis_config.epoch_schedule = EpochSchedule::new(32);
 
         if let Some(genesis_cert) = genesis_cert {
@@ -1098,7 +1100,7 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000);
+        } = create_genesis_config_with_tower_leader(10_000, &Pubkey::new_unique(), 0);
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let root_bank = bank_forks.read().unwrap().root_bank();
 

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -794,7 +794,7 @@ mod tests {
         crate::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
-            genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
+            genesis_utils::{create_genesis_config, create_genesis_config_with_tower_leader},
         },
         bytes::Bytes,
         rand::Rng,
@@ -819,9 +819,9 @@ mod tests {
         Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config)
     }
 
-    fn create_test_bank_alpenglow() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
-        let mut genesis_config_info = create_genesis_config(10_000);
-        activate_all_features_alpenglow(&mut genesis_config_info.genesis_config);
+    fn create_test_bank_tower() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
+        let genesis_config_info =
+            create_genesis_config_with_tower_leader(10_000, &Pubkey::new_unique(), 0);
         Bank::new_with_bank_forks_for_tests(&genesis_config_info.genesis_config)
     }
 
@@ -1082,7 +1082,7 @@ mod tests {
     #[test]
     fn test_first_alpenglow_block_with_genesis_certificate_marker_succeeds() {
         let migration_status = post_migration_status_with_genesis_slot(1);
-        let (genesis_bank, bank_forks) = create_test_bank();
+        let (genesis_bank, bank_forks) = create_test_bank_tower();
         let parent = create_child_bank(&bank_forks, &genesis_bank, 1);
         let parent_block_id = Hash::new_unique();
         parent.set_block_id(Some(parent_block_id));
@@ -1109,7 +1109,7 @@ mod tests {
     fn test_genesis_certificate_marker_aborts_tower_bank_during_migration() {
         let migration_status = MigrationStatus::default();
         migration_status.record_feature_activation(0);
-        let (genesis_bank, bank_forks) = create_test_bank();
+        let (genesis_bank, bank_forks) = create_test_bank_tower();
         let parent = create_child_bank(&bank_forks, &genesis_bank, 1);
         let parent_block_id = Hash::new_unique();
         parent.set_block_id(Some(parent_block_id));
@@ -1810,7 +1810,7 @@ mod tests {
         let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
-        let (parent, bank_forks) = create_test_bank_alpenglow();
+        let (parent, bank_forks) = create_test_bank();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
 
         // Set up clock on parent so validation doesn't skip bounds checking
@@ -1852,7 +1852,7 @@ mod tests {
         let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
-        let (parent, bank_forks) = create_test_bank_alpenglow();
+        let (parent, bank_forks) = create_test_bank();
         assert_eq!(parent.get_nanosecond_clock(), None);
 
         let bank = create_child_bank(&bank_forks, &parent, 1);
@@ -1887,7 +1887,7 @@ mod tests {
         let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
-        let (parent, bank_forks) = create_test_bank_alpenglow();
+        let (parent, bank_forks) = create_test_bank();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
         parent.update_clock_from_footer(parent_time_nanos);
         let bank = create_child_bank(&bank_forks, &parent, 1);

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -596,9 +596,8 @@ mod tests {
         crate::{
             bank_forks::BankForks,
             genesis_utils::{
-                ValidatorVoteKeypairs, activate_all_features_alpenglow,
-                create_genesis_config_with_alpenglow_vote_accounts,
-                create_genesis_config_with_leader_ex, create_validator,
+                ValidatorVoteKeypairs, create_genesis_config_with_leader_ex,
+                create_genesis_config_with_vote_accounts, create_validator,
             },
             inflation_rewards::{MAX_BPS, commission_split_preserve_lamports},
             stake_utils,
@@ -739,7 +738,7 @@ mod tests {
         let validator_keypairs = (0..num_validators)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+        let mut genesis_config = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![per_validator_stake; validator_keypairs.len()],
@@ -838,7 +837,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
         let per_validator_stake = LAMPORTS_PER_SOL * 100;
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+        let mut genesis_config = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![per_validator_stake; validator_keypairs.len()],
@@ -909,7 +908,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
         let per_validator_stake = LAMPORTS_PER_SOL * 100;
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+        let mut genesis_config = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![per_validator_stake; validator_keypairs.len()],
@@ -990,7 +989,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+        let mut genesis_config = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![per_validator_stake; validator_keypairs.len()],
@@ -1129,7 +1128,6 @@ mod tests {
                 vec![],
             );
             genesis_config.epoch_schedule = EpochSchedule::without_warmup();
-            activate_all_features_alpenglow(&mut genesis_config);
             for (ind, keypair) in validators.iter().enumerate().skip(1) {
                 let node_pubkey = keypair.node_keypair.pubkey();
                 let vote_pubkey = keypair.vote_keypair.pubkey();
@@ -1638,7 +1636,7 @@ mod tests {
         let slots_per_epoch = 32;
         let stake = 200_000_000 * LAMPORTS_PER_SOL;
         let validators = vec![ValidatorVoteKeypairs::new_rand()];
-        let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
+        let mut genesis_config = create_genesis_config_with_vote_accounts(
             100_000_000 * LAMPORTS_PER_SOL,
             &validators,
             vec![stake],

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -13,7 +13,7 @@ use {
 
 /// The account address for the off curve account used to store metadata for calculating and
 /// paying voting rewards.
-static VOTE_REWARD_ACCOUNT_ADDR: LazyLock<Pubkey> = LazyLock::new(|| {
+pub(crate) static VOTE_REWARD_ACCOUNT_ADDR: LazyLock<Pubkey> = LazyLock::new(|| {
     let (pubkey, _) = Pubkey::find_program_address(
         &[b"vote_reward_account"],
         &agave_feature_set::alpenglow::id(),
@@ -181,7 +181,8 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config,
-                create_genesis_config_with_alpenglow_vote_accounts, deactivate_features,
+                create_genesis_config_with_tower_leader, create_genesis_config_with_vote_accounts,
+                deactivate_features,
             },
             slot_params::slot_time_feature_ids,
         },
@@ -222,7 +223,7 @@ mod tests {
             let validator_keypairs = (0..10)
                 .map(|_| ValidatorVoteKeypairs::new_rand())
                 .collect::<Vec<_>>();
-            let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            let genesis = create_genesis_config_with_vote_accounts(
                 1_000_000_000,
                 &validator_keypairs,
                 vec![100; validator_keypairs.len()],
@@ -340,7 +341,7 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000);
+        } = create_genesis_config_with_tower_leader(10_000, &Pubkey::new_unique(), 0);
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let root_bank = bank_forks.read().unwrap().root_bank();
 

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -9,8 +9,8 @@ mod tests {
                 tests::{new_bank_from_parent, set_commission, split_commission_checked},
             },
             genesis_utils::{
-                ValidatorVoteKeypairs, activate_all_features, create_genesis_config_with_leader_ex,
-                create_validator,
+                ValidatorVoteKeypairs, activate_all_features_tower,
+                create_genesis_config_with_leader_ex, create_validator,
             },
             stake_utils,
             sysvar_account::from_account,
@@ -155,11 +155,11 @@ mod tests {
                 FeeRateGovernor::new(0, 0),
                 Rent::default(),
                 ClusterType::Development,
-                &FeatureSet::all_enabled(),
+                &FeatureSet::default(),
                 vec![],
             );
             genesis_config.epoch_schedule = EpochSchedule::without_warmup();
-            activate_all_features(&mut genesis_config);
+            activate_all_features_tower(&mut genesis_config);
             for (ind, keypair) in validators.iter().enumerate().skip(1) {
                 let node_pubkey = keypair.node_keypair.pubkey();
                 let vote_pubkey = keypair.vote_keypair.pubkey();

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -158,15 +158,6 @@ pub fn create_genesis_config_with_vote_accounts(
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-pub fn create_genesis_config_with_alpenglow_vote_accounts(
-    mint_lamports: u64,
-    voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
-    stakes: Vec<u64>,
-) -> GenesisConfigInfo {
-    create_genesis_config_with_vote_accounts(mint_lamports, voting_keypairs, stakes)
-}
-
-#[cfg(feature = "dev-context-only-utils")]
 pub fn create_genesis_config_with_tower_vote_accounts(
     mint_lamports: u64,
     voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
@@ -373,10 +364,6 @@ fn create_genesis_config_with_leader_with_mint_keypair_and_feature_set(
         voting_keypair,
         validator_pubkey: *validator_pubkey,
     }
-}
-
-pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
-    activate_all_features(genesis_config);
 }
 
 pub fn activate_all_features(genesis_config: &mut GenesisConfig) {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -152,8 +152,7 @@ pub fn create_genesis_config_with_vote_accounts(
         voting_keypairs,
         stakes,
         ClusterType::Development,
-        &FeatureSet::all_enabled(),
-        true,
+        FeatureSet::all_enabled(),
     )
 }
 
@@ -163,13 +162,14 @@ pub fn create_genesis_config_with_tower_vote_accounts(
     voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
     stakes: Vec<u64>,
 ) -> GenesisConfigInfo {
+    let mut feature_set = FeatureSet::all_enabled();
+    feature_set.deactivate(&agave_feature_set::alpenglow::id());
     create_genesis_config_with_vote_accounts_and_cluster_type(
         mint_lamports,
         voting_keypairs,
         stakes,
         ClusterType::Development,
-        &FeatureSet::all_enabled(),
-        false,
+        feature_set,
     )
 }
 
@@ -178,8 +178,7 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
     voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
     stakes: Vec<u64>,
     cluster_type: ClusterType,
-    feature_set: &FeatureSet,
-    is_alpenglow: bool,
+    feature_set: FeatureSet,
 ) -> GenesisConfigInfo {
     assert!(!voting_keypairs.is_empty());
     assert_eq!(voting_keypairs.len(), stakes.len());
@@ -196,14 +195,6 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
             .public
             .to_bytes_compressed(),
     );
-    let mut feature_set = if is_alpenglow {
-        FeatureSet::all_enabled()
-    } else {
-        feature_set.clone()
-    };
-    if !is_alpenglow {
-        feature_set.deactivate(&agave_feature_set::alpenglow::id());
-    }
 
     let genesis_config = create_genesis_config_with_leader_ex(
         mint_lamports,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -153,12 +153,21 @@ pub fn create_genesis_config_with_vote_accounts(
         stakes,
         ClusterType::Development,
         &FeatureSet::all_enabled(),
-        false,
+        true,
     )
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 pub fn create_genesis_config_with_alpenglow_vote_accounts(
+    mint_lamports: u64,
+    voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
+    stakes: Vec<u64>,
+) -> GenesisConfigInfo {
+    create_genesis_config_with_vote_accounts(mint_lamports, voting_keypairs, stakes)
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+pub fn create_genesis_config_with_tower_vote_accounts(
     mint_lamports: u64,
     voting_keypairs: &[impl Borrow<ValidatorVoteKeypairs>],
     stakes: Vec<u64>,
@@ -169,7 +178,7 @@ pub fn create_genesis_config_with_alpenglow_vote_accounts(
         stakes,
         ClusterType::Development,
         &FeatureSet::all_enabled(),
-        true,
+        false,
     )
 }
 
@@ -196,7 +205,16 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
             .public
             .to_bytes_compressed(),
     );
-    let mut genesis_config = create_genesis_config_with_leader_ex(
+    let mut feature_set = if is_alpenglow {
+        FeatureSet::all_enabled()
+    } else {
+        feature_set.clone()
+    };
+    if !is_alpenglow {
+        feature_set.deactivate(&agave_feature_set::alpenglow::id());
+    }
+
+    let genesis_config = create_genesis_config_with_leader_ex(
         mint_lamports,
         &mint_keypair.pubkey(),
         &validator_pubkey,
@@ -208,13 +226,9 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
         Rent::free(),               // most tests don't expect rent
         cluster_type,
-        feature_set,
+        &feature_set,
         vec![],
     );
-
-    if is_alpenglow {
-        activate_all_features_alpenglow(&mut genesis_config);
-    }
 
     let mut genesis_config_info = GenesisConfigInfo {
         genesis_config,
@@ -283,11 +297,45 @@ pub fn create_genesis_config_with_leader(
     )
 }
 
+#[cfg(feature = "dev-context-only-utils")]
+pub fn create_genesis_config_with_tower_leader(
+    mint_lamports: u64,
+    validator_pubkey: &Pubkey,
+    validator_stake_lamports: u64,
+) -> GenesisConfigInfo {
+    let mint_keypair = Keypair::from_seed(&MINT_KEYPAIR_SEED).unwrap();
+    let mut feature_set = FeatureSet::all_enabled();
+    feature_set.deactivate(&agave_feature_set::alpenglow::id());
+    create_genesis_config_with_leader_with_mint_keypair_and_feature_set(
+        mint_keypair,
+        mint_lamports,
+        validator_pubkey,
+        validator_stake_lamports,
+        &feature_set,
+    )
+}
+
 pub fn create_genesis_config_with_leader_with_mint_keypair(
     mint_keypair: Keypair,
     mint_lamports: u64,
     validator_pubkey: &Pubkey,
     validator_stake_lamports: u64,
+) -> GenesisConfigInfo {
+    create_genesis_config_with_leader_with_mint_keypair_and_feature_set(
+        mint_keypair,
+        mint_lamports,
+        validator_pubkey,
+        validator_stake_lamports,
+        &FeatureSet::all_enabled(),
+    )
+}
+
+fn create_genesis_config_with_leader_with_mint_keypair_and_feature_set(
+    mint_keypair: Keypair,
+    mint_lamports: u64,
+    validator_pubkey: &Pubkey,
+    validator_stake_lamports: u64,
+    feature_set: &FeatureSet,
 ) -> GenesisConfigInfo {
     // Use deterministic keypair so we don't get confused by randomness in tests
     let voting_keypair = Keypair::from_seed(&[
@@ -315,7 +363,7 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
         FeeRateGovernor::new(0, 0), // most tests can't handle transaction fees
         Rent::free(),               // most tests don't expect rent
         ClusterType::Development,
-        &FeatureSet::all_enabled(),
+        feature_set,
         vec![],
     );
 
@@ -328,6 +376,10 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
 }
 
 pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
+    activate_all_features(genesis_config);
+}
+
+pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     do_activate_all_features::<true>(genesis_config);
     configure_alpenglow_at_genesis(genesis_config);
 }
@@ -363,7 +415,7 @@ fn configure_alpenglow_at_genesis(genesis_config: &mut GenesisConfig) {
     EpochInflationAccountState::insert_into_genesis_config(genesis_config);
 }
 
-pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
+pub fn activate_all_features_tower(genesis_config: &mut GenesisConfig) {
     do_activate_all_features::<false>(genesis_config);
 }
 
@@ -561,11 +613,10 @@ pub fn create_genesis_config_with_leader_ex(
     );
 
     for feature_id in feature_set.active().keys() {
-        // Skip alpenglow (existing behavior)
-        if *feature_id == agave_feature_set::alpenglow::id() {
-            continue;
-        }
         activate_feature(&mut genesis_config, *feature_id);
+    }
+    if feature_set.is_active(&agave_feature_set::alpenglow::id()) {
+        configure_alpenglow_at_genesis(&mut genesis_config);
     }
 
     genesis_config
@@ -631,4 +682,85 @@ pub fn create_lockup_stake_account(
         .expect("set_state");
 
     stake_account
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_alpenglow_genesis(genesis_config: &GenesisConfig) {
+        assert!(
+            genesis_config
+                .accounts
+                .contains_key(&agave_feature_set::alpenglow::id())
+        );
+        assert!(
+            genesis_config
+                .accounts
+                .contains_key(&agave_feature_set::alpenglow_fast_leader_handover::id())
+        );
+        assert!(
+            genesis_config
+                .accounts
+                .contains_key(&GENESIS_CERTIFICATE_ACCOUNT)
+        );
+        assert!(genesis_config.poh_config.hashes_per_tick.is_none());
+    }
+
+    fn assert_tower_genesis(genesis_config: &GenesisConfig) {
+        assert!(
+            !genesis_config
+                .accounts
+                .contains_key(&agave_feature_set::alpenglow::id())
+        );
+        assert!(
+            genesis_config
+                .accounts
+                .contains_key(&agave_feature_set::alpenglow_fast_leader_handover::id())
+        );
+        assert!(
+            !genesis_config
+                .accounts
+                .contains_key(&GENESIS_CERTIFICATE_ACCOUNT)
+        );
+    }
+
+    #[test]
+    fn test_default_genesis_is_alpenglow() {
+        assert_alpenglow_genesis(&create_genesis_config(1_000_000).genesis_config);
+    }
+
+    #[test]
+    fn test_default_vote_account_genesis_is_alpenglow() {
+        let validator = ValidatorVoteKeypairs::new_rand();
+        let genesis_config =
+            create_genesis_config_with_vote_accounts(1_000_000, &[validator], vec![1])
+                .genesis_config;
+        assert_alpenglow_genesis(&genesis_config);
+    }
+
+    #[test]
+    fn test_activate_all_features_includes_alpenglow() {
+        let mut genesis_config = GenesisConfig::default();
+        activate_all_features(&mut genesis_config);
+        assert_alpenglow_genesis(&genesis_config);
+    }
+
+    #[test]
+    fn test_tower_genesis_helpers_disable_alpenglow() {
+        let validator = ValidatorVoteKeypairs::new_rand();
+        let vote_account_genesis =
+            create_genesis_config_with_tower_vote_accounts(1_000_000, &[validator], vec![1])
+                .genesis_config;
+        assert_tower_genesis(&vote_account_genesis);
+
+        let leader_genesis =
+            create_genesis_config_with_tower_leader(1_000_000, &Pubkey::new_unique(), 1)
+                .genesis_config;
+        assert_tower_genesis(&leader_genesis);
+
+        let mut activated_genesis = GenesisConfig::default();
+        activate_all_features_tower(&mut activated_genesis);
+        assert_tower_genesis(&activated_genesis);
+    }
 }

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -2,8 +2,13 @@
 #![cfg(feature = "dev-context-only-utils")]
 
 use {
-    crate::{bank::Bank, static_ids},
+    crate::{
+        bank::Bank,
+        block_component_processor::vote_reward::epoch_inflation_account_state::VOTE_REWARD_ACCOUNT_ADDR,
+        static_ids,
+    },
     agave_reserved_account_keys::ReservedAccountKeys,
+    agave_votor_messages::migration::GENESIS_CERTIFICATE_ACCOUNT,
     dashmap::DashSet,
     log::info,
     rayon::{
@@ -129,6 +134,9 @@ impl<'a> SnapshotMinimizer<'a> {
         static_ids::STATIC_IDS.iter().for_each(|pubkey| {
             self.minimized_account_set.insert(*pubkey);
         });
+        self.minimized_account_set
+            .insert(*GENESIS_CERTIFICATE_ACCOUNT);
+        self.minimized_account_set.insert(*VOTE_REWARD_ACCOUNT_ADDR);
     }
 
     /// Used to get reserved accounts in `minimize`
@@ -355,11 +363,13 @@ impl<'a> SnapshotMinimizer<'a> {
 mod tests {
     use {
         crate::{
-            bank::Bank, genesis_utils::create_genesis_config_with_leader,
-            runtime_config::RuntimeConfig, snapshot_bank_utils,
-            snapshot_minimizer::SnapshotMinimizer, snapshot_utils,
+            bank::Bank,
+            block_component_processor::vote_reward::epoch_inflation_account_state::VOTE_REWARD_ACCOUNT_ADDR,
+            genesis_utils::create_genesis_config_with_leader, runtime_config::RuntimeConfig,
+            snapshot_bank_utils, snapshot_minimizer::SnapshotMinimizer, snapshot_utils,
         },
         agave_snapshots::snapshot_config::SnapshotConfig,
+        agave_votor_messages::migration::GENESIS_CERTIFICATE_ACCOUNT,
         dashmap::DashSet,
         solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
         solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
@@ -375,6 +385,24 @@ mod tests {
         tempfile::TempDir,
         test_case::test_case,
     };
+
+    #[test]
+    fn test_minimization_get_static_runtime_accounts() {
+        let genesis_config_info = create_genesis_config_with_leader(10, &Pubkey::new_unique(), 30);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
+        let minimizer = SnapshotMinimizer {
+            bank: &bank,
+            starting_slot: 0,
+            minimized_account_set: DashSet::new(),
+        };
+
+        minimizer.get_static_runtime_accounts();
+
+        for pubkey in [*GENESIS_CERTIFICATE_ACCOUNT, *VOTE_REWARD_ACCOUNT_ADDR] {
+            assert!(bank.get_account(&pubkey).is_some());
+            assert!(minimizer.minimized_account_set.contains(&pubkey));
+        }
+    }
 
     #[test]
     fn test_minimization_get_vote_accounts() {

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -413,9 +413,7 @@ impl ValidatedBlockFinalizationCert {
 mod tests {
     use {
         super::*,
-        crate::genesis_utils::{
-            ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-        },
+        crate::genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         agave_votor_messages::{vote::Vote, wire::get_vote_payload_to_sign},
         bitvec::prelude::*,
         rand::Rng,
@@ -436,11 +434,8 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect();
 
-        let genesis_config_info = create_genesis_config_with_alpenglow_vote_accounts(
-            10_000_000,
-            &validator_keypairs,
-            stakes,
-        );
+        let genesis_config_info =
+            create_genesis_config_with_vote_accounts(10_000_000, &validator_keypairs, stakes);
 
         let bank = Arc::new(Bank::new_for_tests(&genesis_config_info.genesis_config));
         (bank, validator_keypairs)

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -186,9 +186,7 @@ impl ValidatedRewardCert {
 mod tests {
     use {
         super::*,
-        crate::genesis_utils::{
-            ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-        },
+        crate::genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         agave_votor_messages::{
             certificate::{CertSignature, GenesisCert},
             consensus_message::VoteMessage,
@@ -242,11 +240,8 @@ mod tests {
     fn test_extract_slot_rejects_tower_slots() {
         let migration_slot = 1;
         let validator_keypairs = [ValidatorVoteKeypairs::new_rand()];
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            vec![100],
-        );
+        let genesis =
+            create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, vec![100]);
         let (root_bank, _bank_forks) =
             Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
         let genesis_cert = GenesisCert {
@@ -313,7 +308,7 @@ mod tests {
                 )
             })
             .collect::<HashMap<_, _>>();
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+        let genesis = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![100; validator_keypairs.len()],

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -591,9 +591,7 @@ mod tests {
         solana_runtime::{
             bank::{Bank, NewBankOptions, SlotLeader},
             bank_forks::BankForks,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         solana_signer::Signer,
         solana_signer_store::encode_base2,
@@ -821,7 +819,7 @@ mod tests {
     pub(crate) fn create_bank_forks(
         validator_keypairs: &[ValidatorVoteKeypairs],
     ) -> Arc<RwLock<BankForks>> {
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+        let genesis = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             validator_keypairs,
             vec![100; validator_keypairs.len()],

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -741,9 +741,7 @@ mod tests {
         solana_ledger::get_tmp_ledger_path_auto_delete,
         solana_runtime::{
             bank_forks::BankForks,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         std::sync::Arc,
     };
@@ -772,11 +770,8 @@ mod tests {
                 .rev()
                 .map(|i| (i.saturating_add(5).saturating_mul(100)) as u64)
                 .collect::<Vec<_>>();
-            let genesis = create_genesis_config_with_alpenglow_vote_accounts(
-                1_000_000_000,
-                &validator_keypairs,
-                stake,
-            );
+            let genesis =
+                create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stake);
             let my_keypair = validator_keypairs[0].node_keypair.insecure_clone();
             let bank0 = Bank::new_for_tests(&genesis.genesis_config);
             let bank_forks = BankForks::new_rw_arc(bank0);

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1067,9 +1067,7 @@ mod tests {
             bank::{Bank, BankTestConfig, SlotLeader},
             bank_forks::BankForks,
             bank_forks_controller::{BankForksController, BankForksControllerError},
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
             installed_scheduler_pool::BankWithScheduler,
         },
         solana_streamer::evicting_sender::EvictingSender,
@@ -1172,11 +1170,8 @@ mod tests {
             .rev()
             .map(|i| 100_u64.saturating_add(i as u64))
             .collect::<Vec<_>>();
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            stakes,
-        );
+        let genesis =
+            create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         let my_index = 0;
         let my_node_keypair = validator_keypairs[my_index].node_keypair.insecure_clone();
         let my_vote_keypair = validator_keypairs[my_index].vote_keypair.insecure_clone();

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -238,9 +238,7 @@ mod tests {
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
@@ -327,11 +325,8 @@ mod tests {
             })
             .collect();
 
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
-            1_000_000_000,
-            &validator_keypairs,
-            stakes,
-        );
+        let genesis =
+            create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
 
         let mut bank0 = Bank::new_for_tests(&genesis.genesis_config);
         let base_slot_epoch = bank0.epoch_schedule().get_epoch(base_slot);

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -390,9 +390,7 @@ mod tests {
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         solana_signer::Signer,
         std::{
@@ -594,7 +592,7 @@ mod tests {
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+        let genesis = create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
             vec![100; validator_keypairs.len()],

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -379,9 +379,7 @@ mod tests {
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
             epoch_stakes::VersionedEpochStakes,
-            genesis_utils::{
-                ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
-            },
+            genesis_utils::{ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts},
         },
         std::sync::{Arc, RwLock},
     };
@@ -425,11 +423,8 @@ mod tests {
     ) -> (VotingContext, Arc<RwLock<BankForks>>, Receiver<RewardInput>) {
         // Can't have stake of 0, so start at 1 and go to 10. In descending order, so 0 has largest stake.
         let stakes: Vec<u64> = (1u64..=10).rev().map(|x| x.saturating_mul(100)).collect();
-        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
-            1_000_000_000,
-            validator_keypairs,
-            stakes,
-        );
+        let genesis =
+            create_genesis_config_with_vote_accounts(1_000_000_000, validator_keypairs, stakes);
         let bank0 = Bank::new_for_tests(&genesis.genesis_config);
         let bank_forks = BankForks::new_rw_arc(bank0);
 


### PR DESCRIPTION
#### Problem
Feature is deactivated by default, now that we're close to activation, enable it by default

#### Summary of Changes

- `create_genesis_config*` now enables alpenglow
- added `create_genesis_config_with_tower_vote_accounts` for tower specific tests
  - core: replay_stage fork choice tests, commitment_service, vote_simulator, window_service duplicate
  - gossip: duplicate_shred_handler 
  - ledger: blockstore_processor poh / tower startup related tests
  - runtime: some PER tests, bank tests that rely on `TowerSync`, bank forks migration tests
- added `LocalCluster::new_tower` and flipped `LocalCluster::new` to use AG:
  - deactivate in `test_snapshot_restart_tower`, `test_no_voting`, `test_optimistic_confirmation_violation_detection`, `test_validator_saves_tower`, `test_future_tower`, `test_hard_fork_invalidates_tower`, `test_hard_fork_with_gap_in_roots`, `test_restart_tower_rollback`, `test_oc_bad_signatures`, `test_lockout_violation`, `test_slot_hash_expiry` `test_duplicate_with_pruned_ancestors`, `test_invalid_forks_persisted_on_restart`
 - update existing tests for AG:
   - warp -> not payed out credits are skipped in AG
   - RPC adjust for AG clock
   - PER use AG calculations

#### Testing
CI