### PR TITLE
chore(dep): bump itertools from 0.14.0 to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
  "crossbeam-channel",
  "fd-lock",
  "indicatif",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -487,7 +487,7 @@ dependencies = [
  "bitvec",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "parking_lot 0.12.3",
  "rand 0.9.4",
@@ -3905,6 +3905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6922,7 +6931,7 @@ dependencies = [
  "bv",
  "criterion",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "memoffset",
  "modular-bitfield",
@@ -7839,7 +7848,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.34",
  "histogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "libc",
  "log",
@@ -7968,7 +7977,7 @@ dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
  "ahash 0.8.12",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "solana-bincode",
  "solana-compute-budget",
@@ -8391,7 +8400,7 @@ dependencies = [
  "bincode",
  "bs58",
  "clap 2.33.3",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -8536,7 +8545,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "num-traits",
@@ -8819,7 +8828,7 @@ name = "solana-leader-schedule"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-random",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "solana-clock",
@@ -8853,7 +8862,7 @@ dependencies = [
  "eager",
  "fs_extra",
  "futures 0.3.34",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",
@@ -8992,7 +9001,7 @@ dependencies = [
  "crossbeam-channel",
  "fs_extra",
  "gag",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "rand 0.9.4",
  "rayon",
@@ -9137,7 +9146,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "dashmap",
  "hxdmp",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "nix",
  "pcap-file",
@@ -9507,7 +9516,7 @@ dependencies = [
  "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libsecp256k1",
  "log",
  "openssl",
@@ -9777,7 +9786,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -10058,7 +10067,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "libsecp256k1",
  "log",
@@ -10320,7 +10329,7 @@ version = "4.4.0-alpha.1"
 dependencies = [
  "agave-logger",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "solana-account 4.6.0",
  "solana-fee-calculator",
@@ -10655,7 +10664,7 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.34",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "nix",
@@ -11161,7 +11170,7 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.34",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "lru 0.18.2",
  "quinn",
@@ -11336,7 +11345,7 @@ dependencies = [
  "bs58",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ imbl = "7.0.1"
 indexmap = "2.14.0"
 indicatif = "0.18.6"
 io-uring = { version = "0.7.14", features = ["io_safety"] }
-itertools = "0.14.0"
+itertools = "0.15.0"
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0", features = [
     "stats",
 ] }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -213,7 +213,6 @@ impl QosService {
 mod tests {
     use {
         super::*,
-        itertools::Itertools,
         solana_cost_model::cost_tracker::CostTrackerLimits,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -255,16 +254,12 @@ mod tests {
 
         // verify the size of txs_costs and its contents
         assert_eq!(txs_costs.len(), txs.len());
-        txs_costs
-            .iter()
-            .enumerate()
-            .map(|(index, cost)| {
-                assert_eq!(
-                    cost.as_ref().unwrap().sum(),
-                    CostModel::calculate_cost(&txs[index], &FeatureSet::all_enabled()).sum()
-                );
-            })
-            .collect_vec();
+        txs_costs.iter().enumerate().for_each(|(index, cost)| {
+            assert_eq!(
+                cost.as_ref().unwrap().sum(),
+                CostModel::calculate_cost(&txs[index], &FeatureSet::all_enabled()).sum()
+            );
+        });
     }
 
     #[test]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.34",
  "histogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "num_cpus",
  "pretty-hex",
@@ -404,7 +404,7 @@ dependencies = [
  "bitvec",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "parking_lot 0.12.5",
  "smallvec",
@@ -3243,6 +3243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,7 +5674,7 @@ dependencies = [
  "blake3",
  "bv",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "modular-bitfield",
  "num_cpus",
@@ -6238,7 +6247,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.34",
  "histogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "libc",
  "log",
@@ -6728,7 +6737,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "num-traits",
@@ -6943,7 +6952,7 @@ name = "solana-leader-schedule"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-random",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "rand_chacha 0.9.0",
  "solana-clock",
  "solana-pubkey 4.3.0",
@@ -6971,7 +6980,7 @@ dependencies = [
  "eager",
  "fs_extra",
  "futures 0.3.34",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",
@@ -7154,7 +7163,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.4",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "nix",
  "rand 0.9.4",
@@ -7419,7 +7428,7 @@ dependencies = [
  "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "qualifier_attr",
  "rand 0.9.4",
@@ -7589,7 +7598,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7785,7 +7794,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "mockall",
@@ -8021,7 +8030,7 @@ name = "solana-send-transaction-service"
 version = "4.4.0-alpha.1"
 dependencies = [
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "solana-hash 4.6.0",
  "solana-keypair",
@@ -8292,7 +8301,7 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.34",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "nix",
@@ -8668,7 +8677,7 @@ dependencies = [
  "bytes",
  "futures 0.3.34",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "lru 0.18.2",
  "quinn",
@@ -8816,7 +8825,7 @@ dependencies = [
  "agave-votor-messages",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -51,7 +51,7 @@ dashmap = "5.5.3"
 env_logger = "0.11.11"
 futures = "0.3.34"
 histogram = "0.6.9"
-itertools = "0.14.0"
+itertools = "0.15.0"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "unprefixed_malloc_on_supported_platforms",
 ] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "crossbeam-channel",
  "fd-lock",
  "indicatif",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -391,7 +391,7 @@ dependencies = [
  "bitvec",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "parking_lot 0.12.2",
  "smallvec",
@@ -3218,6 +3218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,7 +5698,7 @@ dependencies = [
  "blake3",
  "bv",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "modular-bitfield",
  "num_cpus",
@@ -6330,7 +6339,7 @@ dependencies = [
  "dashmap",
  "futures 0.3.34",
  "histogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "libc",
  "log",
@@ -6853,7 +6862,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "flate2",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "num-traits",
@@ -7070,7 +7079,7 @@ name = "solana-leader-schedule"
 version = "4.4.0-alpha.1"
 dependencies = [
  "agave-random",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "rand_chacha 0.9.0",
  "solana-clock",
  "solana-pubkey 4.3.0",
@@ -7098,7 +7107,7 @@ dependencies = [
  "eager",
  "fs_extra",
  "futures 0.3.34",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",
@@ -7281,7 +7290,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.4",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "nix",
  "rand 0.9.4",
@@ -7594,7 +7603,7 @@ dependencies = [
  "base64 0.23.1",
  "bincode",
  "cfg-if 1.0.4",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "qualifier_attr",
  "rand 0.9.4",
@@ -7826,7 +7835,7 @@ dependencies = [
  "bs58",
  "crossbeam-channel",
  "dashmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -8021,7 +8030,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "mockall",
@@ -8985,7 +8994,7 @@ name = "solana-send-transaction-service"
 version = "4.4.0-alpha.1"
 dependencies = [
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "solana-hash 4.6.0",
  "solana-keypair",
@@ -9256,7 +9265,7 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.34",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "nix",
@@ -9655,7 +9664,7 @@ dependencies = [
  "bytes",
  "futures 0.3.34",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "lru 0.18.2",
  "quinn",
@@ -9803,7 +9812,7 @@ dependencies = [
  "agave-votor-messages",
  "bytes",
  "crossbeam-channel",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy-lru",
  "log",
  "lru 0.18.2",


### PR DESCRIPTION
#### Summary of Changes

- bump itertools from 0.14.0 to 0.15.0
- remove unused return value