### PR TITLE
codeowners: exclude programs/sbf/Cargo.lock from svm team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /programs/bpf_loader/ @anza-xyz/svm
 /programs/compute-budget/ @anza-xyz/svm
 /programs/sbf/ @anza-xyz/svm
+/programs/sbf/Cargo.lock
 /programs/system/ @anza-xyz/svm
 /runtime-transaction/ @anza-xyz/tx-metadata
 /svm-callback/ @anza-xyz/svm


### PR DESCRIPTION
#### Problem
We don't want to get flagged for every lockfile change.

#### Summary of Changes
Exclude `programs/sbf/Cargo.lock` from SVM team's CODEOWNERS policy.
