### PR TITLE
DO NOT MERGE: Caller socket addr check

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -119,6 +119,7 @@ impl ForwardAddressGetter {
         leaders.extend(leader_pubkeys.iter().filter_map(|leader_pubkey| {
             self.cluster_info
                 .lookup_contact_info(leader_pubkey, |node| node.tpu_forwards(Protocol::QUIC))?
+                .filter(|addr| self.cluster_info.socket_addr_space().check(addr))
         }));
     }
 
@@ -136,6 +137,7 @@ impl ForwardAddressGetter {
         leader_pubkeys.into_iter().find_map(|leader_pubkey| {
             self.cluster_info
                 .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(Protocol::UDP))?
+                .filter(|addr| self.cluster_info.socket_addr_space().check(addr))
         })
     }
 }
@@ -787,13 +789,27 @@ mod tests {
         super::*,
         crossbeam_channel::bounded,
         packet::PacketFlags,
+        solana_gossip::{contact_info::ContactInfo, node::Node},
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_ledger::{
+            blockstore::Blockstore, get_tmp_ledger_path_auto_delete,
+            leader_schedule_cache::LeaderScheduleCache,
+        },
+        solana_net_utils::socket_addr_space::SocketAddrSpace,
         solana_perf::packet::{Packet, PacketBatch, RecycledPacketBatch},
+        solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
-        solana_runtime::genesis_utils::create_genesis_config,
+        solana_runtime::genesis_utils::{
+            bootstrap_validator_stake_lamports, create_genesis_config,
+            create_genesis_config_with_leader,
+        },
+        solana_signer::Signer,
         solana_system_transaction as system_transaction,
-        std::sync::{Arc, Mutex},
+        std::{
+            net::Ipv4Addr,
+            sync::{Arc, Mutex, atomic::AtomicBool},
+        },
     };
 
     #[derive(Clone)]
