### PR TITLE
v4.3: revert program cache extract criteria (#14484 and #14509)

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -324,6 +324,7 @@ impl Consumer {
                 &mut error_counters,
                 TransactionProcessingConfig {
                     account_overrides: None,
+                    check_program_deployment_slot: bank.check_program_deployment_slot(),
                     log_messages_bytes_limit: self.log_messages_bytes_limit,
                     limit_to_load_programs: true,
                     recording_config: ExecutionRecordingConfig::new_single_setting(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2053,7 +2053,7 @@ fn load_frozen_forks(
                 progress.num_shreds = u64::from(meta.replay_fec_set_index);
             }
             let mut m = Measure::start("process_single_slot");
-            let bank = bank_forks.write().unwrap().insert(bank);
+            let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
             if let Err(error) = process_single_slot(
                 blockstore,
                 &bank,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -203,8 +203,8 @@ pub struct ProgramToLoad<'a> {
     pub program_id: &'a Pubkey,
     /// The program loader
     pub loader: ProgramCacheEntryOwner,
-    /// Ignore entries deployed before this slot.
-    pub deployed_on_or_after_slot: Slot,
+    /// Potentially filter out / ignore some entries during the start up / catch up phase
+    pub match_criteria: ProgramCacheMatchCriteria,
     /// When the program account was last written to (might be after the deployment slot)
     pub last_modification_slot: Slot,
 }
@@ -364,6 +364,12 @@ impl ProgramCacheForTxBatch {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum ProgramCacheMatchCriteria {
+    DeployedOnOrAfterSlot(Slot),
+    NoCriteria,
 }
 
 impl<FG: ForkGraph> ProgramCache<FG> {
@@ -577,6 +583,18 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         environment == program_runtime_environment
     }
 
+    fn matches_criteria(
+        program: &Arc<ProgramCacheEntry>,
+        criteria: &ProgramCacheMatchCriteria,
+    ) -> bool {
+        match criteria {
+            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot) => {
+                program.deployment_slot >= *slot
+            }
+            ProgramCacheMatchCriteria::NoCriteria => true,
+        }
+    }
+
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(
@@ -636,9 +654,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                             .or(Some(entry.deployment_slot));
                                         continue;
                                     }
-                                    if entry.deployment_slot
-                                        < program_to_load.deployed_on_or_after_slot
-                                    {
+                                    if !Self::matches_criteria(
+                                        entry,
+                                        &program_to_load.match_criteria,
+                                    ) {
                                         break;
                                     }
                                     if let ProgramCacheEntryType::Unloaded(_environment) =
@@ -953,7 +972,8 @@ pub(crate) mod tests {
         crate::{
             loaded_programs::{
                 BlockRelation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
-                ProgramRuntimeEnvironment, ProgramToLoad, get_mock_program_runtime_environment,
+                ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramToLoad,
+                get_mock_program_runtime_environment,
             },
             program_cache_entry::{
                 ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
@@ -1817,7 +1837,7 @@ pub(crate) mod tests {
                     .map(|(_program_id, entry)| ProgramToLoad {
                         program_id: key,
                         loader: entry.account_owner,
-                        deployed_on_or_after_slot: 0,
+                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                         last_modification_slot: entry.deployment_slot,
                     })
             })
@@ -2079,8 +2099,10 @@ pub(crate) mod tests {
 
         // Test the same fork, but request the program modified at a later slot than what's in the cache.
         let mut missing = get_entries_to_load(&cache, 12, keys);
-        missing.get_mut(0).unwrap().deployed_on_or_after_slot = 5;
-        missing.get_mut(1).unwrap().deployed_on_or_after_slot = 5;
+        missing.get_mut(0).unwrap().match_criteria =
+            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
+        missing.get_mut(1).unwrap().match_criteria =
+            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2227,7 +2249,7 @@ pub(crate) mod tests {
         let mut missing = vec![ProgramToLoad {
             program_id: &program1,
             loader: ProgramCacheEntryOwner::LoaderV3,
-            deployed_on_or_after_slot: 0,
+            match_criteria: ProgramCacheMatchCriteria::NoCriteria,
             last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(0);
@@ -2386,5 +2408,63 @@ pub(crate) mod tests {
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 20));
+    }
+
+    #[test]
+    fn test_usable_entries_for_slot() {
+        ProgramCache::<TestForkGraph>::new(0);
+        let tombstone = Arc::new(ProgramCacheEntry::new_closed_tombstone(
+            0,
+            ProgramCacheEntryOwner::LoaderV2,
+        ));
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &tombstone,
+            &ProgramCacheMatchCriteria::NoCriteria
+        ));
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &tombstone,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
+        ));
+
+        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
+            &tombstone,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
+        ));
+
+        let program = new_test_entry(0);
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::NoCriteria
+        ));
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
+        ));
+
+        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
+        ));
+
+        let program = Arc::new(new_test_entry_with_usage(0, ProgramStatistics::default()));
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::NoCriteria
+        ));
+
+        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
+        ));
+
+        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
+            &program,
+            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
+        ));
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -697,6 +697,7 @@ impl PartialEq for Bank {
             accounts_data_size_delta_off_chain: _,
             epoch_reward_status: _,
             transaction_processor: _,
+            check_program_deployment_slot: _,
             collector_fee_details: _,
             compute_budget: _,
             transaction_account_lock_limit: _,
@@ -1023,6 +1024,8 @@ pub struct Bank {
 
     transaction_processor: TransactionBatchProcessor<BankForks>,
 
+    check_program_deployment_slot: bool,
+
     /// Collected fee details
     collector_fee_details: RwLock<CollectorFeeDetails>,
 
@@ -1264,6 +1267,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
+            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: None,
             transaction_account_lock_limit: None,
@@ -1531,6 +1535,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: parent.epoch_reward_status.clone(),
             transaction_processor,
+            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: parent.compute_budget,
             transaction_account_lock_limit: parent.transaction_account_lock_limit,
@@ -1644,6 +1649,7 @@ impl Bank {
                 self.transaction_processor
                     .prepare_one_program_for_upcoming_feature_set(
                         self,
+                        self.check_program_deployment_slot(),
                         &upcoming_environment,
                         &key,
                         &program_to_recompile.stats,
@@ -2195,6 +2201,7 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
+            check_program_deployment_slot: false,
             // collector_fee_details is not serialized to snapshot
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: runtime_config.compute_budget,
@@ -3864,6 +3871,7 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: Some(&account_overrides),
+                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit: None,
                 limit_to_load_programs: true,
                 recording_config: ExecutionRecordingConfig {
@@ -4626,6 +4634,7 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: None,
+                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
@@ -6549,6 +6558,14 @@ impl Bank {
             return slot_hashes.get(slot).is_some();
         }
         false
+    }
+
+    pub fn check_program_deployment_slot(&self) -> bool {
+        self.check_program_deployment_slot
+    }
+
+    pub fn set_check_program_deployment_slot(&mut self, check: bool) {
+        self.check_program_deployment_slot = check;
     }
 
     pub fn fee_structure(&self) -> &FeeStructure {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -79,6 +79,7 @@ pub struct BankForks {
     root: Slot,
     working_slot: Slot,
     sharable_banks: SharableBanks,
+    highest_slot_at_startup: Slot,
     scheduler_pool: Option<InstalledSchedulerPoolArc>,
 
     /// The status tracker for the Alpenglow migration. Initialized via either
@@ -135,6 +136,7 @@ impl BankForks {
             },
             banks,
             descendants,
+            highest_slot_at_startup: 0,
             scheduler_pool: None,
             migration_status,
         }));
@@ -301,8 +303,12 @@ impl BankForks {
     pub fn insert_with_scheduling_mode(
         &mut self,
         mode: SchedulingMode,
-        bank: Bank,
+        mut bank: Bank,
     ) -> BankWithScheduler {
+        if self.root < self.highest_slot_at_startup {
+            bank.set_check_program_deployment_slot(true);
+        }
+
         let bank = Arc::new(bank);
         let bank = if let Some(scheduler_pool) = &self.scheduler_pool {
             Self::install_scheduler_into_bank(scheduler_pool, mode, bank)
@@ -342,6 +348,11 @@ impl BankForks {
             scheduler_pool.register_timeout_listener(bank_with_scheduler.create_timeout_listener());
         }
         bank_with_scheduler
+    }
+
+    pub fn insert_from_ledger(&mut self, bank: Bank) -> BankWithScheduler {
+        self.highest_slot_at_startup = std::cmp::max(self.highest_slot_at_startup, bank.slot());
+        self.insert(bank)
     }
 
     pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -243,6 +243,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     keys: impl Iterator<Item = &'a Pubkey>,
+    check_program_deployment_slot: bool,
 ) -> Vec<ProgramToLoad<'a>> {
     let mut result = Vec::new();
     for account_key in keys {
@@ -278,10 +279,15 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             else {
                 continue;
             };
+            let match_criteria = if check_program_deployment_slot {
+                ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot)
+            } else {
+                ProgramCacheMatchCriteria::NoCriteria
+            };
             result.push(ProgramToLoad {
                 program_id: account_key,
                 loader,
-                match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot),
+                match_criteria,
                 last_modification_slot,
             });
         }
@@ -916,6 +922,31 @@ mod tests {
             &mock_bank,
             &loaded_programs_for_tx_batch,
             sanitized_tx.account_keys().iter(),
+            false,
+        );
+        assert_eq!(
+            missing_programs,
+            &[
+                ProgramToLoad {
+                    program_id: &program_ids[1],
+                    loader: ProgramCacheEntryOwner::LoaderV2,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                },
+                ProgramToLoad {
+                    program_id: &program_ids[2],
+                    loader: ProgramCacheEntryOwner::LoaderV3,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    last_modification_slot: 0,
+                },
+            ]
+        );
+
+        let missing_programs = filter_executable_program_accounts(
+            &mock_bank,
+            &loaded_programs_for_tx_batch,
+            sanitized_tx.account_keys().iter(),
+            true,
         );
         assert_eq!(
             missing_programs,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -7,7 +7,10 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::{
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramToLoad},
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
+            ProgramToLoad,
+        },
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
     },
     solana_pubkey::Pubkey,
@@ -278,7 +281,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             result.push(ProgramToLoad {
                 program_id: account_key,
                 loader,
-                deployed_on_or_after_slot: deployment_slot,
+                match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot),
                 last_modification_slot,
             });
         }
