### PR TITLE
snapshots: always include tombstones in snapshot archives

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -163,6 +163,21 @@ impl AccountStorageEntry {
         self.tombstone_offsets.read().unwrap()
     }
 
+    /// Insert tombstone offsets directly (test-only).
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn insert_tombstone_offsets_for_tests(
+        &self,
+        offsets: impl IntoIterator<Item = Offset>,
+    ) -> usize {
+        self.batch_insert_tombstone_offsets(offsets)
+    }
+
+    /// Remove all obsolete-account marks (test-only).
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn clear_obsolete_accounts_for_tests(&self) {
+        *self.obsolete_accounts.write().unwrap() = ObsoleteAccounts::default();
+    }
+
     /// Number of tombstone offsets in the storage.
     pub(crate) fn num_tombstones(&self) -> usize {
         self.tombstone_offsets.read().unwrap().len()

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1599,6 +1599,159 @@ mod tests {
         );
     }
 
+    /// A full snapshot archive must retain tombstones: if one is excluded while an older
+    /// version of the account is archived unmarked, consumers resurrect the stale balance.
+    #[test]
+    fn test_full_snapshot_archive_with_tombstone_does_not_resurrect_accounts() {
+        let key1 = Keypair::new();
+
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let snapshot_config = snapshot_config_for_tests(
+            &bank_snapshots_dir,
+            &full_snapshot_archives_dir,
+            &incremental_snapshot_archives_dir,
+        );
+
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            1_000_000 * LAMPORTS_PER_SOL,
+        );
+        // the drain transfer below must bring Account1 to exactly zero
+        genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
+
+        let lamports_to_transfer = 123_456 * LAMPORTS_PER_SOL;
+        let (bank0, bank_forks) =
+            Bank::new_with_paths_for_tests(&genesis_config, None, vec![accounts_dir.clone()], None)
+                .wrap_with_bank_forks_for_tests();
+        let leader = *bank0.leader();
+        bank0.fill_bank_with_ticks_for_tests();
+
+        // the anchor account keeps slot 1's storage alive when slot 2 supersedes the rest
+        let key_anchor = Keypair::new();
+        let bank1 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank0, leader, 1);
+        bank1
+            .transfer(lamports_to_transfer, &mint_keypair, &key1.pubkey())
+            .unwrap();
+        bank1
+            .transfer(LAMPORTS_PER_SOL, &mint_keypair, &key_anchor.pubkey())
+            .unwrap();
+        bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
+        // flush slot 1 before slot 2 supersedes Account1's funded version
+        bank1.squash();
+        bank1.force_flush_accounts_cache();
+
+        // a full snapshot exists, so newer zero-lamport shadows must be retained
+        bank1
+            .rc
+            .accounts
+            .accounts_db
+            .set_latest_full_snapshot_slot(1);
+
+        // slot 2 (the snapshot slot): drain Account1 back to zero
+        let zeroed_slot = 2;
+        let bank2 =
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, zeroed_slot);
+        bank2
+            .transfer(lamports_to_transfer, &key1, &mint_keypair.pubkey())
+            .unwrap();
+        assert_eq!(
+            bank2.get_balance(&key1.pubkey()),
+            0,
+            "Ensure Account1's balance is zero"
+        );
+        bank2.fill_bank_with_ticks_for_tests();
+        bank2.set_block_id(Some(Hash::default()));
+
+        // root and flush so slot 1's (funded) and slot 2's (zero-lamport) storages exist
+        bank2.squash();
+        bank2.force_flush_accounts_cache();
+
+        let accounts_db = &bank2.rc.accounts.accounts_db;
+
+        // Account1's funded version is the record at risk of resurrection
+        let mut funded_version_lamports = None;
+        let funded_storages = accounts_db.get_storages(1..2).0;
+        funded_storages
+            .first()
+            .expect("slot 1 must have a storage")
+            .accounts
+            .scan_accounts_without_data(|_offset, account| {
+                if account.pubkey() == &key1.pubkey() {
+                    funded_version_lamports = Some(account.lamports);
+                }
+            })
+            .unwrap();
+        assert_eq!(
+            funded_version_lamports,
+            Some(lamports_to_transfer),
+            "Account1's funded version must be in slot 1's storage"
+        );
+
+        let storages = accounts_db.get_storages(zeroed_slot..zeroed_slot + 1).0;
+        let storage = storages.first().expect("slot 2 must have a storage");
+        let mut tombstone_offset = None;
+        storage
+            .accounts
+            .scan_accounts_without_data(|offset, account| {
+                if account.pubkey() == &key1.pubkey() {
+                    assert_eq!(account.lamports, 0);
+                    tombstone_offset = Some(offset);
+                }
+            })
+            .unwrap();
+        let tombstone_offset =
+            tombstone_offset.expect("Account1's zero-lamport record must be in slot 2's storage");
+        storage.insert_tombstone_offsets_for_tests([tombstone_offset]);
+
+        // the archiver never observes the obsolete marks paired with the tombstone
+        funded_storages
+            .first()
+            .unwrap()
+            .clear_obsolete_accounts_for_tests();
+
+        let full_snapshot_archive_info =
+            bank_to_full_snapshot_archive(&snapshot_config, &bank2).unwrap();
+
+        // The rebuilt bank must observe Account1 as dead, with matching capitalization
+        let deserialized_bank = bank_from_snapshot_archives(
+            slice::from_ref(&accounts_dir),
+            &full_snapshot_archive_info,
+            None,
+            &snapshot_config,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None, // leader_for_tests
+            None,
+            false,
+            false,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            deserialized_bank, *bank2,
+            "Ensure rebuilding from the full snapshot matches the live bank"
+        );
+        assert!(
+            deserialized_bank
+                .get_account_modified_slot(&key1.pubkey())
+                .is_none(),
+            "Account1 must not be resurrected by the full snapshot archive"
+        );
+    }
+
     /// Test that cleaning works well in the edge cases of zero-lamport accounts and snapshots.
     /// Here's the scenario:
     ///

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -143,13 +143,8 @@ pub fn archive_snapshot(
                 matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
             let use_direct_io = io_setup.use_direct_io && !use_page_cache;
 
-            // Full snapshots do not need to persist tombstones as their older versions are
-            // guaranteed to be skipped as obsolete accounts
-            let tombstones_filter = if matches!(snapshot_archive_kind, SnapshotArchiveKind::Full) {
-                TombstonesFilter::Exclude
-            } else {
-                TombstonesFilter::Include
-            };
+            // Tombstones must always be archived: they are the only shadow consumers observe
+            let tombstones_filter = TombstonesFilter::Include;
 
             // Walk storages and their (lazily-opened) file handles in chunks,
             // bounding how many archive-mode fds are simultaneously open.


### PR DESCRIPTION
#### Problem

Full snapshot archives exclude tombstone records (#13851) on the assumption that their older versions are always skipped as obsolete accounts. That pairing is not atomic from the archiver's view: the exclusion sets are read live, per storage, while background clean/flush/shrink keep mutating them during the multi-minute archive write, so an older version of an account can be streamed into the archive before its obsolete mark lands while the newer tombstone is excluded. Consumers then rebuild the index with no shadowing zero-lamport record, resurrect the stale balance, and fail startup with `failed to load bank: capitalization mismatch` — observed in the wild on mainnet RPC nodes running v4.3.0-beta.1.

#### Summary of Changes

Always include tombstones in snapshot archives: a physically present zero-lamport record is the only shadow a consumer can rely on, and retaining tombstones costs only archive bytes. Excluding them would only be safe if both exclusion sets were frozen at package-capture time, which is left as a possible follow-up. Two `dev-context-only-utils` hooks are added for the regression test.

#### Testing

A new regression test constructs the state an in-flight archiver can observe (tombstone recorded while the older version's obsolete marks are not visible on the archived storage) and round-trips a full snapshot: without this change it fails with `MismatchedCapitalization`, off by exactly the resurrected account's balance, and with it it passes. The failure also reproduces live on mainnet: fresh validators bootstrapping from a v4.3.0-beta.1 node's snapshots die with capitalization mismatches (calculated exceeds expected, with the delta shrinking under newer incrementals as resurrected accounts get re-shadowed), while same-slot archives produced by v4.2.1 nodes load cleanly. End-to-end verification that a fixed producer's snapshots load cleanly on a fresh mainnet validator is in progress and this PR will be updated with the result.

Regression introduced in #13851.

Thanks to @sbhattaram-jump for helping develop the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