@@ -839,6 +855,89 @@ mod tests {
         let mut packet = Packet::from_data(None, &transaction).unwrap();
         packet.meta_mut().flags = packet_flags;
         packet
+    }
+
+    fn new_forward_address_getter(
+        leader: &Keypair,
+        tpu_vote: SocketAddr,
+        tpu_forwards: SocketAddr,
+        socket_addr_space: SocketAddrSpace,
+    ) -> ForwardAddressGetter {
+        let genesis_config = create_genesis_config_with_leader(
+            1_000_000_000,
+            &leader.pubkey(),
+            bootstrap_validator_stake_lamports(),
+        )
+        .genesis_config;
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            0,
+            bank.last_blockhash(),
+            bank.clone(),
+            None,
+            bank.ticks_per_slot(),
+            blockstore,
+            &leader_schedule_cache,
+            &PohConfig::default(),
+            Arc::new(AtomicBool::default()),
+        );
+
+        let identity = Arc::new(Keypair::new());
+        let cluster_info = Arc::new(ClusterInfo::new(
+            Node::new_localhost_with_pubkey(&identity.pubkey()).info,
+            identity,
+            socket_addr_space,
+        ));
+        let mut leader_info = ContactInfo::new(leader.pubkey(), 0, 0);
+        leader_info.set_tpu_vote(Protocol::UDP, tpu_vote).unwrap();
+        leader_info
+            .set_tpu_forwards(Protocol::QUIC, tpu_forwards)
+            .unwrap();
+        cluster_info.insert_info(leader_info);
+
+        ForwardAddressGetter::new(cluster_info, Arc::new(RwLock::new(poh_recorder)))
+    }
+
+    #[test]
+    fn test_forwarding_addresses_respect_socket_addr_space() {
+        let leader = Keypair::new();
+        let tpu_vote = SocketAddr::from((Ipv4Addr::LOCALHOST, 8005));
+        let tpu_forwards = SocketAddr::from(([10, 0, 0, 1], 8006));
+        let global_address_getter =
+            new_forward_address_getter(&leader, tpu_vote, tpu_forwards, SocketAddrSpace::Global);
+
+        assert!(
+            !global_address_getter
+                .cluster_info
+                .socket_addr_space()
+                .check(&tpu_vote)
+        );
+        assert!(
+            !global_address_getter
+                .cluster_info
+                .socket_addr_space()
+                .check(&tpu_forwards)
+        );
+        assert_eq!(global_address_getter.next_vote_forwarding_address(), None);
+        let mut leaders = Vec::new();
+        global_address_getter.non_vote_forwarding_addresses(3, &mut leaders);
+        assert!(leaders.is_empty());
+
+        let unrestricted_address_getter = new_forward_address_getter(
+            &leader,
+            tpu_vote,
+            tpu_forwards,
+            SocketAddrSpace::Unspecified,
+        );
+        assert_eq!(
+            unrestricted_address_getter.next_vote_forwarding_address(),
+            Some(tpu_vote)
+        );
+        unrestricted_address_getter.non_vote_forwarding_addresses(3, &mut leaders);
+        assert_eq!(leaders, vec![tpu_forwards; 3]);
     }
 
     #[test]

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -24,7 +24,9 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         .into_iter()
         .dedup()
         .filter_map(|leader_pubkey| {
-            cluster_info.lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
+            cluster_info
+                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(protocol))?
+                .filter(|addr| cluster_info.socket_addr_space().check(addr))
         })
         // dedup again since leaders could potentially share the same tpu vote socket
         .dedup()

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1081,8 +1081,10 @@ impl RepairService {
             .iter()
             .filter_map(|(pubkey, stake)| {
                 let peer_repair_addr = cluster_info
-                    .lookup_contact_info(pubkey, |node| node.serve_repair(Protocol::UDP));
-                if let Some(Some(peer_repair_addr)) = peer_repair_addr {
+                    .lookup_contact_info(pubkey, |node| node.serve_repair(Protocol::UDP))
+                    .flatten()
+                    .filter(|addr| cluster_info.socket_addr_space().check(addr));
+                if let Some(peer_repair_addr) = peer_repair_addr {
                     trace!("Repair peer {pubkey} has a valid repair socket: {peer_repair_addr:?}");
                     Some((
                         *pubkey,
@@ -1126,9 +1128,11 @@ impl RepairService {
 
         // Check validity of passed in peer.
         if let Some(pubkey) = pubkey {
-            let peer_repair_addr =
-                cluster_info.lookup_contact_info(&pubkey, |node| node.serve_repair(Protocol::UDP));
-            if let Some(Some(peer_repair_addr)) = peer_repair_addr {
+            let peer_repair_addr = cluster_info
+                .lookup_contact_info(&pubkey, |node| node.serve_repair(Protocol::UDP))
+                .flatten()
+                .filter(|addr| cluster_info.socket_addr_space().check(addr));
+            if let Some(peer_repair_addr) = peer_repair_addr {
                 trace!("Repair peer {pubkey} has valid repair socket: {peer_repair_addr:?}");
                 repair_peers.push((pubkey, peer_repair_addr));
             }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -726,6 +726,7 @@ impl RepairPeers {
         weight_source: RepairPeerWeightSource,
         peers: &[ContactInfo],
         weights: &[u64],
+        socket_addr_space: &SocketAddrSpace,
     ) -> Result<Self> {
         if peers.len() != weights.len() {
             return Err(Error::from(WeightedError::InvalidWeight));
@@ -734,9 +735,13 @@ impl RepairPeers {
             .iter()
             .zip(weights)
             .filter_map(|(peer, &weight)| {
+                let serve_repair = peer.serve_repair(Protocol::UDP)?;
+                if !socket_addr_space.check(&serve_repair) {
+                    return None;
+                }
                 let node = Node {
                     pubkey: *peer.pubkey(),
-                    serve_repair: peer.serve_repair(Protocol::UDP)?,
+                    serve_repair,
                 };
                 Some((node, weight))
             })
@@ -893,8 +898,13 @@ impl ServeRepair {
         peers_cache.pop(&slot);
         let repair_peers = self.repair_peers(repair_validators, slot, &identity_keypair.pubkey());
         let weights = self.repair_peer_weights(slot, cluster_slots, &repair_peers, weight_source);
-        let repair_peers =
-            RepairPeers::new(Instant::now(), weight_source, &repair_peers, &weights)?;
+        let repair_peers = RepairPeers::new(
+            Instant::now(),
+            weight_source,
+            &repair_peers,
+            &weights,
+            self.cluster_info.socket_addr_space(),
+        )?;
         peers_cache.put(slot, repair_peers);
         Ok(peers_cache.get(&slot).unwrap())
     }
@@ -1790,6 +1800,9 @@ impl ServeRepair {
             .map(|i| index[i])
             .filter_map(|i| {
                 let addr = repair_peers[i].serve_repair(repair_protocol)?;
+                if !self.cluster_info.socket_addr_space().check(&addr) {
+                    return None;
+                }
                 Some((*repair_peers[i].pubkey(), addr))
             })
             .take(get_ancestor_hash_repair_sample_size())
@@ -1812,10 +1825,11 @@ impl ServeRepair {
         let (weights, index) = cluster_slots.compute_weights_exclude_nonfrozen(slot, &repair_peers);
         let k = WeightedIndex::new(weights).ok()?.sample(&mut rand::rng());
         let n = index[k];
-        Some((
-            *repair_peers[n].pubkey(),
-            repair_peers[n].serve_repair(Protocol::UDP)?,
-        ))
+        let addr = repair_peers[n].serve_repair(Protocol::UDP)?;
+        if !self.cluster_info.socket_addr_space().check(&addr) {
+            return None;
+        }
+        Some((*repair_peers[n].pubkey(), addr))
     }
 
     pub(crate) fn map_repair_request(
@@ -2045,6 +2059,43 @@ mod tests {
     ) -> usize {
         requests.retain(|request| is_well_formed_repair_request(&PacketRef::from(request), stats));
         requests.len()
+    }
+
+    #[test]
+    fn test_repair_peers_respect_socket_addr_space() {
+        let private_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 8000));
+        let public_addr = SocketAddr::from(([8, 8, 8, 8], 8001));
+        let mut private_peer = ContactInfo::new(Pubkey::new_unique(), 0, 0);
+        private_peer
+            .set_serve_repair(Protocol::UDP, private_addr)
+            .unwrap();
+        let mut public_peer = ContactInfo::new(Pubkey::new_unique(), 0, 0);
+        public_peer
+            .set_serve_repair(Protocol::UDP, public_addr)
+            .unwrap();
+        let peers = [private_peer, public_peer];
+        let weights = [1, 1];
+
+        let filtered = RepairPeers::new(
+            Instant::now(),
+            RepairPeerWeightSource::ClusterSlots,
+            &peers,
+            &weights,
+            &SocketAddrSpace::Global,
+        )
+        .unwrap();
+        assert_eq!(filtered.peers.len(), 1);
+        assert_eq!(filtered.peers[0].serve_repair, public_addr);
+
+        let unrestricted = RepairPeers::new(
+            Instant::now(),
+            RepairPeerWeightSource::ClusterSlots,
+            &peers,
+            &weights,
+            &SocketAddrSpace::Unspecified,
+        )
+        .unwrap();
+        assert_eq!(unrestricted.peers.len(), 2);
     }
 
     #[test]

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -38,6 +38,7 @@ impl WarmQuicCacheService {
         if let Some(connection_cache) = cache
             && let Some(Some(addr)) =
                 cluster_info.lookup_contact_info(leader_pubkey, contact_info_selector)
+            && cluster_info.socket_addr_space().check(&addr)
         {
             let conn = connection_cache.get_connection(&addr);
             if let Err(err) = conn.send_data(&[]) {

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -424,6 +424,9 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                                 let tvu = cluster_info.lookup_contact_info(pubkey, |node| {
                                     node.tvu(Protocol::UDP)
                                 })??;
+                                if !socket_addr_space.check(&tvu) {
+                                    return None;
+                                }
                                 Some((shred.payload(), tvu))
                             })
                             .collect(),

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -109,7 +109,14 @@ impl PeerListUpdater {
                 node.alpenglow()
             })
             .into_iter()
-            .map(|(pubkey, socket)| (pubkey, socket.flatten()))
+            .map(|(pubkey, socket)| {
+                (
+                    pubkey,
+                    socket
+                        .flatten()
+                        .filter(|addr| cluster_info.socket_addr_space().check(addr)),
+                )
+            })
             .collect();
         // An override that pins an address wins over whatever gossip resolved to.
         for (pubkey, socket) in overrides.iter().filter(|(_, socket)| socket.is_some()) {
@@ -278,6 +285,20 @@ mod tests {
         num_zero_stake_nodes: usize,
         base_slot: u64,
     ) -> (Arc<RwLock<BankForks>>, ClusterInfo, Vec<Pubkey>) {
+        create_bank_forks_and_cluster_info_with_socket_addr_space(
+            num_nodes,
+            num_zero_stake_nodes,
+            base_slot,
+            SocketAddrSpace::Unspecified,
+        )
+    }
+
+    fn create_bank_forks_and_cluster_info_with_socket_addr_space(
+        num_nodes: usize,
+        num_zero_stake_nodes: usize,
+        base_slot: u64,
+        socket_addr_space: SocketAddrSpace,
+    ) -> (Arc<RwLock<BankForks>>, ClusterInfo, Vec<Pubkey>) {
         let mut rng = rand::rng();
         let validator_keypairs = (0..num_nodes)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -317,7 +338,7 @@ mod tests {
         let mut cluster_info = ClusterInfo::new(
             Node::new_localhost_with_pubkey(&my_keypair.pubkey()).info,
             Arc::new(my_keypair),
-            SocketAddrSpace::Unspecified,
+            socket_addr_space,
         );
         update_cluster_info(&mut cluster_info, node_keypair_map);
         (
@@ -569,6 +590,40 @@ mod tests {
             snapshot.peers.get(&staked_peer),
             Some(&Some(pinned)),
             "a pinned address replaces the peer's gossip socket"
+        );
+    }
+
+    #[test]
+    fn test_gossip_addresses_respect_socket_addr_space_but_pinned_override_does_not() {
+        let slot_num = 123456789;
+        let (bank_forks, cluster_info, node_pubkeys) =
+            create_bank_forks_and_cluster_info_with_socket_addr_space(
+                4,
+                0,
+                slot_num,
+                SocketAddrSpace::Global,
+            );
+        let pinned_peer = node_pubkeys[0];
+        let pinned = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65001);
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
+        let svc = PeerListUpdater::new(
+            bank_forks.read().unwrap().sharable_banks(),
+            peerlist_sender,
+            Arc::new(ArcSwap::from_pointee(HashMap::from([(
+                pinned_peer,
+                Some(pinned),
+            )]))),
+        );
+
+        svc.refresh_peer_list(&cluster_info, &cluster_info.id());
+
+        let snapshot = peerlist_receiver.borrow().clone();
+        assert_eq!(snapshot.peers.get(&pinned_peer), Some(&Some(pinned)));
+        assert!(
+            snapshot
+                .peers
+                .iter()
+                .all(|(pubkey, addr)| pubkey == &pinned_peer || addr.is_none())
         );
     }
 }


### PR DESCRIPTION
This is all of the checks. We should merge one by one.

#### Problem
many places don't check if we contact info contains loopback or local addrs. 

#### Summary of Changes
filter out gossip addresses that contain loopback or local addrs

#### Testing
ci

- [ ] Forwarding Addresses
- [ ] leader vote addresses
- [ ] quic cache warmup
- [ ] repair service peers
- [ ] serve repair peers
- [ ] duplicate broadcast partition (don't actually need)
- [ ] votor gossip addresses