@@ -920,13 +923,13 @@ mod tests {
                 ProgramToLoad {
                     program_id: &program_ids[1],
                     loader: ProgramCacheEntryOwner::LoaderV2,
-                    deployed_on_or_after_slot: 0,
+                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
                     last_modification_slot: 0,
                 },
                 ProgramToLoad {
                     program_id: &program_ids[2],
                     loader: ProgramCacheEntryOwner::LoaderV3,
-                    deployed_on_or_after_slot: 0,
+                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
                     last_modification_slot: 0,
                 },
             ]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -118,6 +118,9 @@ pub struct TransactionProcessingConfig<'a> {
     /// Encapsulates overridden accounts, typically used for transaction
     /// simulation.
     pub account_overrides: Option<&'a AccountOverrides>,
+    /// Whether or not to check a program's deployment slot when replenishing
+    /// a program cache instance.
+    pub check_program_deployment_slot: bool,
     /// The maximum number of bytes that log messages can consume.
     pub log_messages_bytes_limit: Option<usize>,
     /// Whether to limit the number of programs loaded for the transaction
@@ -532,6 +535,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             &account_loader,
                             &program_cache_for_tx_batch,
                             tx.account_keys().iter(),
+                            config.check_program_deployment_slot,
                         ));
                     execute_timings.saturating_add_in_place(
                         ExecuteTimingType::FilterExecutableUs,
@@ -971,6 +975,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     pub fn prepare_one_program_for_upcoming_feature_set<CB: TransactionProcessingCallback>(
         &self,
         account_loader: &CB,
+        check_program_deployment_slot: bool,
         upcoming_environment: &ProgramRuntimeEnvironment,
         key: &Pubkey,
         stats_of_enqueued_program: &ProgramStatistics,
@@ -980,6 +985,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             account_loader,
             &program_cache_for_tx_batch,
             std::iter::once(key),
+            check_program_deployment_slot,
         );
         if missing_programs.is_empty() {
             // Program account was closed

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -42,7 +42,8 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
-            ProgramRuntimeEnvironment, ProgramRuntimeEnvironments, ProgramToLoad,
+            ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+            ProgramToLoad,
         },
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
         program_metrics::ProgramStatistics,
@@ -326,7 +327,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .map(|program_id| ProgramToLoad {
                 program_id,
                 loader: ProgramCacheEntryOwner::NativeLoader,
-                deployed_on_or_after_slot: 0,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             })
             .collect();
@@ -1883,7 +1884,7 @@ mod tests {
             vec![ProgramToLoad {
                 program_id: &key,
                 loader: ProgramCacheEntryOwner::LoaderV3,
-                deployed_on_or_after_slot: 0,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                 last_modification_slot: 0,
             }],
             &program_runtime_environment_for_execution,
@@ -1922,7 +1923,7 @@ mod tests {
                 vec![ProgramToLoad {
                     program_id: &key,
                     loader: ProgramCacheEntryOwner::LoaderV2,
-                    deployed_on_or_after_slot: 0,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],
                 &program_runtime_environment_for_execution,
@@ -2169,7 +2170,7 @@ mod tests {
                 &mut vec![ProgramToLoad {
                     program_id: &key,
                     loader: ProgramCacheEntryOwner::NativeLoader,
-                    deployed_on_or_after_slot: 0,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 }],
                 &mut loaded_programs_for_tx_batch,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -13,7 +13,10 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments, ProgramToLoad},
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
+            ProgramToLoad,
+        },
         program_cache_entry::{ProgramCacheEntryOwner, ProgramCacheEntryType},
         program_metrics::ProgramStatistics,
     },
@@ -62,7 +65,7 @@ fn program_cache_execution(threads: usize) {
                     .map(|program_id| ProgramToLoad {
                         program_id,
                         loader: ProgramCacheEntryOwner::LoaderV3,
-                        deployed_on_or_after_slot: 0,
+                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                         last_modification_slot: 0,
                     })
                     .collect();

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -117,6 +117,7 @@ fn program_cache_execution(threads: usize) {
                     .program_runtime_environment_for_epoch(processor.epoch.saturating_add(1));
                 processor.prepare_one_program_for_upcoming_feature_set(
                     &account_loader,
+                    false,
                     &upcoming_environment,
                     &program,
                     &ProgramStatistics::default(),


### PR DESCRIPTION
#### Problem
We're actively working on the program cache in `master` (v4.4), but a few of the early changes landed in 4.3.

#### Summary of Changes
Pull them out, and keep the recent program cache extraction/indexing changes contained to `master`.

#### Testing
