### PR TITLE
bank quiesce

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -318,8 +318,39 @@ impl Consumer {
             })
             .collect();
 
+        // This guard allows bank retirement to wait for load/execution-side effects before shared
+        // state for the slot is purged.
+        let tx_execution_guard = bank.try_enter_transaction_execution();
+        let Some(tx_execution_guard) = tx_execution_guard else {
+            // This bank is being quiesced! Early exit.
+            retryable_transaction_indexes.extend(
+                batch
+                    .lock_results()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, result)| {
+                        result.is_ok().then_some(RetryableIndex {
+                            index,
+                            immediately_retryable: true,
+                        })
+                    }),
+            );
+            retryable_transaction_indexes.sort_unstable();
+            retryable_transaction_indexes.dedup();
+            return ExecuteAndCommitTransactionsOutput {
+                transaction_counts: LeaderProcessedTransactionCounts {
+                    attempted_processing_count: batch.sanitized_transactions().len() as u64,
+                    ..LeaderProcessedTransactionCounts::default()
+                },
+                retryable_transaction_indexes,
+                commit_transactions_result: Err(PohRecorderError::MaxHeightReached),
+                execute_and_commit_timings,
+                error_counters,
+            };
+        };
+
         let (load_and_execute_transactions_output, load_execute_us) =
