### PR TITLE
snapshots: always include tombstones in snapshot archives

### DIFF
--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -143,13 +143,8 @@ pub fn archive_snapshot(
                 matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
             let use_direct_io = io_setup.use_direct_io && !use_page_cache;
 
-            // Full snapshots do not need to persist tombstones as their older versions are
-            // guaranteed to be skipped as obsolete accounts
-            let tombstones_filter = if matches!(snapshot_archive_kind, SnapshotArchiveKind::Full) {
-                TombstonesFilter::Exclude
-            } else {
-                TombstonesFilter::Include
-            };
+            // Tombstones must always be archived: they are the only shadow consumers observe
+            let tombstones_filter = TombstonesFilter::Include;
 
             // Walk storages and their (lazily-opened) file handles in chunks,
             // bounding how many archive-mode fds are simultaneously open.

--- a/snapshots/src/archive.rs
+++ b/snapshots/src/archive.rs
@@ -143,7 +143,12 @@ pub fn archive_snapshot(
                 matches!(snapshot_archive_kind, SnapshotArchiveKind::Incremental(_));
             let use_direct_io = io_setup.use_direct_io && !use_page_cache;
 
-            // Tombstones must always be archived: they are the only shadow consumers observe
+            // Tombstones must always be included in the snapshot archive.
+            // This is to handle the scenario where a long-running RPC scan_accounts()
+            // causes snapshot handling to flush the write cache _without_ also cleaning,
+            // which could allow an account to have duplicates: an older open version and a new closed (zero lamport) version.
+            // If the newer closed (tombstone) version is filtered out, the older open
+            // version would remain, and revive the now-zombie account.
             let tombstones_filter = TombstonesFilter::Include;
 
             // Walk storages and their (lazily-opened) file handles in chunks,


### PR DESCRIPTION
#### Problem

Since #13851, full snapshots drop tombstones (the zero-lamport records that say an account was deleted), assuming the account's old versions are dropped too. But that state can change while the snapshot is being written, so a snapshot can contain an old version of an account with nothing saying it was deleted. A validator that starts from such a snapshot brings the account back to life and crashes with `failed to load bank: capitalization mismatch` (seen on mainnet nodes running v4.3.0-beta.1).

#### Summary of Changes

Always keep tombstones in snapshots. They are the only way a loading validator can tell an account was deleted.

#### Testing

The fix was validated with a regression test that builds the bad state directly: it fails with `MismatchedCapitalization` without the fix and passes with it. That test is left out of this PR per review feedback, since it would also flag a future fix that prevents the bad state from arising; on live mainnet, a fresh validator loaded a snapshot from a patched node cleanly, while snapshots from the unpatched binary on the same machine failed every time.

Regression introduced in #13851.

Thanks to @sbhattaram-jump for helping develop the fix.
