### PR TITLE
svm: tests: filter_executable_program_accounts

### DIFF
--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1346,6 +1346,227 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_executable_program_accounts_cache_hit() {
+        let mock_bank = MockBankCallback::default();
+        let mut batch = ProgramCacheForTxBatch::new(10);
+        let key = Pubkey::new_unique();
+
+        let mut account = AccountSharedData::default();
+        account.set_owner(bpf_loader::id());
+        account.set_data_from_slice(&[1u8; 4]);
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (account, 0));
+
+        let entry = Arc::new(ProgramCacheEntry::new_closed_tombstone(
+            0,
+            ProgramCacheEntryOwner::LoaderV2,
+        ));
+        batch.replenish(key, Arc::clone(&entry));
+
+        // Already in the batch, so it is counted as used and not asked for
+        // again. The account is never looked at.
+        let keys = [key];
+        let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+        assert!(result.is_empty());
+        assert_eq!(entry.stats.uses.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_account_not_found() {
+        let mock_bank = MockBankCallback::default();
+        let batch = ProgramCacheForTxBatch::new(10);
+
+        // The account does not exist, so there is no program to queue.
+        let keys = [Pubkey::new_unique()];
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_invalid_owner() {
+        let mock_bank = MockBankCallback::default();
+        let batch = ProgramCacheForTxBatch::new(10);
+
+        // The account exists, but is not owned by any loader, so there is no
+        // program to queue.
+        let key = Pubkey::new_unique();
+        let mut account = AccountSharedData::default();
+        account.set_owner(Pubkey::new_unique());
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (account, 0));
+
+        let keys = [key];
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_loader_v1_v2() {
+        let mock_bank = MockBankCallback::default();
+        let batch = ProgramCacheForTxBatch::new(10);
+        let key = Pubkey::new_unique();
+        let keys = [key];
+
+        for (owner, loader) in [
+            (
+                bpf_loader_deprecated::id(),
+                ProgramCacheEntryOwner::LoaderV1,
+            ),
+            (bpf_loader::id(), ProgramCacheEntryOwner::LoaderV2),
+        ] {
+            // Empty data returns `ProgramAccountNotFound` for deployment slot,
+            // so nothing is queued.
+            let mut empty = AccountSharedData::default();
+            empty.set_owner(owner);
+            mock_bank
+                .account_shared_data
+                .borrow_mut()
+                .insert(key, (empty, 40));
+            assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+
+            // Any non-empty data is considered to *maybe* be a program, and
+            // both loaders always use deployment slot 0. The modification slot
+            // is the program account's own.
+            let mut account = AccountSharedData::default();
+            account.set_owner(owner);
+            account.set_data_from_slice(&[1u8; 4]);
+            mock_bank
+                .account_shared_data
+                .borrow_mut()
+                .insert(key, (account, 40));
+
+            let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+            assert_eq!(result.len(), 1);
+            let program_to_load = result.first().unwrap();
+            assert_eq!(program_to_load.loader, loader);
+            assert_eq!(program_to_load.deployment_slot, 0);
+            assert_eq!(program_to_load.last_modification_slot, 40);
+        }
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_loader_v3() {
+        let mock_bank = MockBankCallback::default();
+        let batch = ProgramCacheForTxBatch::new(10);
+        let key = Pubkey::new_unique();
+        let programdata_key = Pubkey::new_unique();
+        let keys = [key];
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (loader_v3_program_account(programdata_key), 50));
+
+        // Case: programdata account does not exist.
+        // Can't read deployment slot, nothing is queued.
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+
+        // Case: programdata account exists, but wrong owner.
+        // Can't read deployment slot, nothing is queued.
+        let mut programdata_account = loader_v3_programdata_account(7);
+        programdata_account.set_owner(Pubkey::new_unique());
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(programdata_key, (programdata_account, 60));
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+
+        // Case: programdata account exists, but wrong state.
+        // Can't read deployment slot, nothing is queued.
+        let mut programdata_account = AccountSharedData::default();
+        programdata_account.set_owner(bpf_loader_upgradeable::id());
+        programdata_account.set_data_from_slice(&[0u8; 4]); // `Uninitialized`
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(programdata_key, (programdata_account, 60));
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+
+        // Successfully queued.
+        // Both fields come from the programdata account: the deployment slot
+        // *and* the modification slot.
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(programdata_key, (loader_v3_programdata_account(7), 60));
+        let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+        assert_eq!(result.len(), 1);
+        let program_to_load = result.first().unwrap();
+        assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV3);
+        assert_eq!(program_to_load.deployment_slot, 7);
+        assert_eq!(program_to_load.last_modification_slot, 60);
+    }
+
+    #[test]
+    fn test_filter_executable_program_accounts_loader_v4() {
+        let mock_bank = MockBankCallback::default();
+        let batch = ProgramCacheForTxBatch::new(10);
+        let key = Pubkey::new_unique();
+        let keys = [key];
+
+        // Case: program account exists, but wrong state.
+        // Can't read deployment slot, nothing is queued.
+        let mut too_small = AccountSharedData::default();
+        too_small.set_owner(loader_v4::id());
+        too_small.set_data_from_slice(&[0u8; 4]);
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (too_small, 100));
+        assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
+
+        // Case: program account is sized correctly, but all-zeroes. Since
+        // `LoaderV4Status::Retracted` holds variant `0`, this is a retracted
+        // program, and nothing should be queued.
+        let mut gifted = AccountSharedData::default();
+        gifted.set_owner(loader_v4::id());
+        gifted.set_data_from_slice(&[0u8; LoaderV4State::program_data_offset()]);
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (gifted, 100));
+        // TODO: We have a mismatch here in the Loader V4 valid state contract
+        // between `get_program_deployment_slot` and `load_program_accounts`.
+        // See `test_get_program_deployment_slot_loader_v4`.
+        let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+        assert_eq!(result.len(), 1);
+        let program_to_load = result.first().unwrap();
+        assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV4);
+        assert_eq!(program_to_load.deployment_slot, 0);
+        assert_eq!(program_to_load.last_modification_slot, 100);
+
+        // Case: program account holds valid state, but is `Retracted`.
+        // `load_program_accounts` calls this invalid, so nothing should be
+        // queued here either.
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (loader_v4_account(9, LoaderV4Status::Retracted), 100));
+        // TODO: Same issue as the above case.
+        let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+        assert_eq!(result.len(), 1);
+        let program_to_load = result.first().unwrap();
+        assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV4);
+        assert_eq!(program_to_load.deployment_slot, 9);
+        assert_eq!(program_to_load.last_modification_slot, 100);
+
+        // Successfully queued.
+        // Both fields come from the program account: the deployment slot from
+        // its state, the modification slot from the account itself.
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, (loader_v4_account(9, LoaderV4Status::Deployed), 100));
+        let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
+        assert_eq!(result.len(), 1);
+        let program_to_load = result.first().unwrap();
+        assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV4);
+        assert_eq!(program_to_load.deployment_slot, 9);
+        assert_eq!(program_to_load.last_modification_slot, 100);
+    }
+
+    #[test]
     fn test_loader_v4_get_state() {
         // Anything shorter than the state itself is rejected.
         for len in [0, LoaderV4State::program_data_offset().saturating_sub(1)] {


### PR DESCRIPTION
#### Problem
We could use some more test coverage in solana-svm surrounding the program loader.

#### Summary of Changes
Just like in https://github.com/anza-xyz/agave/pull/14822, https://github.com/anza-xyz/agave/pull/14827, and https://github.com/anza-xyz/agave/pull/14868, widen existing tests to per-loader test functions covering each case one-by-one. Then drops tests that becomes redundant.

I've also documented the `LoaderV4Status::Retracted` issue that will be fixed in #14838.

#### Testing
Adds new tests.