### PR TITLE
refactor(vote-bench): move account clones out of timed benchmark loop

### DIFF
--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -1,7 +1,7 @@
 use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
     bincode::serialize,
-    criterion::{Criterion, criterion_group, criterion_main},
+    criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     solana_account::{Account, AccountSharedData, WritableAccount},
     solana_clock::{Clock, Slot},
     solana_epoch_schedule::EpochSchedule,
@@ -292,15 +292,6 @@ impl BenchAuthorize {
             instruction_accounts,
         }
     }
-
-    fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchInitializeAccount {
@@ -355,14 +346,6 @@ impl BenchInitializeAccount {
             transaction_accounts,
             instruction_accounts,
         }
-    }
-    pub fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
     }
 }
 
@@ -1079,14 +1062,46 @@ impl BenchTowerSync {
 fn bench_initialize_account(c: &mut Criterion) {
     let test_setup = BenchInitializeAccount::new();
     c.bench_function("vote_instruction_initialize_account", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_authorize(c: &mut Criterion) {
     let test_setup = BenchAuthorize::new();
     c.bench_function("vote_instruction_authorize", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -557,14 +557,6 @@ impl BenchVoteSwitch {
             instruction_accounts,
         }
     }
-    fn run(&self) {
-        let _accounts = process_deprecated_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchAuthorizeChecked {
@@ -635,14 +627,6 @@ impl BenchAuthorizeChecked {
             instruction_accounts,
         }
     }
-    fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchUpdateVoteState {
@@ -687,15 +671,6 @@ impl BenchUpdateVoteState {
             transaction_accounts,
             instruction_accounts,
         }
-    }
-
-    fn run(&self) {
-        let _accounts = process_deprecated_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
     }
 }
 
@@ -1165,28 +1140,92 @@ fn bench_update_commission(c: &mut Criterion) {
 fn bench_vote_switch(c: &mut Criterion) {
     let test_setup = BenchVoteSwitch::new();
     c.bench_function("vote_vote_switch", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_authorize_checked(c: &mut Criterion) {
     let test_setup = BenchAuthorizeChecked::new();
     c.bench_function("vote_authorize_checked", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_update_vote_state(c: &mut Criterion) {
     let test_setup = BenchUpdateVoteState::new(false);
     c.bench_function("vote_update_vote_state", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_update_vote_state_switch(c: &mut Criterion) {
     let test_setup = BenchUpdateVoteState::new(true);
     c.bench_function("vote_update_vote_state_switch", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -759,14 +759,6 @@ impl BenchAuthorizeWithSeed {
             instruction_accounts,
         }
     }
-    fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchAuthorizeCheckedWithSeed {
@@ -862,14 +854,6 @@ impl BenchAuthorizeCheckedWithSeed {
             instruction_accounts,
         }
     }
-    fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchCompactUpdateVoteState {
@@ -925,14 +909,6 @@ impl BenchCompactUpdateVoteState {
             instruction_accounts,
         }
     }
-    fn run(&self) {
-        let _accounts = process_deprecated_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchTowerSync {
@@ -987,14 +963,6 @@ impl BenchTowerSync {
             transaction_accounts,
             instruction_accounts,
         }
-    }
-    fn run(&self) {
-        let _accounts = process_deprecated_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
     }
 }
 
@@ -1232,42 +1200,138 @@ fn bench_update_vote_state_switch(c: &mut Criterion) {
 fn bench_authorize_with_seed(c: &mut Criterion) {
     let test_setup = BenchAuthorizeWithSeed::new();
     c.bench_function("vote_authorize_with_seed", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_authorize_checked_with_seed(c: &mut Criterion) {
     let test_setup = BenchAuthorizeCheckedWithSeed::new();
     c.bench_function("vote_authorize_checked_with_seed", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_compact_update_vote_state(c: &mut Criterion) {
     let test_setup = BenchCompactUpdateVoteState::new(false);
     c.bench_function("vote_compact_update_vote_state", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_compact_update_vote_state_switch(c: &mut Criterion) {
     let test_setup = BenchCompactUpdateVoteState::new(true);
     c.bench_function("vote_compact_update_vote_state_switch", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_tower_sync(c: &mut Criterion) {
     let test_setup = BenchTowerSync::new(false);
     c.bench_function("vote_tower_sync", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_tower_sync_switch(c: &mut Criterion) {
     let test_setup = BenchTowerSync::new(true);
     c.bench_function("vote_tower_sync_switch", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -384,15 +384,6 @@ impl BenchVote {
             instruction_accounts,
         }
     }
-
-    pub fn run(&self) {
-        let _accounts = process_deprecated_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchWithdraw {
@@ -434,16 +425,6 @@ impl BenchWithdraw {
             transaction_accounts,
             instruction_accounts,
         }
-    }
-
-    fn run(&self) {
-        // should pass, withdraw using authorized_withdrawer to authorized_withdrawer's account
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
     }
 }
 
@@ -492,15 +473,6 @@ impl BenchUpdateValidatorIdentity {
             instruction_accounts,
         }
     }
-
-    pub fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
-    }
 }
 
 struct BenchUpdateCommission {
@@ -546,14 +518,6 @@ impl BenchUpdateCommission {
             transaction_accounts,
             instruction_accounts,
         }
-    }
-    fn run(&self) {
-        let _accounts = process_instruction(
-            &self.instruction_data,
-            self.transaction_accounts.clone(),
-            self.instruction_accounts.clone(),
-            Ok(()),
-        );
     }
 }
 
@@ -1108,28 +1072,93 @@ fn bench_authorize(c: &mut Criterion) {
 fn bench_vote(c: &mut Criterion) {
     let test_setup = BenchVote::new();
     c.bench_function("vote_instruction_vote", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_deprecated_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_withdraw(c: &mut Criterion) {
     let test_setup = BenchWithdraw::new();
     c.bench_function("vote_instruction_withdraw", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            // should pass, withdraw using authorized_withdrawer to authorized_withdrawer's account
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_update_validator_identity(c: &mut Criterion) {
     let test_setup = BenchUpdateValidatorIdentity::new();
     c.bench_function("vote_update_validator_identity", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_update_commission(c: &mut Criterion) {
     let test_setup = BenchUpdateCommission::new();
     c.bench_function("vote_update_commission", |bencher| {
-        bencher.iter(|| test_setup.run())
+        bencher.iter_batched(
+            || {
+                (
+                    test_setup.transaction_accounts.clone(),
+                    test_setup.instruction_accounts.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_accounts)| {
+                process_instruction(
+                    &test_setup.instruction_data,
+                    transaction_accounts,
+                    instruction_accounts,
+                    Ok(()),
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 


### PR DESCRIPTION
Fixes #5006

Follow-up https://github.com/anza-xyz/agave/pull/4884#discussion_r1949583684Moves account clones out of the timed `bencher.iter` closure using `iter_batched`, matching the existing pattern in `process_vote.rs`.

cc @tao-stones @ksolana