-            measure_us!(bank.load_and_execute_transactions(
+            measure_us!(tx_execution_guard.load_and_execute_transactions(
                 batch,
                 bank.max_processing_age(),
                 &mut execute_and_commit_timings.execute_timings,
@@ -368,8 +399,12 @@ impl Consumer {
             processed_transactions
         });
 
+        // Handoff from the execution guard to the traditional freeze lock before recording. A
+        // normal freeze only waits for this record/commit section, while bank retirement first
+        // waits for execution guards and then for this lock.
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
+        drop(tx_execution_guard);
 
         let reserved_bytes =
             bank.entry_bytes_budget()

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -792,16 +792,25 @@ fn record_and_complete_block(
         bank.slot()
     );
 
+    let reward_certs = ctx
+        .reward_certs_requestor
+        .recv_reward_certs(ctx.my_pubkey, reward_cert_request)
+        .map_err(|()| PohRecorderError::ChannelDisconnected)?;
+
+    // Root advancement can retire and purge this Bank concurrently with block completion. Hold
+    // execution token through remaining mutations.
+    let Some(_completion_guard) = bank.try_enter_transaction_execution() else {
+        // Bank is being retired!
+        w_poh_recorder.clear_bank(true);
+        return Err(PohRecorderError::WindowMovedOn(bank_slot));
+    };
+
     let max_tick_height = bank.max_tick_height();
     // Set the tick height for the bank to max_tick_height - 1, so that PohRecorder::flush_cache()
     // will properly increment the tick_height to max_tick_height.
     bank.set_tick_height(max_tick_height - 1);
 
     let footer = {
-        let reward_certs = ctx
-            .reward_certs_requestor
-            .recv_reward_certs(ctx.my_pubkey, reward_cert_request)
-            .map_err(|()| PohRecorderError::ChannelDisconnected)?;
         let RewardRespSucc {
             skip,
             notar,
@@ -828,7 +837,6 @@ fn record_and_complete_block(
         footer
     };
 
-    drop(bank);
     // Write the single tick for this slot
     w_poh_recorder.tick_alpenglow(max_tick_height, footer)?;
     Ok(())
@@ -897,7 +905,7 @@ fn abort_working_bank(ctx: &mut LeaderContext, slot: Slot) -> Result<(), BankFor
     let reset_bank = bank
         .parent()
         .unwrap_or_else(|| ctx.bank_forks.read().unwrap().root_bank());
-    bank.wait_for_inflight_commits();
+    bank.quiesce_transaction_execution();
     ctx.bank_forks_controller.clear_bank(slot)?;
     reset_poh_recorder(&reset_bank, ctx);
     Ok(())
@@ -981,7 +989,7 @@ fn handle_parent_ready(
             new_parent_slot,
         ))?;
     let cleared_bank_id = bank.bank_id();
-    bank.wait_for_inflight_commits();
+    bank.quiesce_transaction_execution();
     let entry_bytes_consumed = bank.entry_bytes_budget().consumed();
     ctx.bank_forks_controller
         .clear_bank(slot)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2300,6 +2300,7 @@ impl ReplayStage {
                 .collect()
         };
         for bank in banks_to_remove {
+            bank.quiesce_transaction_execution();
             let _ = bank.wait_for_completed_scheduler();
         }
 
@@ -2589,6 +2590,7 @@ impl ReplayStage {
 
         // Wait for any in progress execution
         for bank in banks_to_clear.iter() {
+            bank.quiesce_transaction_execution();
             let _ = bank.wait_for_completed_scheduler();
         }
         let bank_slots_to_clear = banks_to_clear

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -186,6 +186,8 @@ fn test_scheduler_waited_by_drop_bank_service() {
     drop_bank_service.join().unwrap();
     info!("finally joined the drop bank service!");
 
-    // the scheduler used by the pruned_bank have been returned now.
-    assert_eq!(pool_raw.pooled_scheduler_count(), 1);
+    // Quiescing the pruned bank prevents the stalled transaction from entering
+    // execution.  CommitCancelled aborts the scheduler, so it is retired instead
+    // of being returned to the reusable pool.
+    assert_eq!(pool_raw.pooled_scheduler_count(), 0);
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -96,6 +96,7 @@ use {
         wire::{WireBlockCertMessage, WireCertSignature},
     },
     ahash::AHashSet,
+    crossbeam_utils::CachePadded,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
     rayon::ThreadPool,
@@ -211,7 +212,7 @@ use {
             Weak,
             atomic::{
                 AtomicBool, AtomicI64, AtomicU64,
-                Ordering::{AcqRel, Acquire, Relaxed},
+                Ordering::{AcqRel, Acquire, Relaxed, Release},
             },
         },
         time::{Duration, Instant},
@@ -713,6 +714,7 @@ impl PartialEq for Bank {
             bank_hash_stats: _,
             epoch_rewards_calculation_cache: _,
             block_component_processor: _,
+            transaction_execution_gate: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -1078,6 +1080,57 @@ pub struct Bank {
 
     /// Cached Alpenglow migration state, derived from the genesis certificate account.
     is_alpenglow: AtomicBool,
+
+    /// Coordinates transaction execution with retirement of an unfrozen Bank. Padding keeps the
+    /// frequently mutated lock state from sharing a cache line with unrelated Bank fields.
+    transaction_execution_gate: CachePadded<TransactionExecutionGate>,
+}
+
+#[derive(Default)]
+struct TransactionExecutionGate {
+    lock: RwLock<()>,
+    quiesce_requested: AtomicBool,
+}
+
+/// Proof that transaction execution has been admitted for a specific [`Bank`].
+///
+/// The guard is Bank-bound so guarded operations cannot accidentally use an execution token from
+/// a different Bank. Dropping it allows Bank retirement to make progress.
+#[must_use = "the transaction execution guard must be held while executing transactions"]
+pub struct TxExecutionGuard<'a> {
+    bank: &'a Bank,
+    _lock_guard: RwLockReadGuard<'a, ()>,
+}
+
+impl TxExecutionGuard<'_> {
+    /// Loads and executes transactions against the Bank that admitted this guard.
+    pub fn load_and_execute_transactions(
+        &self,
+        batch: &TransactionBatch<impl TransactionWithMeta>,
+        max_age: usize,
+        timings: &mut ExecuteTimings,
+        error_counters: &mut TransactionErrorMetrics,
+        processing_config: TransactionProcessingConfig,
+    ) -> LoadAndExecuteTransactionsOutput {
+        self.bank.do_load_and_execute_transactions(
+            batch,
+            max_age,
+            timings,
+            error_counters,
+            processing_config,
+        )
+    }
+
+    fn commit_transactions(
+        &self,
+        sanitized_txs: &[impl TransactionWithMeta],
+        processing_results: Vec<TransactionProcessingResult>,
+        processed_counts: &ProcessedTransactionCounts,
+        timings: &mut ExecuteTimings,
+    ) -> Vec<TransactionCommitResult> {
+        self.bank
+            .commit_transactions(sanitized_txs, processing_results, processed_counts, timings)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1284,6 +1337,7 @@ impl Bank {
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(false),
+            transaction_execution_gate: CachePadded::new(TransactionExecutionGate::default()),
         };
 
         bank.transaction_processor =
@@ -1551,6 +1605,7 @@ impl Bank {
             epoch_rewards_calculation_cache: parent.epoch_rewards_calculation_cache.clone(),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(parent.is_alpenglow()),
+            transaction_execution_gate: CachePadded::new(TransactionExecutionGate::default()),
         };
 
         let (_, ancestors_time_us) = measure_us!({
@@ -2216,6 +2271,7 @@ impl Bank {
             expected_bank_hash: RwLock::new(None),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(false),
+            transaction_execution_gate: CachePadded::new(TransactionExecutionGate::default()),
         };
 
         if bank.get_alpenglow_genesis_certificate().is_some() {
@@ -2342,14 +2398,56 @@ impl Bank {
         self.hash.read().unwrap()
     }
 
+    /// Acquires permission to execute transactions unless this Bank is being quiesced.
+    pub fn try_enter_transaction_execution(&self) -> Option<TxExecutionGuard<'_>> {
+        // If quiesce has been requested, don't allow new transaction execution to start.
+        // We do this before grabbing the lock to prevent some starvation scenario where
+        // bank can't be retired because scheduler keeps scheduling and we hold the read
+        // lock forever.
+        if self
+            .transaction_execution_gate
+            .quiesce_requested
+            .load(Acquire)
+        {
+            return None;
+        }
+        let lock_guard = self.transaction_execution_gate.lock.read().unwrap();
+
+        // We check the quiesce requested flag again after acquiring the lock to ensure
+        // that we don't allow new transaction execution to start if quiesce was requested
+        // while we were waiting for the lock.
+        if self
+            .transaction_execution_gate
+            .quiesce_requested
+            .load(Acquire)
+        {
+            None
+        } else {
+            Some(TxExecutionGuard {
+                bank: self,
+                _lock_guard: lock_guard,
+            })
+        }
+    }
+
     /// Waits for in-flight BankingStage commits to finish without freezing the bank.
     ///
-    /// BankingStage holds the read side of this lock from before a successful
-    /// PoH record until after the matching account commit. Taking and dropping
-    /// the write side gives callers a quiescence point before abandoning and
-    /// purging an unfrozen leader bank.
+    /// BankingStage holds the read side of this lock from before a successful PoH record until
+    /// after the matching account commit.
     pub fn wait_for_inflight_commits(&self) {
         drop(self.hash.write().unwrap());
+    }
+
+    /// Rejects new transaction execution and waits for admitted execution and commits to finish.
+    pub fn quiesce_transaction_execution(&self) {
+        // Signal no new work should be started
+        self.transaction_execution_gate
+            .quiesce_requested
+            .store(true, Release);
+        // Quiesce execute and load
+        drop(self.transaction_execution_gate.lock.write().unwrap());
+        // Quiesce record and commit
+        self.wait_for_inflight_commits();
     }
 
     pub fn hash(&self) -> Hash {
@@ -4045,7 +4143,40 @@ impl Bank {
         balances
     }
 
+    fn cancelled_load_and_execute_tx_batch(
+        batch: &TransactionBatch<impl TransactionWithMeta>,
+    ) -> LoadAndExecuteTransactionsOutput {
+        LoadAndExecuteTransactionsOutput {
+            processing_results: std::iter::repeat_with(|| Err(TransactionError::CommitCancelled))
+                .take(batch.sanitized_transactions().len())
+                .collect(),
+            processed_counts: ProcessedTransactionCounts::default(),
+            balance_collector: None,
+        }
+    }
+
+    /// Loads and executes transactions after acquiring an execution token for this Bank.
     pub fn load_and_execute_transactions(
+        &self,
+        batch: &TransactionBatch<impl TransactionWithMeta>,
+        max_age: usize,
+        timings: &mut ExecuteTimings,
+        error_counters: &mut TransactionErrorMetrics,
+        processing_config: TransactionProcessingConfig,
+    ) -> LoadAndExecuteTransactionsOutput {
+        let Some(execution_guard) = self.try_enter_transaction_execution() else {
+            return Self::cancelled_load_and_execute_tx_batch(batch);
+        };
+        execution_guard.load_and_execute_transactions(
+            batch,
+            max_age,
+            timings,
+            error_counters,
+            processing_config,
+        )
+    }
+
+    fn do_load_and_execute_transactions(
         &self,
         batch: &TransactionBatch<impl TransactionWithMeta>,
         max_age: usize,
@@ -4626,37 +4757,47 @@ impl Bank {
         log_messages_bytes_limit: Option<usize>,
         pre_commit_callback: Option<impl FnOnce(&[TransactionProcessingResult]) -> Result<()>>,
     ) -> Result<(Vec<TransactionCommitResult>, Option<BalanceCollector>)> {
+        let execution_guard = self.try_enter_transaction_execution();
         let LoadAndExecuteTransactionsOutput {
             processing_results,
             processed_counts,
             balance_collector,
-        } = self.load_and_execute_transactions(
-            batch,
-            self.max_processing_age(),
-            timings,
-            &mut TransactionErrorMetrics::default(),
-            TransactionProcessingConfig {
-                account_overrides: None,
-                log_messages_bytes_limit,
-                limit_to_load_programs: false,
-                recording_config,
-                drop_on_failure: false,
-                all_or_nothing: false,
-                strict_nonce_size_check: false,
-                drop_noop_transactions: false,
-            },
-        );
+        } = if let Some(execution_guard) = execution_guard.as_ref() {
+            execution_guard.load_and_execute_transactions(
+                batch,
+                self.max_processing_age(),
+                timings,
+                &mut TransactionErrorMetrics::default(),
+                TransactionProcessingConfig {
+                    account_overrides: None,
+                    log_messages_bytes_limit,
+                    limit_to_load_programs: false,
+                    recording_config,
+                    drop_on_failure: false,
+                    all_or_nothing: false,
+                    strict_nonce_size_check: false,
+                    drop_noop_transactions: false,
+                },
+            )
+        } else {
+            Self::cancelled_load_and_execute_tx_batch(batch)
+        };
 
         if let Some(pre_commit_callback) = pre_commit_callback {
             let () = pre_commit_callback(&processing_results)?;
         }
 
-        let commit_results = self.commit_transactions(
-            batch.sanitized_transactions(),
-            processing_results,
-            &processed_counts,
-            timings,
-        );
+        let commit_results = if let Some(execution_guard) = execution_guard.as_ref() {
+            execution_guard.commit_transactions(
+                batch.sanitized_transactions(),
+                processing_results,
+                &processed_counts,
+                timings,
+            )
+        } else {
+            Self::create_commit_results(processing_results)
+        };
+        drop(execution_guard);
         Ok((commit_results, balance_collector))
     }
 

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -201,6 +201,7 @@ pub fn check_and_handle_new_root<CB>(
 }
 
 /// Sets the bank forks root:
+/// - Quiesce and synchronously purge banks orphaned by the new root
 /// - Prune the program cache
 /// - Prune bank forks and drop the removed banks
 /// - Calls the callback for use in replay stage and tests
@@ -217,13 +218,45 @@ pub fn set_bank_forks_root<CB>(
 {
     let banks_to_remove: Vec<_> = {
         let bank_forks = bank_forks.read().unwrap();
+        let old_root = bank_forks.root();
+        let new_root_ancestors = bank_forks
+            .get(new_root)
+            .expect("Root bank doesn't exist")
+            .proper_ancestors_set();
         bank_forks
             .get_non_rooted(new_root, highest_super_majority_root)
-            .filter_map(|slot| bank_forks.get_with_scheduler(slot))
+            .filter_map(|slot| {
+                bank_forks.get_with_scheduler(slot).map(|bank| {
+                    let is_orphaned = slot > old_root && !new_root_ancestors.contains(&slot);
+                    (bank, is_orphaned)
+                })
+            })
             .collect()
     };
-    for bank in banks_to_remove {
+
+    let mut orphaned_slot_bank_ids = Vec::new();
+    for (bank, is_orphaned) in &banks_to_remove {
+        // Quiesce all banks whose shared slot state will be purged before waiting on schedulers.
+        // Banks removed because they are rooted ancestors are already frozen and do not need the
+        // retirement barrier.
+        if *is_orphaned {
+            bank.quiesce_transaction_execution();
+            orphaned_slot_bank_ids.push((bank.slot(), bank.bank_id()));
+        }
+    }
+    for (bank, _) in &banks_to_remove {
         let _ = bank.wait_for_completed_scheduler();
+    }
+
+    if !orphaned_slot_bank_ids.is_empty() {
+        // Purge these banks inline so we are not waiting on the lazy Accounts Background Service for cleanup.
+        // Waiting could stall replay if we recreate a bank for this slot.
+        let root_bank = bank_forks.read().unwrap().root_bank();
+        root_bank.remove_unrooted_slots(&orphaned_slot_bank_ids);
+        for (slot, _) in &orphaned_slot_bank_ids {
+            root_bank.clear_slot_signatures(*slot);
+            root_bank.prune_program_cache_by_deployment_slot(*slot);
+        }
     }
 
     bank_forks.read().unwrap().prune_program_cache(new_root);


### PR DESCRIPTION
#### Problem
current quiesce doesn't cover the leader side

#### Summary of Changes

1. add atomic for indicating quiesce has been requested and respond to it by quiescing
2. add a lock to understand when execution has quiesced
3. gate cleaning up bank state on bank quiesce