### PR TITLE
Reconstruct V1 messages in storage-proto instead of downgrading them to V0

### DIFF
--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -2136,7 +2136,8 @@ mod test {
             config: v1::TransactionConfig::empty()
                 .with_priority_fee(5_000)
                 .with_compute_unit_limit(30_000)
-                .with_loaded_accounts_data_size_limit(200_000),
+                .with_loaded_accounts_data_size_limit(200_000)
+                .with_heap_size(65_536),
             lifetime_specifier: Hash::new_unique(),
             account_keys: account_keys(),
             instructions: instructions(),

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1363,6 +1363,34 @@ impl From<entries::Entry> for EntrySummary {
 mod test {
     use {super::*, enum_iterator::all};
 
+    fn header() -> MessageHeader {
+        MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        }
+    }
+
+    fn account_keys() -> Vec<Pubkey> {
+        vec![
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ]
+    }
+
+    fn instructions() -> Vec<CompiledInstruction> {
+        vec![CompiledInstruction {
+            program_id_index: 2,
+            accounts: vec![0, 1],
+            data: vec![1, 2, 3, 4],
+        }]
+    }
+
+    fn round_trip(message: VersionedMessage) -> VersionedMessage {
+        VersionedMessage::from(generated::Message::from(message))
+    }
+
     #[test]
     fn test_reward_type_encode() {
         let mut reward = Reward {
@@ -2069,42 +2097,6 @@ mod test {
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod message_conversion_tests {
-    use {
-        super::*,
-        solana_message::{compiled_instruction::CompiledInstruction, v1},
-    };
-
-    fn header() -> MessageHeader {
-        MessageHeader {
-            num_required_signatures: 1,
-            num_readonly_signed_accounts: 0,
-            num_readonly_unsigned_accounts: 1,
-        }
-    }
-
-    fn account_keys() -> Vec<Pubkey> {
-        vec![
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-        ]
-    }
-
-    fn instructions() -> Vec<CompiledInstruction> {
-        vec![CompiledInstruction {
-            program_id_index: 2,
-            accounts: vec![0, 1],
-            data: vec![1, 2, 3, 4],
-        }]
-    }
-
-    fn round_trip(message: VersionedMessage) -> VersionedMessage {
-        VersionedMessage::from(generated::Message::from(message))
     }
 
     #[test]

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -414,6 +414,25 @@ impl From<generated::Message> for VersionedMessage {
             .map(Hash::new_from_array)
             .unwrap();
         let instructions = value.instructions.into_iter().map(|ix| ix.into()).collect();
+
+        // `config` is written only for V1 messages, whose lifetime specifier travels in
+        // `recent_blockhash` and which have no address table lookups. It has to be checked before
+        // `versioned`, which is true for V0 *and* V1 and so cannot tell them apart on its own.
+        if let Some(config) = value.config {
+            return Self::V1(v1::Message {
+                header,
+                config: v1::TransactionConfig {
+                    priority_fee: config.priority_fee,
+                    compute_unit_limit: config.compute_unit_limit,
+                    loaded_accounts_data_size_limit: config.loaded_accounts_data_size_limit,
+                    heap_size: config.heap_size,
+                },
+                lifetime_specifier: recent_blockhash,
+                account_keys,
+                instructions,
+            });
+        }
+
         let address_table_lookups = value
             .address_table_lookups
             .into_iter()
@@ -2050,5 +2069,100 @@ mod test {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod message_conversion_tests {
+    use {
+        super::*,
+        solana_message::{compiled_instruction::CompiledInstruction, v1},
+    };
+
+    fn header() -> MessageHeader {
+        MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 1,
+        }
+    }
+
+    fn account_keys() -> Vec<Pubkey> {
+        vec![
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+        ]
+    }
+
+    fn instructions() -> Vec<CompiledInstruction> {
+        vec![CompiledInstruction {
+            program_id_index: 2,
+            accounts: vec![0, 1],
+            data: vec![1, 2, 3, 4],
+        }]
+    }
+
+    fn round_trip(message: VersionedMessage) -> VersionedMessage {
+        VersionedMessage::from(generated::Message::from(message))
+    }
+
+    #[test]
+    fn legacy_message_round_trips() {
+        let message = VersionedMessage::Legacy(LegacyMessage {
+            header: header(),
+            account_keys: account_keys(),
+            recent_blockhash: Hash::new_unique(),
+            instructions: instructions(),
+        });
+        assert_eq!(round_trip(message.clone()), message);
+    }
+
+    #[test]
+    fn v0_message_round_trips() {
+        let message = VersionedMessage::V0(v0::Message {
+            header: header(),
+            account_keys: account_keys(),
+            recent_blockhash: Hash::new_unique(),
+            instructions: instructions(),
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![1, 2],
+                readonly_indexes: vec![3],
+            }],
+        });
+        assert_eq!(round_trip(message.clone()), message);
+    }
+
+    /// `versioned` is true for V0 and V1 alike, so a V1 message is only recognisable by the
+    /// presence of `config`. Reading it back as V0 would silently drop the compute-budget request
+    /// and misreport the version.
+    #[test]
+    fn v1_message_round_trips() {
+        let message = VersionedMessage::V1(v1::Message {
+            header: header(),
+            config: v1::TransactionConfig::empty()
+                .with_priority_fee(5_000)
+                .with_compute_unit_limit(30_000)
+                .with_loaded_accounts_data_size_limit(200_000),
+            lifetime_specifier: Hash::new_unique(),
+            account_keys: account_keys(),
+            instructions: instructions(),
+        });
+        assert_eq!(round_trip(message.clone()), message);
+    }
+
+    /// A V1 message may request nothing at all — an empty config mask is legal, and must still be
+    /// distinguishable from V0.
+    #[test]
+    fn v1_message_with_empty_config_round_trips() {
+        let message = VersionedMessage::V1(v1::Message {
+            header: header(),
+            config: v1::TransactionConfig::empty(),
+            lifetime_specifier: Hash::new_unique(),
+            account_keys: account_keys(),
+            instructions: instructions(),
+        });
+        assert_eq!(round_trip(message.clone()), message);
     }
 }


### PR DESCRIPTION
#### Problem

`impl From<generated::Message> for VersionedMessage` in `storage-proto/src/convert.rs` decides the message version by branching on the `versioned` boolean alone and never reads `value.config`. `versioned` is true for both V0 and V1, so every V1 message decodes back as `VersionedMessage::V0`: the version is misreported and the inline compute-budget request (`config`) is silently dropped. No error is raised.

The outbound direction in the same file is correct — `impl From<v1::Message> for generated::Message` writes `config: Some(...)`. Both halves were added in the same commit (edd5368eda, #10699); only the write direction handles V1.

Beyond the missing field, a V1 message reconstructed as V0 no longer corresponds to the bytes that were signed: re-serializing it produces a different message hash, and the attached signature does not verify against it.

This affects published `solana-storage-proto` 4.2.0 and current master. Downstream, `rpcpool/yellowstone-grpc`'s Node client decodes through this conversion, so its `txEncode.encode` reports V1 transactions as `version: 0` with `transactionConfig` absent. yellowstone-grpc fixed the identical bug in their own copy of this conversion (rpcpool/yellowstone-grpc#855) by checking `config` before `versioned`.

#### Summary of Changes

* In `From<generated::Message> for VersionedMessage`, return `VersionedMessage::V1` early when `value.config` is present, mapping the four config fields and using `recent_blockhash` as the `lifetime_specifier`. Presence of `config` is the only signal on the wire separating V0 from V1: it is written only for V1 messages, whose lifetime specifier travels in `recent_blockhash` and which carry no address table lookups.
* Move the `address_table_lookups` computation below the V1 early return (V1 messages have none). Legacy and V0 decoding are unchanged.
* Add round-trip tests (`VersionedMessage -> generated::Message -> VersionedMessage`) for legacy, V0, V1, and V1 with an empty config — a V1 message may request nothing at all and must still be distinguishable from V0.

#### Testing

* `cargo test -p solana-storage-proto --features agave-unstable-api` — all 20 tests pass.
* With the fix reverted and the new tests kept, `v1_message_round_trips` and `v1_message_with_empty_config_round_trips` fail with `V0(...)` on the left and `V1(...)` on the right; the legacy and V0 round-trip tests still pass.
* `cargo fmt -p solana-storage-proto -- --check` and `cargo clippy -p solana-storage-proto --features agave-unstable-api --all-targets` are clean.

Fixes #14873
