### PR TITLE
[syscall] Add cryptographic syscall bench code for local testing [do not merge]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
 name = "hidapi"
 version = "2.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10823,8 +10829,13 @@ dependencies = [
 name = "solana-syscalls"
 version = "4.4.0-alpha.1"
 dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
  "assert_matches",
  "bincode",
+ "criterion",
+ "hex-literal",
  "libsecp256k1",
  "num-traits",
  "solana-account 4.6.0",

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -64,19 +64,83 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
+ark-bn254 = "0.5.0"
+ark-ec = "0.5.0"
+ark-ff = "0.5.0"
 assert_matches = { workspace = true }
+criterion = { workspace = true }
+hex-literal = "1.1.0"
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = { path = "../program-runtime", features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-slot-hashes = { workspace = true }
-solana-svm-callback = { path = "../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../svm-callback", features = [
+    "agave-unstable-api",
+] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+    "agave-unstable-api",
+    "bincode",
+    "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "syscall_secp256k1_recover"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_hash"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_alt_bn128"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_alt_bn128_pairing"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_alt_bn128_compression"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_curve25519"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_poseidon"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_big_mod_exp"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_bls12_381"
+harness = false
+required-features = ["agave-unstable-api"]
+
+[[bench]]
+name = "syscall_bls12_381_pairing"
+harness = false
+required-features = ["agave-unstable-api"]

--- a/syscalls/benches/common/bls12_381.rs
+++ b/syscalls/benches/common/bls12_381.rs
@@ -1,0 +1,282 @@
+//! BLS12-381 fixtures.
+//!
+//! The worst-case vectors below are copied verbatim from
+//! `curves/bls12-381/benches/test_vectors.rs` in this workspace. They were
+//! chosen by the implementers to maximise the runtime of each operation, which
+//! is exactly what a pricing study needs: a flat price has to cover the slowest
+//! valid input, not an average one.
+//!
+//! Byte layouts, per `encoding.rs` of that crate:
+//!   BE  - Zcash/IETF standard, fed straight to blstrs.
+//!   LE  - each 48-byte Fq reversed; for G2, the c0/c1 halves of each Fq2 also
+//!         swapped.
+//!   G1 point 96 B, G2 point 192 B, G1 compressed 48 B, G2 compressed 96 B,
+//!   scalar 32 B, Gt element 576 B.
+
+#![allow(dead_code)]
+
+use {
+    hex_literal::hex,
+    solana_bls12_381_syscall::{
+        bls12_381_g1_decompress, bls12_381_g1_point_validation, bls12_381_g2_decompress,
+        bls12_381_g2_point_validation, Endianness, PodG1Compressed, PodG1Point, PodG2Compressed,
+        PodG2Point, PodScalar, Version,
+    },
+    std::mem::size_of,
+};
+
+pub const G1_POINT_SIZE: usize = 96;
+pub const G2_POINT_SIZE: usize = 192;
+pub const G1_COMPRESSED_SIZE: usize = 48;
+pub const G2_COMPRESSED_SIZE: usize = 96;
+pub const SCALAR_SIZE: usize = 32;
+pub const GT_SIZE: usize = 576;
+
+pub fn endianness(le: bool) -> Endianness {
+    if le {
+        Endianness::LE
+    } else {
+        Endianness::BE
+    }
+}
+
+// ---------------------------------------------------------------- vectors
+
+const INPUT_BE_G1_ADD_WORST_CASE: &[u8] = &hex!(
+    "0408fcfce79d55404c279812a8bdfc02525f215e70f717cbf9f97c305f6845d6661f3a5a46c513a24cf706410e878a2c12aca07fea5564f2bdcf28ba9f12f2d88c85ae28b1a2c33f965cad4a1af3c796ee6d33fc7e322cc8954b223f53febd330eea76a913985d932eea073ebf8e86d21c6e4d4c8bfbef927c006abe860b51282629eea7b197385deb9057e603aa9c6e1104b5ffaabfe1d55de81f8acc668c913479611296668293535b602ab8cf24797522ad15ca4a2e8f898855d94d0a58fe"
+);
+
+const INPUT_LE_G1_ADD_WORST_CASE: &[u8] = &hex!(
+    "2c8a870e4106f74ca213c5465a3a1f66d645685f307cf9f9cb17f7705e215f5202fcbda81298274c40559de7fcfc080433bdfe533f224b95c82c327efc336dee96c7f31a4aad5c963fc3a2b128ae858cd8f2129fba28cfbdf26455ea7fa0ac126e9caa03e65790eb5d3897b1a7ee292628510b86be6a007c92effb8b4c4d6e1cd2868ebf3e07ea2e935d9813a976ea0efe580a4dd95588898f2e4aca15ad22757924cfb82a605b539382669612617934918c66cc8a1fe85dd5e1bfaaffb50411"
+);
+
+const INPUT_BE_G1_SUB_WORST_CASE: &[u8] = &hex!(
+    "0408fcfce79d55404c279812a8bdfc02525f215e70f717cbf9f97c305f6845d6661f3a5a46c513a24cf706410e878a2c12aca07fea5564f2bdcf28ba9f12f2d88c85ae28b1a2c33f965cad4a1af3c796ee6d33fc7e322cc8954b223f53febd330eea76a913985d932eea073ebf8e86d21c6e4d4c8bfbef927c006abe860b51282629eea7b197385deb9057e603aa9c6e1104b5ffaabfe1d55de81f8acc668c913479611296668293535b602ab8cf24797522ad15ca4a2e8f898855d94d0a58fe"
+);
+
+const INPUT_LE_G1_SUB_WORST_CASE: &[u8] = &hex!(
+    "2c8a870e4106f74ca213c5465a3a1f66d645685f307cf9f9cb17f7705e215f5202fcbda81298274c40559de7fcfc080433bdfe533f224b95c82c327efc336dee96c7f31a4aad5c963fc3a2b128ae858cd8f2129fba28cfbdf26455ea7fa0ac126e9caa03e65790eb5d3897b1a7ee292628510b86be6a007c92effb8b4c4d6e1cd2868ebf3e07ea2e935d9813a976ea0efe580a4dd95588898f2e4aca15ad22757924cfb82a605b539382669612617934918c66cc8a1fe85dd5e1bfaaffb50411"
+);
+
+const INPUT_BE_G1_MUL_WORST_CASE: &[u8] = &hex!(
+    "0408fcfce79d55404c279812a8bdfc02525f215e70f717cbf9f97c305f6845d6661f3a5a46c513a24cf706410e878a2c12aca07fea5564f2bdcf28ba9f12f2d88c85ae28b1a2c33f965cad4a1af3c796ee6d33fc7e322cc8954b223f53febd3373eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000"
+);
+
+const INPUT_LE_G1_MUL_WORST_CASE: &[u8] = &hex!(
+    "2c8a870e4106f74ca213c5465a3a1f66d645685f307cf9f9cb17f7705e215f5202fcbda81298274c40559de7fcfc080433bdfe533f224b95c82c327efc336dee96c7f31a4aad5c963fc3a2b128ae858cd8f2129fba28cfbdf26455ea7fa0ac1200000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+);
+
+const INPUT_BE_G1_DECOMPRESS_WORST_CASE: &[u8] = &hex!(
+    "a408fcfce79d55404c279812a8bdfc02525f215e70f717cbf9f97c305f6845d6661f3a5a46c513a24cf706410e878a2c"
+);
+
+const INPUT_LE_G1_DECOMPRESS_WORST_CASE: &[u8] = &hex!(
+    "2c8a870e4106f74ca213c5465a3a1f66d645685f307cf9f9cb17f7705e215f5202fcbda81298274c40559de7fcfc08a4"
+);
+
+const INPUT_BE_G1_VALIDATE_WORST_CASE: &[u8] = &hex!(
+    "0408fcfce79d55404c279812a8bdfc02525f215e70f717cbf9f97c305f6845d6661f3a5a46c513a24cf706410e878a2c12aca07fea5564f2bdcf28ba9f12f2d88c85ae28b1a2c33f965cad4a1af3c796ee6d33fc7e322cc8954b223f53febd33"
+);
+
+const INPUT_LE_G1_VALIDATE_WORST_CASE: &[u8] = &hex!(
+    "2c8a870e4106f74ca213c5465a3a1f66d645685f307cf9f9cb17f7705e215f5202fcbda81298274c40559de7fcfc080433bdfe533f224b95c82c327efc336dee96c7f31a4aad5c963fc3a2b128ae858cd8f2129fba28cfbdf26455ea7fa0ac12"
+);
+
+const INPUT_BE_G2_ADD_WORST_CASE: &[u8] = &hex!(
+    "03bd018dadd58e94c755ae7e3ca3a2359582282475a85ad70d94d051298f2cbcc86d5440032e927e432f2c7b2f28dcb90169a750864019b9aaaf37c7e5a005a525b70e3e52d04ea58874a79af8b835b68eba547558e9627d6e2051f080b560d307a3d35f55ddb9732ee23283533f7aed5b6b702f932ef3cad72cc79d31cb953700d0bd3fe12230c989e9d199ef580989119af50a55aeedc4b0a7972bbcb2d4a1da1a53f469b49f89458271bb84d341065afca90fae7b9cabf2245622cc2e08730377679657a9200ab2be940cb280e114de3ec7ba85bd35f33b7abb97844ae37d4dc01f39cbb981e6ca64b561c42e28b8074753c2c1ae0f67b96f5eccee6db19581a8d8d72d736929e1126970d0dfb62c64022f37b10fb65328ceb8282d56afc10457daadf9144fb306599b420c3787b5d388ea5eb48d997873a5c0316a71564132fa3c08122f85948c926b98e5074a2f048865ccd58cf6e3afc55b59b382ff03df30d63fa09f1622f3f62663e0ff5203c370fb2019e5caa9eeba9d29b17470ed"
+);
+
+const INPUT_LE_G2_ADD_WORST_CASE: &[u8] = &hex!(
+    "d360b580f051206e7d62e9587554ba8eb635b8f89aa77488a54ed0523e0eb725a505a0e5c737afaab919408650a76901b9dc282f7b2c2f437e922e0340546dc8bc2c8f2951d0940dd75aa8752428829535a2a33c7eae55c7948ed5ad8d01bd0373082ecc225624f2ab9c7bae0fa9fc5a0641d384bb718245899fb469f4531adaa1d4b2bc2b97a7b0c4edae550af59a11890958ef99d1e989c93022e13fbdd0003795cb319dc72cd7caf32e932f706b5bed7a3f538332e22e73b9dd555fd3a307c1af562d28b8ce2853b60fb1372f02642cb6dfd0706912e12969732dd7d8a88195b16deecc5e6fb9670faec1c2534707b8282ec461b564cae681b9cb391fc04d7de34a8497bb7a3bf335bd85bac73ede14e180b20c94beb20a20a95796677703ed7074b1299dbaeea9cae51920fb70c30352ffe06326f6f322169fa03fd630df03ff82b3595bc5afe3f68cd5cc6588042f4a07e5986b928c94852f12083cfa324156716a31c0a57378998db45eea88d3b587370c429b5906b34f14f9adda5704"
+);
+
+const INPUT_BE_G2_SUB_WORST_CASE: &[u8] = &hex!(
+    "03bd018dadd58e94c755ae7e3ca3a2359582282475a85ad70d94d051298f2cbcc86d5440032e927e432f2c7b2f28dcb90169a750864019b9aaaf37c7e5a005a525b70e3e52d04ea58874a79af8b835b68eba547558e9627d6e2051f080b560d307a3d35f55ddb9732ee23283533f7aed5b6b702f932ef3cad72cc79d31cb953700d0bd3fe12230c989e9d199ef580989119af50a55aeedc4b0a7972bbcb2d4a1da1a53f469b49f89458271bb84d341065afca90fae7b9cabf2245622cc2e08730377679657a9200ab2be940cb280e114de3ec7ba85bd35f33b7abb97844ae37d4dc01f39cbb981e6ca64b561c42e28b8074753c2c1ae0f67b96f5eccee6db19581a8d8d72d736929e1126970d0dfb62c64022f37b10fb65328ceb8282d56afc10457daadf9144fb306599b420c3787b5d388ea5eb48d997873a5c0316a71564132fa3c08122f85948c926b98e5074a2f048865ccd58cf6e3afc55b59b382ff03df30d63fa09f1622f3f62663e0ff5203c370fb2019e5caa9eeba9d29b17470ed"
+);
+
+const INPUT_LE_G2_SUB_WORST_CASE: &[u8] = &hex!(
+    "d360b580f051206e7d62e9587554ba8eb635b8f89aa77488a54ed0523e0eb725a505a0e5c737afaab919408650a76901b9dc282f7b2c2f437e922e0340546dc8bc2c8f2951d0940dd75aa8752428829535a2a33c7eae55c7948ed5ad8d01bd0373082ecc225624f2ab9c7bae0fa9fc5a0641d384bb718245899fb469f4531adaa1d4b2bc2b97a7b0c4edae550af59a11890958ef99d1e989c93022e13fbdd0003795cb319dc72cd7caf32e932f706b5bed7a3f538332e22e73b9dd555fd3a307c1af562d28b8ce2853b60fb1372f02642cb6dfd0706912e12969732dd7d8a88195b16deecc5e6fb9670faec1c2534707b8282ec461b564cae681b9cb391fc04d7de34a8497bb7a3bf335bd85bac73ede14e180b20c94beb20a20a95796677703ed7074b1299dbaeea9cae51920fb70c30352ffe06326f6f322169fa03fd630df03ff82b3595bc5afe3f68cd5cc6588042f4a07e5986b928c94852f12083cfa324156716a31c0a57378998db45eea88d3b587370c429b5906b34f14f9adda5704"
+);
+
+const INPUT_BE_G2_MUL_WORST_CASE: &[u8] = &hex!(
+    "03bd018dadd58e94c755ae7e3ca3a2359582282475a85ad70d94d051298f2cbcc86d5440032e927e432f2c7b2f28dcb90169a750864019b9aaaf37c7e5a005a525b70e3e52d04ea58874a79af8b835b68eba547558e9627d6e2051f080b560d307a3d35f55ddb9732ee23283533f7aed5b6b702f932ef3cad72cc79d31cb953700d0bd3fe12230c989e9d199ef580989119af50a55aeedc4b0a7972bbcb2d4a1da1a53f469b49f89458271bb84d341065afca90fae7b9cabf2245622cc2e087373eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000"
+);
+
+const INPUT_LE_G2_MUL_WORST_CASE: &[u8] = &hex!(
+    "d360b580f051206e7d62e9587554ba8eb635b8f89aa77488a54ed0523e0eb725a505a0e5c737afaab919408650a76901b9dc282f7b2c2f437e922e0340546dc8bc2c8f2951d0940dd75aa8752428829535a2a33c7eae55c7948ed5ad8d01bd0373082ecc225624f2ab9c7bae0fa9fc5a0641d384bb718245899fb469f4531adaa1d4b2bc2b97a7b0c4edae550af59a11890958ef99d1e989c93022e13fbdd0003795cb319dc72cd7caf32e932f706b5bed7a3f538332e22e73b9dd555fd3a30700000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+);
+
+const INPUT_BE_G2_DECOMPRESS_WORST_CASE: &[u8] = &hex!(
+    "83bd018dadd58e94c755ae7e3ca3a2359582282475a85ad70d94d051298f2cbcc86d5440032e927e432f2c7b2f28dcb90169a750864019b9aaaf37c7e5a005a525b70e3e52d04ea58874a79af8b835b68eba547558e9627d6e2051f080b560d3"
+);
+
+const INPUT_LE_G2_DECOMPRESS_WORST_CASE: &[u8] = &hex!(
+    "d360b580f051206e7d62e9587554ba8eb635b8f89aa77488a54ed0523e0eb725a505a0e5c737afaab919408650a76901b9dc282f7b2c2f437e922e0340546dc8bc2c8f2951d0940dd75aa8752428829535a2a33c7eae55c7948ed5ad8d01bd83"
+);
+
+const INPUT_BE_G2_VALIDATE_WORST_CASE: &[u8] = &hex!(
+    "02298dc5b07ca647c4f87741130b540b7c2410f40bc644ffb5de3f85c6b116f09323fdd675774b9507e1898a5e32ae990a01305b6d86169d57048a21f8144f4a7706eadc687e81b2cd47bea2152ca6c467be4fdb4a7ce8038deede79b40e7d9a0e83c50a4e6f3cfb1333cea38add85a7ca08a351ca2e208f9282e6a224081fa16343263da17e1f37132209f399c5b915140a85dd41147c0346f6bae0719c2ad94a1893901e99ea3a493c57e1827bb65db214b403de77e52d050b17f46f8fe2f1"
+);
+
+const INPUT_LE_G2_VALIDATE_WORST_CASE: &[u8] = &hex!(
+    "9a7d0eb479deee8d03e87c4adb4fbe67c4a62c15a2be47cdb2817e68dcea06774a4f14f8218a04579d16866d5b30010a99ae325e8a89e107954b7775d6fd2393f016b1c6853fdeb5ff44c60bf410247c0b540b134177f8c447a67cb0c58d2902f1e28f6ff4170b052de577de03b414b25db67b82e1573c493aea991e9093184ad92a9c71e0baf646037c1441dd850a1415b9c599f3092213371f7ea13d264363a11f0824a2e682928f202eca51a308caa785dd8aa3ce3313fb3c6f4e0ac5830e"
+);
+
+const INPUT_BE_PAIRING_WORST_CASE: &[u8] = &hex!(
+    "023d85d0663f73ae66687d68dc64927752a9ca27de3b1118ba0aaeaa4a6ecb03907530f12c79f8bf2859b6c286f9a93315e8ef5d9d9d224906d22a13683e4419e2463b728ade94b1569e4210c0f6d50765062d57c92027148db03e245d52a57f19dbe2d5c1b709b81868241ce0a838a2ad95c5f3f85f9f619bc5f542f8ec518af5d15ee6b0bcabb81f926ea9b314afdf13df5d30b648ce7429bfc057710c5e936fcfe5330188512344fad45797d34dd278c0ee96353cafec4435eedd5bc0c08508fa6979ce323b0172f90cb94ed927011860bc41e3be0ff6db84427cc750432281f3903f57b291faec6ca7fc438eeb1012ec3ae72921a2fd455262e7e26f3c20f47c2f83a4fffce5d2a562b9e9f35cbb5a689217fa6a18c7e2337f59d4be0876"
+);
+
+const INPUT_LE_PAIRING_WORST_CASE: &[u8] = &hex!(
+    "33a9f986c2b65928bff8792cf130759003cb6e4aaaae0aba18113bde27caa952779264dc687d6866ae733f66d0853d027fa5525d243eb08d142720c9572d066507d5f6c010429e56b194de8a723b46e219443e68132ad20649229d9d5defe81585c0c05bddee3544ecaf3c3596eec078d24dd39757d4fa442351880133e5cf6f935e0c7157c0bf2974ce48b6305ddf13dfaf14b3a96e921fb8abbcb0e65ed1f58a51ecf842f5c59b619f5ff8f3c595ada238a8e01c246818b809b7c1d5e2db197608bed4597f33e2c7186afa1792685abb5cf3e9b962a5d2e5fcffa4832f7cf4203c6fe2e7625245fda22129e73aec1210eb8e43fca76cecfa91b2573f90f381224350c77c4284dbf60fbee341bc60180127d94eb90cf972013b32ce7969fa08"
+);
+
+// ---------------------------------------------------------------- constructors
+
+fn g1_point(bytes: &[u8]) -> PodG1Point {
+    assert_eq!(size_of::<PodG1Point>(), G1_POINT_SIZE);
+    PodG1Point(bytes.try_into().expect("G1 point must be 96 bytes"))
+}
+
+fn g2_point(bytes: &[u8]) -> PodG2Point {
+    assert_eq!(size_of::<PodG2Point>(), G2_POINT_SIZE);
+    PodG2Point(bytes.try_into().expect("G2 point must be 192 bytes"))
+}
+
+fn scalar(bytes: &[u8]) -> PodScalar {
+    PodScalar(bytes.try_into().expect("scalar must be 32 bytes"))
+}
+
+fn pick(le: bool, be_vec: &'static [u8], le_vec: &'static [u8]) -> &'static [u8] {
+    if le {
+        le_vec
+    } else {
+        be_vec
+    }
+}
+
+// ---------------------------------------------------------------- G1
+
+/// Two G1 points for `GROUP_OP_ADD`. Vector layout is `left || right`.
+pub fn g1_add_inputs(le: bool) -> (PodG1Point, PodG1Point) {
+    let v = pick(le, INPUT_BE_G1_ADD_WORST_CASE, INPUT_LE_G1_ADD_WORST_CASE);
+    let (l, r) = v.split_at(G1_POINT_SIZE);
+    (g1_point(l), g1_point(r))
+}
+
+/// Two G1 points for `GROUP_OP_SUB`.
+pub fn g1_sub_inputs(le: bool) -> (PodG1Point, PodG1Point) {
+    let v = pick(le, INPUT_BE_G1_SUB_WORST_CASE, INPUT_LE_G1_SUB_WORST_CASE);
+    let (l, r) = v.split_at(G1_POINT_SIZE);
+    (g1_point(l), g1_point(r))
+}
+
+/// Returned in **syscall argument order**: scalar first, point second.
+///
+/// The stored vector is `point || scalar`, matching the library function
+/// signature, but `SyscallCurveGroupOps` reads the scalar from
+/// `left_input_addr` and the point from `right_input_addr`. The swap happens
+/// here so no caller has to remember it.
+///
+/// The scalar is `r - 1`, the largest canonical value, so the multiplication
+/// runs its full ladder.
+pub fn g1_mul_inputs(le: bool) -> (PodScalar, PodG1Point) {
+    let v = pick(le, INPUT_BE_G1_MUL_WORST_CASE, INPUT_LE_G1_MUL_WORST_CASE);
+    let (point, s) = v.split_at(G1_POINT_SIZE);
+    (scalar(s), g1_point(point))
+}
+
+pub fn g1_decompress_input(le: bool) -> PodG1Compressed {
+    let v = pick(
+        le,
+        INPUT_BE_G1_DECOMPRESS_WORST_CASE,
+        INPUT_LE_G1_DECOMPRESS_WORST_CASE,
+    );
+    let pod = PodG1Compressed(v.try_into().expect("G1 compressed must be 48 bytes"));
+    assert!(
+        bls12_381_g1_decompress(Version::V0, &pod, endianness(le)).is_some(),
+        "G1 decompress vector rejected (le={le})"
+    );
+    pod
+}
+
+pub fn g1_validate_input(le: bool) -> PodG1Point {
+    let v = pick(
+        le,
+        INPUT_BE_G1_VALIDATE_WORST_CASE,
+        INPUT_LE_G1_VALIDATE_WORST_CASE,
+    );
+    let pod = g1_point(v);
+    assert!(
+        bls12_381_g1_point_validation(Version::V0, &pod, endianness(le)),
+        "G1 validate vector rejected (le={le})"
+    );
+    pod
+}
+
+// ---------------------------------------------------------------- G2
+
+pub fn g2_add_inputs(le: bool) -> (PodG2Point, PodG2Point) {
+    let v = pick(le, INPUT_BE_G2_ADD_WORST_CASE, INPUT_LE_G2_ADD_WORST_CASE);
+    let (l, r) = v.split_at(G2_POINT_SIZE);
+    (g2_point(l), g2_point(r))
+}
+
+pub fn g2_sub_inputs(le: bool) -> (PodG2Point, PodG2Point) {
+    let v = pick(le, INPUT_BE_G2_SUB_WORST_CASE, INPUT_LE_G2_SUB_WORST_CASE);
+    let (l, r) = v.split_at(G2_POINT_SIZE);
+    (g2_point(l), g2_point(r))
+}
+
+/// Syscall argument order: scalar first, point second. See `g1_mul_inputs`.
+pub fn g2_mul_inputs(le: bool) -> (PodScalar, PodG2Point) {
+    let v = pick(le, INPUT_BE_G2_MUL_WORST_CASE, INPUT_LE_G2_MUL_WORST_CASE);
+    let (point, s) = v.split_at(G2_POINT_SIZE);
+    (scalar(s), g2_point(point))
+}
+
+pub fn g2_decompress_input(le: bool) -> PodG2Compressed {
+    let v = pick(
+        le,
+        INPUT_BE_G2_DECOMPRESS_WORST_CASE,
+        INPUT_LE_G2_DECOMPRESS_WORST_CASE,
+    );
+    let pod = PodG2Compressed(v.try_into().expect("G2 compressed must be 96 bytes"));
+    assert!(
+        bls12_381_g2_decompress(Version::V0, &pod, endianness(le)).is_some(),
+        "G2 decompress vector rejected (le={le})"
+    );
+    pod
+}
+
+pub fn g2_validate_input(le: bool) -> PodG2Point {
+    let v = pick(
+        le,
+        INPUT_BE_G2_VALIDATE_WORST_CASE,
+        INPUT_LE_G2_VALIDATE_WORST_CASE,
+    );
+    let pod = g2_point(v);
+    assert!(
+        bls12_381_g2_point_validation(Version::V0, &pod, endianness(le)),
+        "G2 validate vector rejected (le={le})"
+    );
+    pod
+}
+
+// ---------------------------------------------------------------- pairing
+
+/// One `(G1, G2)` pair. The stored vector is `G1 (96) || G2 (192)`.
+pub fn pairing_pair(le: bool) -> (PodG1Point, PodG2Point) {
+    let v = pick(le, INPUT_BE_PAIRING_WORST_CASE, INPUT_LE_PAIRING_WORST_CASE);
+    let (g1, g2) = v.split_at(G1_POINT_SIZE);
+    (g1_point(g1), g2_point(g2))
+}
+
+/// `n` copies of the worst-case pair, as two parallel arrays.
+///
+/// Repeating one pair is what the curve crate's own bench does. The Miller loop
+/// cost per pair does not depend on the point values, so this measures the
+/// per-pair slope correctly.
+pub fn pairing_batch(n: usize, le: bool) -> (Vec<PodG1Point>, Vec<PodG2Point>) {
+    let (g1, g2) = pairing_pair(le);
+    (vec![g1; n], vec![g2; n])
+}

--- a/syscalls/benches/common/bn254.rs
+++ b/syscalls/benches/common/bn254.rs
@@ -1,0 +1,88 @@
+//! BN254 point encoding shared across the alt_bn128 bench targets.
+
+use {
+    ark_bn254::{Fq, Fr, G1Affine, G2Affine},
+    ark_ec::AffineRepr,
+    ark_ff::{BigInteger, PrimeField},
+    solana_bn254::versioned::{
+        alt_bn128_versioned_g2_addition, Endianness, VersionedG2Addition,
+        ALT_BN128_G1_POINT_SIZE, ALT_BN128_G2_POINT_SIZE,
+    },
+    std::sync::OnceLock,
+};
+
+pub fn endian(le: bool) -> Endianness {
+    if le {
+        Endianness::LE
+    } else {
+        Endianness::BE
+    }
+}
+
+pub fn fq_bytes(x: &Fq, le: bool) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let be = x.into_bigint().to_bytes_be();
+    out[32 - be.len()..].copy_from_slice(&be);
+    if le {
+        out.reverse();
+    }
+    out
+}
+
+pub fn fr_bytes(s: &Fr, le: bool) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let be = s.into_bigint().to_bytes_be();
+    out[32 - be.len()..].copy_from_slice(&be);
+    if le {
+        out.reverse();
+    }
+    out
+}
+
+pub fn g1_bytes(p: &G1Affine, le: bool) -> [u8; ALT_BN128_G1_POINT_SIZE] {
+    let mut out = [0u8; ALT_BN128_G1_POINT_SIZE];
+    out[..32].copy_from_slice(&fq_bytes(&p.x, le));
+    out[32..].copy_from_slice(&fq_bytes(&p.y, le));
+    out
+}
+
+pub fn g2_bytes_with(
+    p: &G2Affine,
+    le: bool,
+    c1_first: bool,
+) -> [u8; ALT_BN128_G2_POINT_SIZE] {
+    let parts = if c1_first {
+        [p.x.c1, p.x.c0, p.y.c1, p.y.c0]
+    } else {
+        [p.x.c0, p.x.c1, p.y.c0, p.y.c1]
+    };
+    let mut out = [0u8; ALT_BN128_G2_POINT_SIZE];
+    for (i, part) in parts.iter().enumerate() {
+        out[i * 32..(i + 1) * 32].copy_from_slice(&fq_bytes(part, le));
+    }
+    out
+}
+
+/// EIP-197 puts the imaginary component of each Fq2 first. Rather than assume
+/// solana-bn254 matches, probe it once per endianness by feeding the generator
+/// through G2 addition and seeing which ordering deserializes.
+pub fn g2_bytes(p: &G2Affine, le: bool) -> [u8; ALT_BN128_G2_POINT_SIZE] {
+    static BE_C1_FIRST: OnceLock<bool> = OnceLock::new();
+    static LE_C1_FIRST: OnceLock<bool> = OnceLock::new();
+
+    let cell = if le { &LE_C1_FIRST } else { &BE_C1_FIRST };
+    let c1_first = *cell.get_or_init(|| {
+        for candidate in [true, false] {
+            let g = g2_bytes_with(&G2Affine::generator(), le, candidate);
+            let mut input = [0u8; ALT_BN128_G2_POINT_SIZE * 2];
+            input[..ALT_BN128_G2_POINT_SIZE].copy_from_slice(&g);
+            input[ALT_BN128_G2_POINT_SIZE..].copy_from_slice(&g);
+            if alt_bn128_versioned_g2_addition(VersionedG2Addition::V0, &input, endian(le)).is_ok()
+            {
+                return candidate;
+            }
+        }
+        panic!("solana-bn254 rejected both G2 field orderings (le={le})");
+    });
+    g2_bytes_with(p, le, c1_first)
+}

--- a/syscalls/benches/common/mod.rs
+++ b/syscalls/benches/common/mod.rs
@@ -1,0 +1,128 @@
+//! Shared harness for the cryptographic-syscall CU pricing benches.
+//!
+//! Each bench target starts with:
+//!
+//! ```ignore
+//! #[macro_use]
+//! mod common;
+//! use common::*;
+//! ```
+
+#![allow(dead_code)]
+
+pub use {
+    criterion::{measurement::WallTime, BenchmarkGroup, Criterion, Throughput},
+    solana_account::AccountSharedData,
+    solana_program_runtime::with_mock_invoke_context_with_feature_set,
+    solana_pubkey::Pubkey,
+    solana_sbpf::{
+        memory_region::{MemoryMapping, MemoryRegion},
+        program::{BuiltinFunctionDefinition, SBPFVersion},
+        vm::{Config, ContextObject},
+    },
+    solana_sdk_ids::{bpf_loader, native_loader},
+    solana_svm_feature_set::SVMFeatureSet,
+};
+use std::{mem, slice, time::Duration};
+
+pub mod bls12_381;
+pub mod bn254;
+
+/// On-VM layout of `VmSlice<u8>`: a pointer and a length, both u64.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct VmSliceRaw {
+    pub ptr: u64,
+    pub len: u64,
+}
+
+/// Base virtual address of the `slot`-th memory region. Regions are placed one
+/// 4 GiB apart so they can never overlap regardless of how big you make them.
+pub const fn va(slot: u64) -> u64 {
+    (slot + 1) << 32
+}
+
+// Same helpers the crate's own test module defines. They live in `mod tests`,
+// so benches need their own copies.
+
+pub fn bytes_of<T>(val: &T) -> *const [u8] {
+    core::ptr::slice_from_raw_parts(slice::from_ref(val).as_ptr().cast(), mem::size_of::<T>())
+}
+
+pub fn bytes_of_mut<T>(val: &mut T) -> *mut [u8] {
+    core::ptr::slice_from_raw_parts_mut(
+        slice::from_mut(val).as_mut_ptr().cast(),
+        mem::size_of::<T>(),
+    )
+}
+
+pub fn bytes_of_slice<T>(val: &[T]) -> *const [u8] {
+    core::ptr::slice_from_raw_parts(
+        val.as_ptr().cast(),
+        val.len().wrapping_mul(mem::size_of::<T>()),
+    )
+}
+
+pub fn bytes_of_slice_mut<T>(val: &mut [T]) -> *mut [u8] {
+    core::ptr::slice_from_raw_parts_mut(
+        val.as_mut_ptr().cast(),
+        val.len().wrapping_mul(mem::size_of::<T>()),
+    )
+}
+
+/// Uniform criterion settings across every syscall bench, so numbers from
+/// different files are comparable.
+pub fn configure(group: &mut BenchmarkGroup<'_, WallTime>) {
+    group
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(10));
+}
+
+/// Build an `InvokeContext` with a pushed instruction frame.
+///
+/// This has to be a macro, not a function: `with_mock_invoke_context*!`
+/// declares `transaction_context` as a local and `InvokeContext` borrows it,
+/// so there is no way to return one out of a function.
+macro_rules! prepare_mockup {
+    ($invoke_context:ident, $features:expr $(,)?) => {
+        let loader_key = bpf_loader::id();
+        let program_key = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                loader_key,
+                AccountSharedData::new(0, 0, &native_loader::id()),
+            ),
+            (program_key, AccountSharedData::new(0, 0, &loader_key)),
+        ];
+        let feature_set = $features;
+        let feature_set = &feature_set;
+        with_mock_invoke_context_with_feature_set!(
+            $invoke_context,
+            transaction_context,
+            feature_set,
+            transaction_accounts
+        );
+        $invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(1, vec![], vec![])
+            .unwrap();
+        $invoke_context.push().unwrap();
+    };
+}
+
+/// Run the syscall once against a huge budget and return the CU it charged.
+///
+/// Also doubles as an input validator: if your test vector is malformed the
+/// syscall returns a non-zero status via the cheap error path, and you would
+/// otherwise silently benchmark the rejection instead of the crypto.
+macro_rules! charged_cu {
+    ($invoke_context:expr, $call:expr $(,)?) => {{
+        const PROBE_BUDGET: u64 = 1 << 48;
+        $invoke_context
+            .compute_meter
+            .mock_set_remaining(PROBE_BUDGET);
+        let status = ($call).expect("syscall returned Err during CU probe");
+        assert_eq!(status, 0, "syscall returned a failure status - check your test vector");
+        PROBE_BUDGET - ContextObject::get_remaining(&$invoke_context)
+    }};
+}

--- a/syscalls/benches/syscall_alt_bn128.rs
+++ b/syscalls/benches/syscall_alt_bn128.rs
@@ -1,0 +1,247 @@
+//! `sol_alt_bn128_group_op`: G1/G2 addition and multiplication, BE and LE.
+//!
+//! Each of these is flat-priced:
+//!   alt_bn128_g1_addition_cost, alt_bn128_g2_addition_cost,
+//!   alt_bn128_g1_multiplication_cost, alt_bn128_g2_multiplication_cost
+//!
+//! Flat pricing means the adversarial input is whatever is slowest, so the
+//! multiplication cases sweep scalar bit length rather than using a fixed one.
+//!
+//! Pairing and compression live in their own file: their cost models scale
+//! with input size and would muddy the fixed-cost comparison here.
+
+#[macro_use]
+mod common;
+
+use {
+    ark_bn254::{Fr, G1Affine, G1Projective, G2Affine, G2Projective},
+    ark_ec::{AffineRepr, CurveGroup},
+    ark_ff::PrimeField,
+    common::{*, bn254::*},
+    criterion::{criterion_group, criterion_main},
+    solana_bn254::versioned::{
+        alt_bn128_versioned_g1_addition, alt_bn128_versioned_g1_multiplication,
+        alt_bn128_versioned_g2_addition, alt_bn128_versioned_g2_multiplication, Endianness,
+        VersionedG1Addition, VersionedG1Multiplication, VersionedG2Addition,
+        VersionedG2Multiplication, ALT_BN128_G1_ADD_BE, ALT_BN128_G1_ADD_LE, ALT_BN128_G1_MUL_BE,
+        ALT_BN128_G1_MUL_LE, ALT_BN128_G1_POINT_SIZE, ALT_BN128_G2_ADD_BE, ALT_BN128_G2_ADD_LE,
+        ALT_BN128_G2_MUL_BE, ALT_BN128_G2_MUL_LE, ALT_BN128_G2_POINT_SIZE,
+    },
+    solana_syscalls::SyscallAltBn128,
+    std::hint::black_box,
+};
+
+const INPUT_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+
+// ------------------------------------------------------------ cases
+
+struct Case {
+    name: String,
+    group_op: u64,
+    input: Vec<u8>,
+    output_len: usize,
+    /// Layer A: the same operation with no VM around it.
+    primitive: Box<dyn Fn(&[u8])>,
+}
+
+fn build_cases() -> Vec<Case> {
+    let p1 = G1Affine::generator();
+    let p2 = (G1Projective::from(p1) * Fr::from(7u64)).into_affine();
+    let q1 = G2Affine::generator();
+    let q2 = (G2Projective::from(q1) * Fr::from(7u64)).into_affine();
+
+    // Flat price, so sweep the scalar. `r - 1` has full bit length and high
+    // Hamming weight; `2` is the cheap end. The gap bounds what a flat price
+    // has to cover.
+    let k_2pow253 = {
+        let mut bytes = [0u8; 32];
+        bytes[31] = 0x20; // bit 253
+        Fr::from_le_bytes_mod_order(&bytes)
+    };
+    let scalars: [(&str, Fr); 3] = [
+        ("k2", Fr::from(2u64)),
+        ("k_2pow253", k_2pow253),
+        ("k_rminus1", -Fr::from(1u64)),
+    ];
+
+    let mut cases = Vec::new();
+
+    for le in [false, true] {
+        let tag = if le { "le" } else { "be" };
+
+        // ---- G1 addition
+        let mut input = Vec::new();
+        input.extend_from_slice(&g1_bytes(&p1, le));
+        input.extend_from_slice(&g1_bytes(&p2, le));
+        cases.push(Case {
+            name: format!("g1_add_{tag}"),
+            group_op: if le {
+                ALT_BN128_G1_ADD_LE
+            } else {
+                ALT_BN128_G1_ADD_BE
+            },
+            input,
+            output_len: ALT_BN128_G1_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(
+                    alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, i, endian(le))
+                        .unwrap(),
+                );
+            }),
+        });
+
+        // ---- G2 addition
+        let mut input = Vec::new();
+        input.extend_from_slice(&g2_bytes(&q1, le));
+        input.extend_from_slice(&g2_bytes(&q2, le));
+        cases.push(Case {
+            name: format!("g2_add_{tag}"),
+            group_op: if le {
+                ALT_BN128_G2_ADD_LE
+            } else {
+                ALT_BN128_G2_ADD_BE
+            },
+            input,
+            output_len: ALT_BN128_G2_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(
+                    alt_bn128_versioned_g2_addition(VersionedG2Addition::V0, i, endian(le))
+                        .unwrap(),
+                );
+            }),
+        });
+
+        for (sname, scalar) in &scalars {
+            // ---- G1 multiplication
+            let mut input = Vec::new();
+            input.extend_from_slice(&g1_bytes(&p1, le));
+            input.extend_from_slice(&fr_bytes(scalar, le));
+            cases.push(Case {
+                name: format!("g1_mul_{tag}_{sname}"),
+                group_op: if le {
+                    ALT_BN128_G1_MUL_LE
+                } else {
+                    ALT_BN128_G1_MUL_BE
+                },
+                input,
+                output_len: ALT_BN128_G1_POINT_SIZE,
+                primitive: Box::new(move |i| {
+                    black_box(
+                        alt_bn128_versioned_g1_multiplication(
+                            VersionedG1Multiplication::V1,
+                            i,
+                            endian(le),
+                        )
+                        .unwrap(),
+                    );
+                }),
+            });
+
+            // ---- G2 multiplication
+            let mut input = Vec::new();
+            input.extend_from_slice(&g2_bytes(&q1, le));
+            input.extend_from_slice(&fr_bytes(scalar, le));
+            cases.push(Case {
+                name: format!("g2_mul_{tag}_{sname}"),
+                group_op: if le {
+                    ALT_BN128_G2_MUL_LE
+                } else {
+                    ALT_BN128_G2_MUL_BE
+                },
+                input,
+                output_len: ALT_BN128_G2_POINT_SIZE,
+                primitive: Box::new(move |i| {
+                    black_box(
+                        alt_bn128_versioned_g2_multiplication(
+                            VersionedG2Multiplication::V0,
+                            i,
+                            endian(le),
+                        )
+                        .unwrap(),
+                    );
+                }),
+            });
+        }
+    }
+
+    cases
+}
+
+// ------------------------------------------------------------ benches
+
+fn bench_case(c: &mut Criterion, case: &Case) {
+    let mut group = c.benchmark_group(format!("alt_bn128_{}", case.name));
+    configure(&mut group);
+
+    // Layer A
+    group.bench_function("primitive", |b| {
+        b.iter(|| (case.primitive)(black_box(case.input.as_slice())))
+    });
+    group.finish();
+
+    // Layer B
+    let mut result = vec![0u8; case.output_len];
+    let input_len = case.input.len() as u64;
+    let config = Config::default();
+
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of_slice(case.input.as_slice()), INPUT_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallAltBn128::rust(
+            &mut invoke_context,
+            case.group_op,
+            INPUT_VA,
+            input_len,
+            RESULT_VA,
+            0
+        )
+    );
+    eprintln!("alt_bn128 {} -> {cu} CU", case.name);
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let mut group = c.benchmark_group(format!("alt_bn128_{}", case.name));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallAltBn128::rust(
+                    &mut invoke_context,
+                    black_box(case.group_op),
+                    black_box(INPUT_VA),
+                    black_box(input_len),
+                    black_box(RESULT_VA),
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+fn bench_alt_bn128(c: &mut Criterion) {
+    for case in &build_cases() {
+        bench_case(c, case);
+    }
+}
+
+criterion_group!(benches, bench_alt_bn128);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_alt_bn128_compression.rs
+++ b/syscalls/benches/syscall_alt_bn128_compression.rs
@@ -1,0 +1,178 @@
+//! `sol_alt_bn128_compression`: G1/G2 compress and decompress, BE and LE.
+//!
+//! Flat-priced: syscall_base_cost + alt_bn128_g{1,2}_{compress,decompress}.
+//!
+//! Compression is a serialize plus a sign bit. Decompression solves y from x,
+//! which is a square root in Fq (G1) or Fq2 (G2) and costs on the order of a
+//! modular exponentiation. The four constants should be very unequal.
+
+#[macro_use]
+mod common;
+
+use {
+    ark_bn254::{G1Affine, G2Affine},
+    ark_ec::AffineRepr,
+    common::{bn254::*, *},
+    criterion::{criterion_group, criterion_main},
+    solana_bn254::{
+        compression::prelude::{
+            alt_bn128_g1_compress_be, alt_bn128_g1_compress_le, alt_bn128_g1_decompress_be,
+            alt_bn128_g1_decompress_le, alt_bn128_g2_compress_be, alt_bn128_g2_compress_le,
+            alt_bn128_g2_decompress_be, alt_bn128_g2_decompress_le,
+            ALT_BN128_G1_COMPRESSED_POINT_SIZE, ALT_BN128_G1_COMPRESS_BE,
+            ALT_BN128_G1_COMPRESS_LE, ALT_BN128_G1_DECOMPRESS_BE, ALT_BN128_G1_DECOMPRESS_LE,
+            ALT_BN128_G2_COMPRESSED_POINT_SIZE, ALT_BN128_G2_COMPRESS_BE,
+            ALT_BN128_G2_COMPRESS_LE, ALT_BN128_G2_DECOMPRESS_BE, ALT_BN128_G2_DECOMPRESS_LE,
+        },
+        versioned::{ALT_BN128_G1_POINT_SIZE, ALT_BN128_G2_POINT_SIZE},
+    },
+    solana_syscalls::SyscallAltBn128Compression,
+    std::hint::black_box,
+};
+
+const INPUT_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+
+struct Case {
+    name: String,
+    op: u64,
+    input: Vec<u8>,
+    output_len: usize,
+    primitive: Box<dyn Fn(&[u8])>,
+}
+
+fn build_cases() -> Vec<Case> {
+    let mut cases = Vec::new();
+
+    for le in [false, true] {
+        let tag = if le { "le" } else { "be" };
+
+        let g1_full = g1_bytes(&G1Affine::generator(), le).to_vec();
+        let g2_full = g2_bytes(&G2Affine::generator(), le).to_vec();
+
+        // Derive the compressed forms by round-tripping through the library
+        // rather than guessing the flag encoding.
+        let g1_comp = if le {
+            alt_bn128_g1_compress_le(&g1_full).unwrap().to_vec()
+        } else {
+            alt_bn128_g1_compress_be(&g1_full).unwrap().to_vec()
+        };
+        let g2_comp = if le {
+            alt_bn128_g2_compress_le(&g2_full).unwrap().to_vec()
+        } else {
+            alt_bn128_g2_compress_be(&g2_full).unwrap().to_vec()
+        };
+
+        cases.push(Case {
+            name: format!("g1_compress_{tag}"),
+            op: if le { ALT_BN128_G1_COMPRESS_LE } else { ALT_BN128_G1_COMPRESS_BE },
+            input: g1_full.clone(),
+            output_len: ALT_BN128_G1_COMPRESSED_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(if le { alt_bn128_g1_compress_le(i) } else { alt_bn128_g1_compress_be(i) }.unwrap());
+            }),
+        });
+        cases.push(Case {
+            name: format!("g1_decompress_{tag}"),
+            op: if le { ALT_BN128_G1_DECOMPRESS_LE } else { ALT_BN128_G1_DECOMPRESS_BE },
+            input: g1_comp,
+            output_len: ALT_BN128_G1_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(if le { alt_bn128_g1_decompress_le(i) } else { alt_bn128_g1_decompress_be(i) }.unwrap());
+            }),
+        });
+        cases.push(Case {
+            name: format!("g2_compress_{tag}"),
+            op: if le { ALT_BN128_G2_COMPRESS_LE } else { ALT_BN128_G2_COMPRESS_BE },
+            input: g2_full.clone(),
+            output_len: ALT_BN128_G2_COMPRESSED_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(if le { alt_bn128_g2_compress_le(i) } else { alt_bn128_g2_compress_be(i) }.unwrap());
+            }),
+        });
+        cases.push(Case {
+            name: format!("g2_decompress_{tag}"),
+            op: if le { ALT_BN128_G2_DECOMPRESS_LE } else { ALT_BN128_G2_DECOMPRESS_BE },
+            input: g2_comp,
+            output_len: ALT_BN128_G2_POINT_SIZE,
+            primitive: Box::new(move |i| {
+                black_box(if le { alt_bn128_g2_decompress_le(i) } else { alt_bn128_g2_decompress_be(i) }.unwrap());
+            }),
+        });
+    }
+
+    cases
+}
+
+fn bench_case(c: &mut Criterion, case: &Case) {
+    let mut group = c.benchmark_group(format!("alt_bn128_{}", case.name));
+    configure(&mut group);
+    group.bench_function("primitive", |b| {
+        b.iter(|| (case.primitive)(black_box(case.input.as_slice())))
+    });
+    group.finish();
+
+    let mut result = vec![0u8; case.output_len];
+    let input_len = case.input.len() as u64;
+    let config = Config::default();
+
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of_slice(case.input.as_slice()), INPUT_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallAltBn128Compression::rust(
+            &mut invoke_context,
+            case.op,
+            INPUT_VA,
+            input_len,
+            RESULT_VA,
+            0
+        )
+    );
+    eprintln!("alt_bn128 {} -> {cu} CU", case.name);
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let mut group = c.benchmark_group(format!("alt_bn128_{}", case.name));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallAltBn128Compression::rust(
+                    &mut invoke_context,
+                    black_box(case.op),
+                    black_box(INPUT_VA),
+                    black_box(input_len),
+                    black_box(RESULT_VA),
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+fn bench_compression(c: &mut Criterion) {
+    for case in &build_cases() {
+        bench_case(c, case);
+    }
+}
+
+criterion_group!(benches, bench_compression);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_alt_bn128_pairing.rs
+++ b/syscalls/benches/syscall_alt_bn128_pairing.rs
@@ -1,0 +1,141 @@
+//! `sol_alt_bn128_group_op`, pairing variants.
+//!
+//! Unlike the flat-priced group ops, pairing has a two-term model:
+//!
+//!   one_pair_cost_first
+//!     + one_pair_cost_other * (n - 1)
+//!     + sha256_base_cost + input_size + ALT_BN128_PAIRING_OUTPUT_SIZE
+//!
+//! The structural claim is that the marginal pair costs less than the first,
+//! because the final exponentiation runs once while the Miller loop runs per
+//! pair. This file measures whether `one_pair_cost_other` matches that slope.
+
+#[macro_use]
+mod common;
+
+use {
+    ark_bn254::{Fr, G1Affine, G1Projective, G2Affine},
+    ark_ec::{CurveGroup, AffineRepr},
+    common::{bn254::*, *},
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_bn254::versioned::{
+        alt_bn128_versioned_pairing, VersionedPairing, ALT_BN128_PAIRING_BE,
+        ALT_BN128_PAIRING_LE, ALT_BN128_PAIRING_OUTPUT_SIZE,
+    },
+    solana_syscalls::SyscallAltBn128,
+    std::hint::black_box,
+};
+
+const INPUT_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+
+/// 4 is a Groth16 verification. 112 is roughly what fits in a 1.4M CU
+/// transaction, so it bounds what the price has to cover.
+const PAIR_COUNTS: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 112];
+
+/// `n` distinct non-identity pairs. Distinct points so no implementation can
+/// dedupe, non-identity so the Miller loop never short-circuits.
+fn pairing_input(n: usize, le: bool) -> Vec<u8> {
+    let g1 = G1Affine::generator();
+    let g2 = G2Affine::generator();
+    let mut out = Vec::new();
+    for i in 0..n {
+        let p = (G1Projective::from(g1) * Fr::from(i as u64 + 1)).into_affine();
+        out.extend_from_slice(&g1_bytes(&p, le));
+        out.extend_from_slice(&g2_bytes(&g2, le));
+    }
+    out
+}
+
+fn bench_pairing(c: &mut Criterion) {
+    for le in [false, true] {
+        let tag = if le { "le" } else { "be" };
+        let group_op = if le {
+            ALT_BN128_PAIRING_LE
+        } else {
+            ALT_BN128_PAIRING_BE
+        };
+
+        // ---- Layer A
+        let mut group = c.benchmark_group(format!("alt_bn128_pairing_{tag}"));
+        configure(&mut group);
+        for &n in PAIR_COUNTS {
+            let input = pairing_input(n, le);
+            group.bench_with_input(BenchmarkId::new("primitive", n), &n, |b, _| {
+                b.iter(|| {
+                    black_box(
+                        alt_bn128_versioned_pairing(
+                            VersionedPairing::V1,
+                            black_box(input.as_slice()),
+                            endian(le),
+                        )
+                        .unwrap(),
+                    )
+                })
+            });
+        }
+        group.finish();
+
+        // ---- Layer B
+        for &n in PAIR_COUNTS {
+            let input = pairing_input(n, le);
+            let input_len = input.len() as u64;
+            let mut result = [0u8; ALT_BN128_PAIRING_OUTPUT_SIZE];
+            let config = Config::default();
+
+            prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+            let memory_mapping = unsafe {
+                MemoryMapping::new(
+                    vec![
+                        MemoryRegion::new(bytes_of_slice(input.as_slice()), INPUT_VA),
+                        MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                    ],
+                    &config,
+                    SBPFVersion::V3,
+                )
+                .unwrap()
+            };
+            invoke_context
+                .memory_contexts
+                .mock_set_mapping_abi_v1(memory_mapping);
+
+            let cu = charged_cu!(
+                invoke_context,
+                SyscallAltBn128::rust(
+                    &mut invoke_context,
+                    group_op,
+                    INPUT_VA,
+                    input_len,
+                    RESULT_VA,
+                    0
+                )
+            );
+            eprintln!("alt_bn128 pairing_{tag} n={n} -> {cu} CU");
+
+            invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+            let mut group = c.benchmark_group(format!("alt_bn128_pairing_{tag}"));
+            configure(&mut group);
+            group.throughput(Throughput::Elements(cu));
+            group.bench_with_input(BenchmarkId::new("syscall", n), &n, |b, _| {
+                b.iter(|| {
+                    black_box(
+                        SyscallAltBn128::rust(
+                            &mut invoke_context,
+                            black_box(group_op),
+                            black_box(INPUT_VA),
+                            black_box(input_len),
+                            black_box(RESULT_VA),
+                            0,
+                        )
+                        .unwrap(),
+                    )
+                })
+            });
+            group.finish();
+        }
+    }
+}
+
+criterion_group!(benches, bench_pairing);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_big_mod_exp.rs
+++ b/syscalls/benches/syscall_big_mod_exp.rs
@@ -1,0 +1,298 @@
+//! `sol_big_mod_exp`, per SIMD-0529.
+//!
+//! Cost model (charged in two parts by the implementation: a flat base cost up
+//! front, then the operation cost after the exponent is read):
+//!
+//!   if decoded_exponent == 1:
+//!       complexity = mult_complexity(max(base_len, modulus_len))
+//!                    * MOD_REDUCTION_COMPLEXITY_FACTOR      (draft: 15)
+//!   else:
+//!       complexity = mult_complexity(max(base_len, modulus_len))
+//!                    * max(adjusted_exponent_length, MIN_EXPONENT_LENGTH)
+//!                                                            (draft: 75)
+//!   cost = BASE_CU + ceil(complexity / CU_DIVISOR)            (draft: 422, 189)
+//!
+//!   mult_complexity(x) = x^2                       for x <= 64
+//!                      = x^2/4 + 96x - 3072        for 64 < x <= 1024
+//!                      = x^2/16 + 480x - 199680    for x > 1024
+//!
+//! SIMD-0529 states these constants are preliminary and MUST be finalised from
+//! implementation benchmarks before activation, which is precisely what this
+//! file is for.
+//!
+//! Three sweeps, chosen to hit the discontinuities in the model:
+//!
+//!   1. Operand size, at fixed exponent. Brackets the mult_complexity
+//!      breakpoint at x = 64. Note that with MAX_BYTES = 512 the third branch
+//!      of mult_complexity is unreachable.
+//!   2. Exponent length, at fixed operand size. Brackets the
+//!      MIN_EXPONENT_LENGTH clamp at 75 bits, where the price is flat below and
+//!      linear above.
+//!   3. The reduction path (exponent == 1) across operand sizes. Charged as if
+//!      the exponent length were 15, versus a floor of 75 for every other
+//!      exponent, so exponent 1 costs roughly a fifth of exponent 2 while doing
+//!      strictly less work. Whether the real ratio is also 15/75 is the
+//!      question.
+//!
+//! All inputs are little-endian. The modulus must be odd and greater than 1.
+
+#[macro_use]
+mod common;
+
+use {
+    common::*,
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_syscalls::SyscallBigModExp,
+    std::hint::black_box,
+};
+
+const PARAMS_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+const BASE_VA: u64 = va(2);
+const EXPONENT_VA: u64 = va(3);
+const MODULUS_VA: u64 = va(4);
+
+/// `BIG_MOD_EXP_MAX_BYTES`.
+const MAX_BYTES: usize = 512;
+
+/// On-VM layout of `BigModExpParams`: six little-endian u64s, 48 bytes total.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ParamsRaw {
+    base: u64,
+    base_len: u64,
+    exponent: u64,
+    exponent_len: u64,
+    modulus: u64,
+    modulus_len: u64,
+}
+
+/// Deterministic filler. Not cryptographic; it only needs to be reproducible
+/// and free of the special structure that all-ones or all-zeros would have.
+fn pseudorandom(len: usize, seed: u64) -> Vec<u8> {
+    let mut s = seed | 1;
+    (0..len)
+        .map(|_| {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            (s >> 24) as u8
+        })
+        .collect()
+}
+
+/// A full-length odd modulus. Little-endian, so byte 0 is least significant
+/// (forced odd) and byte n-1 is most significant (top bit forced so the value
+/// really occupies n bytes).
+fn modulus(n: usize) -> Vec<u8> {
+    let mut m = pseudorandom(n, 0xA5A5_1234);
+    m[0] |= 1;
+    m[n - 1] |= 0x80;
+    m
+}
+
+fn base(n: usize) -> Vec<u8> {
+    pseudorandom(n, 0x5EED_0001)
+}
+
+/// An exponent whose EIP-198 adjusted length is exactly `bits`.
+///
+/// `adjusted_exponent_length` is `index * 8 + (7 - leading_zeros(byte))` for
+/// the most significant non-zero byte, indexed little-endian.
+fn exponent_with_adjusted_bits(bits: u64) -> Vec<u8> {
+    let index = (bits / 8) as usize;
+    let bit_in_byte = (bits % 8) as u32;
+    let mut e = pseudorandom(index + 1, 0xC0FF_EE01);
+    // Clear everything above the target bit, then set it.
+    e[index] = (1u8 << bit_in_byte) | (e[index] & ((1u8 << bit_in_byte) - 1));
+    e
+}
+
+/// Exponent of `len` bytes, all bits set. Adjusted length is `8 * len - 1`.
+fn exponent_full(len: usize) -> Vec<u8> {
+    vec![0xffu8; len]
+}
+
+struct Case {
+    name: String,
+    base: Vec<u8>,
+    exponent: Vec<u8>,
+    modulus: Vec<u8>,
+}
+
+fn build_cases() -> Vec<Case> {
+    let mut cases = Vec::new();
+
+    // --- 1. Operand size sweep, fixed 32-byte full exponent (adjusted 255).
+    for &n in &[32usize, 64, 65, 128, 256, 384, MAX_BYTES] {
+        cases.push(Case {
+            name: format!("size/n{n}"),
+            base: base(n),
+            exponent: exponent_full(32),
+            modulus: modulus(n),
+        });
+    }
+
+    // --- 2. Exponent sweep at fixed operand size.
+    const N: usize = 256;
+    // Below, at, and just above the MIN_EXPONENT_LENGTH clamp of 75 bits.
+    for bits in [1u64, 32, 74, 75, 76, 128] {
+        cases.push(Case {
+            name: format!("exp/bits{bits}"),
+            base: base(N),
+            exponent: exponent_with_adjusted_bits(bits),
+            modulus: modulus(N),
+        });
+    }
+    // Full-length exponents: adjusted length 8*len - 1.
+    for &len in &[32usize, 64, 128, 256, MAX_BYTES] {
+        cases.push(Case {
+            name: format!("exp/full{len}B"),
+            base: base(N),
+            exponent: exponent_full(len),
+            modulus: modulus(N),
+        });
+    }
+
+    // --- 3. Reduction path: decoded exponent exactly 1.
+    for &n in &[32usize, 64, 128, 256, MAX_BYTES] {
+        cases.push(Case {
+            name: format!("reduce/n{n}"),
+            base: base(n),
+            exponent: vec![1u8],
+            modulus: modulus(n),
+        });
+    }
+
+    cases
+}
+
+fn bench_case(c: &mut Criterion, case: &Case) {
+    let params = ParamsRaw {
+        base: BASE_VA,
+        base_len: case.base.len() as u64,
+        exponent: EXPONENT_VA,
+        exponent_len: case.exponent.len() as u64,
+        modulus: MODULUS_VA,
+        modulus_len: case.modulus.len() as u64,
+    };
+    let mut result = vec![0u8; case.modulus.len()];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of(&params), PARAMS_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+                MemoryRegion::new(bytes_of_slice(case.base.as_slice()), BASE_VA),
+                MemoryRegion::new(bytes_of_slice(case.exponent.as_slice()), EXPONENT_VA),
+                MemoryRegion::new(bytes_of_slice(case.modulus.as_slice()), MODULUS_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallBigModExp::rust(&mut invoke_context, PARAMS_VA, RESULT_VA, 0, 0, 0)
+    );
+    eprintln!(
+        "big_mod_exp {} (base={}B exp={}B mod={}B) -> {cu} CU",
+        case.name,
+        case.base.len(),
+        case.exponent.len(),
+        case.modulus.len()
+    );
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    // Group by sweep so criterion plots each one on its own axis.
+    let (group_name, id) = case.name.split_once('/').expect("name is group/id");
+    let mut group = c.benchmark_group(format!("big_mod_exp_{group_name}"));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function(BenchmarkId::new("syscall", id), |b| {
+        b.iter(|| {
+            black_box(
+                SyscallBigModExp::rust(
+                    &mut invoke_context,
+                    black_box(PARAMS_VA),
+                    black_box(RESULT_VA),
+                    0,
+                    0,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+/// Confirms the 512-byte limit is enforced on each length field.
+fn probe_length_cap() {
+    let n = MAX_BYTES + 1;
+    let b = base(n);
+    let e = exponent_full(32);
+    let m = modulus(n);
+    let params = ParamsRaw {
+        base: BASE_VA,
+        base_len: b.len() as u64,
+        exponent: EXPONENT_VA,
+        exponent_len: e.len() as u64,
+        modulus: MODULUS_VA,
+        modulus_len: m.len() as u64,
+    };
+    let mut result = vec![0u8; m.len()];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of(&params), PARAMS_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+                MemoryRegion::new(bytes_of_slice(b.as_slice()), BASE_VA),
+                MemoryRegion::new(bytes_of_slice(e.as_slice()), EXPONENT_VA),
+                MemoryRegion::new(bytes_of_slice(m.as_slice()), MODULUS_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let before = ContextObject::get_remaining(&invoke_context);
+    let outcome = SyscallBigModExp::rust(&mut invoke_context, PARAMS_VA, RESULT_VA, 0, 0, 0);
+    let charged = before - ContextObject::get_remaining(&invoke_context);
+    match outcome {
+        Err(_) => eprintln!(
+            "big_mod_exp length cap ENFORCED (n={n} rejected), charged {charged} CU on the \
+             reject path; SIMD-0529 says aborts before step 8 MUST NOT charge"
+        ),
+        Ok(status) => eprintln!(
+            "big_mod_exp length cap NOT ENFORCED: n={n} returned status {status}; \
+             SIMD-0529 requires a maximum of {MAX_BYTES}"
+        ),
+    }
+}
+
+fn bench_big_mod_exp(c: &mut Criterion) {
+    probe_length_cap();
+    for case in &build_cases() {
+        bench_case(c, case);
+    }
+}
+
+criterion_group!(benches, bench_big_mod_exp);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_bls12_381.rs
+++ b/syscalls/benches/syscall_bls12_381.rs
@@ -1,0 +1,279 @@
+//! BLS12-381 validation, decompression, and group operations.
+//!
+//! Covered here:
+//!   sol_curve_validate_point   -> bls12_381_g{1,2}_validate_cost
+//!   sol_curve_decompress       -> bls12_381_g{1,2}_decompress_cost
+//!   sol_curve_group_op add/sub/mul
+//!                              -> bls12_381_g{1,2}_{add,subtract,multiply}_cost
+//!
+//! All are flat-priced, so the inputs are the implementers' worst-case vectors
+//! (see `common/bls12_381.rs`): a flat price has to cover the slowest valid
+//! input, not an average one.
+//!
+//! Note that the syscall calls `*_addition_unchecked` and
+//! `*_subtraction_unchecked`, so add and sub perform no subgroup check.
+//! Validation is a separate, separately priced syscall. The honest comparison
+//! for a program that needs safety is therefore validate + op, not op alone.
+//!
+//! Layer A (the raw library functions on these same vectors) is deliberately
+//! not duplicated here: the curve crate already ships it as
+//! `cargo bench -p solana-bls12-381-syscall`. The difference between that and
+//! the numbers below is the syscall overhead.
+
+#[macro_use]
+mod common;
+
+use {
+    common::{bls12_381::*, *},
+    criterion::{criterion_group, criterion_main},
+    solana_define_syscall::curve_constants::{
+        BLS12_381_G1_BE, BLS12_381_G1_LE, BLS12_381_G2_BE, BLS12_381_G2_LE, GROUP_OP_ADD,
+        GROUP_OP_MUL, GROUP_OP_SUB,
+    },
+    solana_syscalls::{SyscallCurveDecompress, SyscallCurveGroupOps, SyscallCurvePointValidation},
+    std::hint::black_box,
+};
+
+const LEFT_VA: u64 = va(0);
+const RIGHT_VA: u64 = va(1);
+const RESULT_VA: u64 = va(2);
+
+fn curve_id(g2: bool, le: bool) -> u64 {
+    match (g2, le) {
+        (false, false) => BLS12_381_G1_BE,
+        (false, true) => BLS12_381_G1_LE,
+        (true, false) => BLS12_381_G2_BE,
+        (true, true) => BLS12_381_G2_LE,
+    }
+}
+
+fn tag(g2: bool, le: bool) -> String {
+    format!(
+        "{}_{}",
+        if g2 { "g2" } else { "g1" },
+        if le { "le" } else { "be" }
+    )
+}
+
+fn point_size(g2: bool) -> usize {
+    if g2 {
+        G2_POINT_SIZE
+    } else {
+        G1_POINT_SIZE
+    }
+}
+
+// ---------------------------------------------------------------- validate
+
+fn bench_validate(c: &mut Criterion, g2: bool, le: bool) {
+    let id = curve_id(g2, le);
+    let name = format!("bls12_381_{}_validate", tag(g2, le));
+
+    // Both are bound unconditionally so the chosen one outlives the mapping.
+    let p1 = g1_validate_input(le);
+    let p2 = g2_validate_input(le);
+    let point_bytes: *const [u8] = if g2 { bytes_of(&p2) } else { bytes_of(&p1) };
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![MemoryRegion::new(point_bytes, LEFT_VA)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallCurvePointValidation::rust(&mut invoke_context, id, LEFT_VA, 0, 0, 0)
+    );
+    eprintln!("{name} -> {cu} CU");
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(name);
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallCurvePointValidation::rust(
+                    &mut invoke_context,
+                    black_box(id),
+                    black_box(LEFT_VA),
+                    0,
+                    0,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------- decompress
+
+fn bench_decompress(c: &mut Criterion, g2: bool, le: bool) {
+    let id = curve_id(g2, le);
+    let name = format!("bls12_381_{}_decompress", tag(g2, le));
+
+    let c1 = g1_decompress_input(le);
+    let c2 = g2_decompress_input(le);
+    let input_bytes: *const [u8] = if g2 { bytes_of(&c2) } else { bytes_of(&c1) };
+    let mut result = vec![0u8; point_size(g2)];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(input_bytes, LEFT_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallCurveDecompress::rust(&mut invoke_context, id, LEFT_VA, RESULT_VA, 0, 0)
+    );
+    eprintln!("{name} -> {cu} CU");
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(name);
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallCurveDecompress::rust(
+                    &mut invoke_context,
+                    black_box(id),
+                    black_box(LEFT_VA),
+                    black_box(RESULT_VA),
+                    0,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------- group ops
+
+fn bench_group_op(c: &mut Criterion, g2: bool, le: bool, op: u64, op_name: &str) {
+    let id = curve_id(g2, le);
+    let name = format!("bls12_381_{}_{op_name}", tag(g2, le));
+
+    // Every fixture is bound before the selection below. Binding them inside
+    // match arms would drop the tuples at the end of each arm while the raw
+    // pointers taken from them are still live.
+    let g1_add = g1_add_inputs(le);
+    let g1_sub = g1_sub_inputs(le);
+    let g1_mul = g1_mul_inputs(le);
+    let g2_add = g2_add_inputs(le);
+    let g2_sub = g2_sub_inputs(le);
+    let g2_mul = g2_mul_inputs(le);
+
+    // For MUL the left operand is the scalar and the right is the point.
+    // For ADD and SUB both operands are points. The `*_mul_inputs` helpers
+    // already return (scalar, point) in syscall order.
+    let (left_bytes, right_bytes): (*const [u8], *const [u8]) = if op == GROUP_OP_ADD {
+        if g2 {
+            (bytes_of(&g2_add.0), bytes_of(&g2_add.1))
+        } else {
+            (bytes_of(&g1_add.0), bytes_of(&g1_add.1))
+        }
+    } else if op == GROUP_OP_SUB {
+        if g2 {
+            (bytes_of(&g2_sub.0), bytes_of(&g2_sub.1))
+        } else {
+            (bytes_of(&g1_sub.0), bytes_of(&g1_sub.1))
+        }
+    } else if g2 {
+        (bytes_of(&g2_mul.0), bytes_of(&g2_mul.1))
+    } else {
+        (bytes_of(&g1_mul.0), bytes_of(&g1_mul.1))
+    };
+
+    let mut result = vec![0u8; point_size(g2)];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(left_bytes, LEFT_VA),
+                MemoryRegion::new(right_bytes, RIGHT_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallCurveGroupOps::rust(&mut invoke_context, id, op, LEFT_VA, RIGHT_VA, RESULT_VA)
+    );
+    eprintln!("{name} -> {cu} CU");
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(name);
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallCurveGroupOps::rust(
+                    &mut invoke_context,
+                    black_box(id),
+                    black_box(op),
+                    black_box(LEFT_VA),
+                    black_box(RIGHT_VA),
+                    black_box(RESULT_VA),
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------- driver
+
+fn bench_bls12_381(c: &mut Criterion) {
+    for g2 in [false, true] {
+        for le in [false, true] {
+            bench_validate(c, g2, le);
+            bench_decompress(c, g2, le);
+            for (op, op_name) in [
+                (GROUP_OP_ADD, "add"),
+                (GROUP_OP_SUB, "sub"),
+                (GROUP_OP_MUL, "mul"),
+            ] {
+                bench_group_op(c, g2, le, op, op_name);
+            }
+        }
+    }
+}
+
+criterion_group!(benches, bench_bls12_381);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_bls12_381_pairing.rs
+++ b/syscalls/benches/syscall_bls12_381_pairing.rs
@@ -1,0 +1,217 @@
+//! `sol_curve_pairing_map` for BLS12-381.
+//!
+//! Cost model:
+//!   bls12_381_one_pair_cost + bls12_381_additional_pair_cost * (n - 1)
+//!
+//! Structurally, a multi-Miller loop runs once per pair while the final
+//! exponentiation runs once for the whole batch, so the marginal pair should be
+//! materially cheaper than the first. Whether `additional_pair_cost` reflects
+//! that ratio is the question this file answers.
+//!
+//! SIMD-0388 bounds `num_pairs` to 8, so every value in 0..=8 is measured
+//! rather than sampled. n=0 is included deliberately: the cost formula uses
+//! `saturating_sub(1)`, so a zero-pair call is still charged the full
+//! `one_pair_cost` while doing almost no work. It is the cleanest estimate of
+//! pure syscall overhead available for this call.
+//!
+//! n=1, 2, 4 and 8 match the curve crate's own `benches/bench_main.rs`, so the
+//! `primitive` numbers here can be cross-checked against
+//! `cargo bench -p solana-bls12-381-syscall`.
+
+#[macro_use]
+mod common;
+
+use {
+    common::{bls12_381::*, *},
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_bls12_381_syscall::{bls12_381_pairing_map, Version},
+    solana_define_syscall::curve_constants::{BLS12_381_BE, BLS12_381_LE},
+    solana_syscalls::SyscallCurvePairingMap,
+    std::hint::black_box,
+};
+
+const G1_VA: u64 = va(0);
+const G2_VA: u64 = va(1);
+const RESULT_VA: u64 = va(2);
+
+/// Maximum `num_pairs` per SIMD-0388.
+const MAX_PAIRS: usize = 8;
+
+fn pair_counts() -> Vec<usize> {
+    (0..=MAX_PAIRS).collect()
+}
+
+fn curve_id(le: bool) -> u64 {
+    if le {
+        BLS12_381_LE
+    } else {
+        BLS12_381_BE
+    }
+}
+
+fn tag(le: bool) -> &'static str {
+    if le {
+        "le"
+    } else {
+        "be"
+    }
+}
+
+// ---------------------------------------------------------------- layer A
+
+/// The pairing map itself: no VM, no translation, no metering.
+fn bench_primitive(c: &mut Criterion, le: bool) {
+    let mut group = c.benchmark_group(format!("bls12_381_pairing_{}", tag(le)));
+    configure(&mut group);
+
+    for n in pair_counts() {
+        // Always allocate at least one pair so the slice has a valid backing
+        // allocation, then take a logical view of length `n`.
+        let (g1, g2) = pairing_batch(n.max(1), le);
+        assert!(
+            bls12_381_pairing_map(Version::V0, &g1[..n], &g2[..n], endianness(le)).is_some(),
+            "pairing map failed at n={n} (le={le})"
+        );
+
+        group.bench_with_input(BenchmarkId::new("primitive", n), &n, |b, _| {
+            b.iter(|| {
+                black_box(bls12_381_pairing_map(
+                    Version::V0,
+                    black_box(&g1[..n]),
+                    black_box(&g2[..n]),
+                    endianness(le),
+                ))
+            })
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------- layer B
+
+/// The full syscall entry point, including memory translation and metering.
+fn bench_syscall(c: &mut Criterion, le: bool) {
+    let id = curve_id(le);
+
+    for n in pair_counts() {
+        let (g1, g2) = pairing_batch(n.max(1), le);
+        let mut result = vec![0u8; GT_SIZE];
+        let config = Config::default();
+
+        prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+        let memory_mapping = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(bytes_of_slice(g1.as_slice()), G1_VA),
+                    MemoryRegion::new(bytes_of_slice(g2.as_slice()), G2_VA),
+                    MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping_abi_v1(memory_mapping);
+
+        let cu = charged_cu!(
+            invoke_context,
+            SyscallCurvePairingMap::rust(
+                &mut invoke_context,
+                id,
+                n as u64,
+                G1_VA,
+                G2_VA,
+                RESULT_VA
+            )
+        );
+        eprintln!("bls12_381 pairing_{} n={n} -> {cu} CU", tag(le));
+
+        invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+        let mut group = c.benchmark_group(format!("bls12_381_pairing_{}", tag(le)));
+        configure(&mut group);
+        group.throughput(Throughput::Elements(cu));
+        group.bench_with_input(BenchmarkId::new("syscall", n), &n, |b, _| {
+            b.iter(|| {
+                black_box(
+                    SyscallCurvePairingMap::rust(
+                        &mut invoke_context,
+                        black_box(id),
+                        black_box(n as u64),
+                        black_box(G1_VA),
+                        black_box(G2_VA),
+                        black_box(RESULT_VA),
+                    )
+                    .unwrap(),
+                )
+            })
+        });
+        group.finish();
+    }
+}
+
+// ---------------------------------------------------------------- conformance
+
+/// Reports whether the implementation enforces the SIMD-0388 cap of 8.
+///
+/// Not a benchmark: it runs once and prints. Deliberately non-fatal, because
+/// the answer is the point. If the cap is not enforced, that is a
+/// spec/implementation divergence rather than a pricing issue, and other
+/// clients that do enforce it would reject a transaction agave accepts.
+fn probe_pair_cap(le: bool) {
+    let over = MAX_PAIRS + 1;
+    let (g1, g2) = pairing_batch(over, le);
+    let mut result = vec![0u8; GT_SIZE];
+    let config = Config::default();
+    let id = curve_id(le);
+
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of_slice(g1.as_slice()), G1_VA),
+                MemoryRegion::new(bytes_of_slice(g2.as_slice()), G2_VA),
+                MemoryRegion::new(bytes_of_slice_mut(result.as_mut_slice()), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let outcome = SyscallCurvePairingMap::rust(
+        &mut invoke_context,
+        id,
+        over as u64,
+        G1_VA,
+        G2_VA,
+        RESULT_VA,
+    );
+    match outcome {
+        Err(e) => eprintln!("pairing cap ENFORCED ({}): n={over} rejected: {e}", tag(le)),
+        Ok(status) => eprintln!(
+            "pairing cap NOT ENFORCED ({}): n={over} returned status {status}; \
+             SIMD-0388 requires a maximum of {MAX_PAIRS}",
+            tag(le)
+        ),
+    }
+}
+
+// ---------------------------------------------------------------- driver
+
+fn bench_pairing(c: &mut Criterion) {
+    for le in [false, true] {
+        probe_pair_cap(le);
+        bench_primitive(c, le);
+        bench_syscall(c, le);
+    }
+}
+
+criterion_group!(benches, bench_pairing);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_curve25519.rs
+++ b/syscalls/benches/syscall_curve25519.rs
@@ -1,0 +1,382 @@
+//! `sol_curve_validate_point`, `sol_curve_group_op`, `sol_curve_multiscalar_mul`
+//! for the Edwards and Ristretto representations of curve25519.
+//!
+//! Validation, add, sub and mul are flat-priced. MSM is two-term:
+//!   msm_base_cost + msm_incremental_cost * (n - 1)
+//!
+//! The interesting property here is that curve25519-dalek changes algorithm
+//! with n (Straus for small n, Pippenger above a threshold), while the price is
+//! strictly linear. A linear price cannot track a piecewise-linear cost, so the
+//! sweep below deliberately brackets the crossover.
+
+#[macro_use]
+mod common;
+
+use {
+    common::*,
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_curve25519::{
+        edwards::{self, PodEdwardsPoint},
+        ristretto::{self, PodRistrettoPoint},
+        scalar::PodScalar,
+    },
+    solana_define_syscall::curve_constants::{
+        CURVE25519_EDWARDS, CURVE25519_RISTRETTO, GROUP_OP_ADD, GROUP_OP_MUL, GROUP_OP_SUB,
+    },
+    solana_syscalls::{
+        SyscallCurveGroupOps, SyscallCurveMultiscalarMultiplication, SyscallCurvePointValidation,
+    },
+    std::hint::black_box,
+};
+
+const LEFT_VA: u64 = va(0);
+const RIGHT_VA: u64 = va(1);
+const RESULT_VA: u64 = va(2);
+const SCALARS_VA: u64 = va(3);
+const POINTS_VA: u64 = va(4);
+
+/// The syscall rejects anything above this.
+const MAX_MSM_POINTS: usize = 512;
+
+/// Brackets dalek's Straus/Pippenger crossover, which sits somewhere in the
+/// 100-200 range depending on version and backend.
+const MSM_COUNTS: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 190, 256, 384, 512];
+
+// ------------------------------------------------------------ curve abstraction
+
+trait Curve {
+    const ID: u64;
+    const NAME: &'static str;
+    type Point: Copy;
+
+    /// A known-valid point, taken verbatim from the crate's own tests.
+    fn base() -> Self::Point;
+
+    fn validate(p: &Self::Point) -> bool;
+    fn add(a: &Self::Point, b: &Self::Point) -> Option<Self::Point>;
+    fn sub(a: &Self::Point, b: &Self::Point) -> Option<Self::Point>;
+    fn mul(s: &PodScalar, p: &Self::Point) -> Option<Self::Point>;
+    fn msm(s: &[PodScalar], p: &[Self::Point]) -> Option<Self::Point>;
+}
+
+struct Edwards;
+impl Curve for Edwards {
+    const ID: u64 = CURVE25519_EDWARDS;
+    const NAME: &'static str = "edwards";
+    type Point = PodEdwardsPoint;
+
+    fn base() -> Self::Point {
+        PodEdwardsPoint([
+            201, 179, 241, 122, 180, 185, 239, 50, 183, 52, 221, 0, 153, 195, 43, 18, 22, 38, 187,
+            206, 179, 192, 210, 58, 53, 45, 150, 98, 89, 17, 158, 11,
+        ])
+    }
+    fn validate(p: &Self::Point) -> bool {
+        edwards::validate_edwards(p)
+    }
+    fn add(a: &Self::Point, b: &Self::Point) -> Option<Self::Point> {
+        edwards::add_edwards(a, b)
+    }
+    fn sub(a: &Self::Point, b: &Self::Point) -> Option<Self::Point> {
+        edwards::subtract_edwards(a, b)
+    }
+    fn mul(s: &PodScalar, p: &Self::Point) -> Option<Self::Point> {
+        edwards::multiply_edwards(s, p)
+    }
+    fn msm(s: &[PodScalar], p: &[Self::Point]) -> Option<Self::Point> {
+        edwards::multiscalar_multiply_edwards(s, p)
+    }
+}
+
+struct Ristretto;
+impl Curve for Ristretto {
+    const ID: u64 = CURVE25519_RISTRETTO;
+    const NAME: &'static str = "ristretto";
+    type Point = PodRistrettoPoint;
+
+    fn base() -> Self::Point {
+        PodRistrettoPoint([
+            226, 242, 174, 10, 106, 188, 78, 113, 168, 132, 169, 97, 197, 0, 81, 95, 88, 227, 11,
+            106, 165, 130, 221, 141, 182, 166, 89, 69, 224, 141, 45, 118,
+        ])
+    }
+    fn validate(p: &Self::Point) -> bool {
+        ristretto::validate_ristretto(p)
+    }
+    fn add(a: &Self::Point, b: &Self::Point) -> Option<Self::Point> {
+        ristretto::add_ristretto(a, b)
+    }
+    fn sub(a: &Self::Point, b: &Self::Point) -> Option<Self::Point> {
+        ristretto::subtract_ristretto(a, b)
+    }
+    fn mul(s: &PodScalar, p: &Self::Point) -> Option<Self::Point> {
+        ristretto::multiply_ristretto(s, p)
+    }
+    fn msm(s: &[PodScalar], p: &[Self::Point]) -> Option<Self::Point> {
+        ristretto::multiscalar_multiply_ristretto(s, p)
+    }
+}
+
+// ------------------------------------------------------------ input generation
+
+/// A canonical scalar (top byte 0x0f keeps it below the group order) with
+/// every other byte set, so the Hamming weight is near maximal. Flat-priced
+/// multiplication has to cover the slowest scalar, not an average one.
+fn heavy_scalar(seed: u8) -> PodScalar {
+    let mut bytes = [0xffu8; 32];
+    bytes[0] = seed;
+    bytes[31] = 0x0f;
+    PodScalar(bytes)
+}
+
+/// Distinct valid points, derived from the known-good base by scalar
+/// multiplication. Every one is a real curve point, so no bench ever ends up
+/// on the cheap rejection path.
+fn distinct_points<C: Curve>(n: usize) -> Vec<C::Point> {
+    let base = C::base();
+    (0..n)
+        .map(|i| {
+            let mut bytes = [0u8; 32];
+            bytes[..8].copy_from_slice(&(i as u64 + 2).to_le_bytes());
+            C::mul(&PodScalar(bytes), &base)
+                .unwrap_or_else(|| panic!("{} point derivation failed at {i}", C::NAME))
+        })
+        .collect()
+}
+
+fn heavy_scalars(n: usize) -> Vec<PodScalar> {
+    (0..n).map(|i| heavy_scalar(i as u8 | 1)).collect()
+}
+
+// ------------------------------------------------------------ validation
+
+fn bench_validate<C: Curve>(c: &mut Criterion) {
+    let point = C::base();
+    assert!(C::validate(&point), "{} base point is invalid", C::NAME);
+
+    let mut group = c.benchmark_group(format!("curve25519_{}_validate", C::NAME));
+    configure(&mut group);
+    group.bench_function("primitive", |b| {
+        b.iter(|| black_box(C::validate(black_box(&point))))
+    });
+    group.finish();
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![MemoryRegion::new(bytes_of(&point), LEFT_VA)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallCurvePointValidation::rust(&mut invoke_context, C::ID, LEFT_VA, 0, 0, 0)
+    );
+    eprintln!("curve25519 {}_validate -> {cu} CU", C::NAME);
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(format!("curve25519_{}_validate", C::NAME));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallCurvePointValidation::rust(
+                    &mut invoke_context,
+                    black_box(C::ID),
+                    black_box(LEFT_VA),
+                    0,
+                    0,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ------------------------------------------------------------ group ops
+
+fn bench_group_op<C: Curve>(c: &mut Criterion, op: u64, op_name: &str) {
+    let points = distinct_points::<C>(2);
+    let scalar = heavy_scalar(0x7f);
+
+    // For MUL the left operand is the scalar and the right is the point.
+    // For ADD and SUB both operands are points.
+    let left_bytes: *const [u8] = if op == GROUP_OP_MUL {
+        bytes_of(&scalar)
+    } else {
+        bytes_of(&points[0])
+    };
+
+    let mut result = [0u8; 32];
+    let config = Config::default();
+
+    let mut group = c.benchmark_group(format!("curve25519_{}_{op_name}", C::NAME));
+    configure(&mut group);
+    group.bench_function("primitive", |b| {
+        b.iter(|| match op {
+            GROUP_OP_ADD => black_box(C::add(black_box(&points[0]), black_box(&points[1])).is_some()),
+            GROUP_OP_SUB => black_box(C::sub(black_box(&points[0]), black_box(&points[1])).is_some()),
+            _ => black_box(C::mul(black_box(&scalar), black_box(&points[1])).is_some()),
+        })
+    });
+    group.finish();
+
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(left_bytes, LEFT_VA),
+                MemoryRegion::new(bytes_of(&points[1]), RIGHT_VA),
+                MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallCurveGroupOps::rust(
+            &mut invoke_context,
+            C::ID,
+            op,
+            LEFT_VA,
+            RIGHT_VA,
+            RESULT_VA
+        )
+    );
+    eprintln!("curve25519 {}_{op_name} -> {cu} CU", C::NAME);
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(format!("curve25519_{}_{op_name}", C::NAME));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallCurveGroupOps::rust(
+                    &mut invoke_context,
+                    black_box(C::ID),
+                    black_box(op),
+                    black_box(LEFT_VA),
+                    black_box(RIGHT_VA),
+                    black_box(RESULT_VA),
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ------------------------------------------------------------ MSM
+
+fn bench_msm<C: Curve>(c: &mut Criterion) {
+    // Layer A
+    let mut group = c.benchmark_group(format!("curve25519_{}_msm", C::NAME));
+    configure(&mut group);
+    for &n in MSM_COUNTS {
+        let scalars = heavy_scalars(n);
+        let points = distinct_points::<C>(n);
+        group.bench_with_input(BenchmarkId::new("primitive", n), &n, |b, _| {
+            b.iter(|| {
+                black_box(
+                    C::msm(black_box(scalars.as_slice()), black_box(points.as_slice())).unwrap(),
+                )
+            })
+        });
+    }
+    group.finish();
+
+    // Layer B
+    for &n in MSM_COUNTS {
+        assert!(n <= MAX_MSM_POINTS);
+        let scalars = heavy_scalars(n);
+        let points = distinct_points::<C>(n);
+        let mut result = [0u8; 32];
+        let config = Config::default();
+
+        prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+        let memory_mapping = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(bytes_of_slice(scalars.as_slice()), SCALARS_VA),
+                    MemoryRegion::new(bytes_of_slice(points.as_slice()), POINTS_VA),
+                    MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping_abi_v1(memory_mapping);
+
+        let cu = charged_cu!(
+            invoke_context,
+            SyscallCurveMultiscalarMultiplication::rust(
+                &mut invoke_context,
+                C::ID,
+                SCALARS_VA,
+                POINTS_VA,
+                n as u64,
+                RESULT_VA
+            )
+        );
+        eprintln!("curve25519 {}_msm n={n} -> {cu} CU", C::NAME);
+
+        invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+        let mut group = c.benchmark_group(format!("curve25519_{}_msm", C::NAME));
+        configure(&mut group);
+        group.throughput(Throughput::Elements(cu));
+        group.bench_with_input(BenchmarkId::new("syscall", n), &n, |b, _| {
+            b.iter(|| {
+                black_box(
+                    SyscallCurveMultiscalarMultiplication::rust(
+                        &mut invoke_context,
+                        black_box(C::ID),
+                        black_box(SCALARS_VA),
+                        black_box(POINTS_VA),
+                        black_box(n as u64),
+                        black_box(RESULT_VA),
+                    )
+                    .unwrap(),
+                )
+            })
+        });
+        group.finish();
+    }
+}
+
+// ------------------------------------------------------------ driver
+
+fn bench_curve<C: Curve>(c: &mut Criterion) {
+    bench_validate::<C>(c);
+    bench_group_op::<C>(c, GROUP_OP_ADD, "add");
+    bench_group_op::<C>(c, GROUP_OP_SUB, "sub");
+    bench_group_op::<C>(c, GROUP_OP_MUL, "mul");
+    bench_msm::<C>(c);
+}
+
+fn bench_curve25519(c: &mut Criterion) {
+    bench_curve::<Edwards>(c);
+    bench_curve::<Ristretto>(c);
+}
+
+criterion_group!(benches, bench_curve25519);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_hash.rs
+++ b/syscalls/benches/syscall_hash.rs
@@ -1,0 +1,264 @@
+//! `sol_sha256`, `sol_keccak256`, `sol_blake3`, `sol_sha512`.
+//!
+//! All four go through the same generic `SyscallHash<H>` and, critically, all
+//! four `HasherImpl` impls return `sha256_base_cost` / `sha256_byte_cost` /
+//! `sha256_max_slices`. They are priced identically. This file measures
+//! whether they cost the same.
+//!
+//! Charged CU for one call over `k` slices:
+//!     sha256_base_cost + sum_i max(mem_op_base_cost, sha256_byte_cost * (len_i / 2))
+//! Note the integer division by two: the "byte" cost is charged per 2 bytes.
+
+#[macro_use]
+mod common;
+
+use {
+    common::*,
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_program_runtime::execution_budget::SVMTransactionExecutionBudget,
+    solana_syscalls::{
+        Blake3Hasher, HasherImpl, Keccak256Hasher, Sha256Hasher, Sha512Hasher, SyscallHash,
+    },
+    std::hint::black_box,
+};
+
+const VALS_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+const DATA_VA: u64 = va(2);
+
+/// Result region is sized for the largest `H::Output` (Hash512 = 64 bytes).
+const RESULT_LEN: usize = 64;
+
+/// Per-slice byte lengths. Spans the region where the `mem_op_base_cost` floor
+/// binds, through sizes a real program would hash, into the tail.
+const LENGTHS: &[usize] = &[16, 32, 64, 128, 256, 1024, 4096, 16_384, 65_536];
+
+/// Slice counts, each slice deliberately small so per-slice overhead dominates.
+const COUNT_SWEEP_SLICE_LEN: usize = 16;
+
+// ---------------------------------------------------------------- layer A
+
+/// The raw hasher, no VM, no translation, no metering.
+fn primitive_by_length<H: HasherImpl>(c: &mut Criterion, name: &str) {
+    let mut group = c.benchmark_group(format!("hash_{name}"));
+    configure(&mut group);
+    for &len in LENGTHS {
+        let data = vec![0xa5u8; len];
+        group.throughput(Throughput::Bytes(len as u64));
+        group.bench_with_input(BenchmarkId::new("primitive", len), &len, |b, _| {
+            b.iter(|| {
+                let mut hasher = H::create_hasher();
+                hasher.hash(black_box(data.as_slice()));
+                black_box(hasher.result())
+            })
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------- layer B
+
+/// One slice, sweeping its length. Isolates the per-byte price.
+fn syscall_by_length<H: HasherImpl>(c: &mut Criterion, name: &str) {
+    let mut group = c.benchmark_group(format!("hash_{name}"));
+    configure(&mut group);
+
+    for &len in LENGTHS {
+        let data = vec![0xa5u8; len];
+        let slices = [VmSliceRaw {
+            ptr: DATA_VA,
+            len: len as u64,
+        }];
+        let mut result = [0u8; RESULT_LEN];
+        let config = Config::default();
+
+        prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+        let memory_mapping = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(bytes_of_slice(&slices), VALS_VA),
+                    MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                    MemoryRegion::new(bytes_of_slice(data.as_slice()), DATA_VA),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping_abi_v1(memory_mapping);
+
+        let cu = charged_cu!(
+            invoke_context,
+            SyscallHash::<H>::rust(&mut invoke_context, VALS_VA, 1, RESULT_VA, 0, 0)
+        );
+        eprintln!("{name} len={len} slices=1 -> {cu} CU");
+
+        invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+        group.throughput(Throughput::Elements(cu));
+        group.bench_with_input(BenchmarkId::new("syscall", len), &len, |b, _| {
+            b.iter(|| {
+                black_box(
+                    SyscallHash::<H>::rust(
+                        &mut invoke_context,
+                        black_box(VALS_VA),
+                        black_box(1),
+                        black_box(RESULT_VA),
+                        0,
+                        0,
+                    )
+                    .unwrap(),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Many small slices. Isolates per-slice translation overhead and the
+/// `mem_op_base_cost` floor.
+fn syscall_by_slice_count<H: HasherImpl>(c: &mut Criterion, name: &str) {
+    let max_slices = H::get_max_slices(&SVMTransactionExecutionBudget::default());
+    let counts: Vec<usize> = [1usize, 2, 4, 8, 16, 32]
+        .into_iter()
+        .filter(|&k| k as u64 <= max_slices)
+        .collect();
+
+    let mut group = c.benchmark_group(format!("hash_{name}"));
+    configure(&mut group);
+
+    for &count in &counts {
+        let data = vec![0xa5u8; COUNT_SWEEP_SLICE_LEN * count];
+        let slices: Vec<VmSliceRaw> = (0..count)
+            .map(|i| VmSliceRaw {
+                ptr: DATA_VA + (i * COUNT_SWEEP_SLICE_LEN) as u64,
+                len: COUNT_SWEEP_SLICE_LEN as u64,
+            })
+            .collect();
+        let mut result = [0u8; RESULT_LEN];
+        let config = Config::default();
+
+        prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+        let memory_mapping = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(bytes_of_slice(slices.as_slice()), VALS_VA),
+                    MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                    MemoryRegion::new(bytes_of_slice(data.as_slice()), DATA_VA),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
+        invoke_context
+            .memory_contexts
+            .mock_set_mapping_abi_v1(memory_mapping);
+
+        let cu = charged_cu!(
+            invoke_context,
+            SyscallHash::<H>::rust(
+                &mut invoke_context,
+                VALS_VA,
+                count as u64,
+                RESULT_VA,
+                0,
+                0
+            )
+        );
+        eprintln!("{name} len={COUNT_SWEEP_SLICE_LEN} slices={count} -> {cu} CU");
+
+        invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+        group.throughput(Throughput::Elements(cu));
+        group.bench_with_input(BenchmarkId::new("slices", count), &count, |b, _| {
+            b.iter(|| {
+                black_box(
+                    SyscallHash::<H>::rust(
+                        &mut invoke_context,
+                        black_box(VALS_VA),
+                        black_box(count as u64),
+                        black_box(RESULT_VA),
+                        0,
+                        0,
+                    )
+                    .unwrap(),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// `vals_len = 0`: no slice array translated, no bytes hashed. Whatever this
+/// costs is pure syscall overhead, and it is what `sha256_base_cost` has to cover.
+fn syscall_base_only<H: HasherImpl>(c: &mut Criterion, name: &str) {
+    let mut result = [0u8; RESULT_LEN];
+    let config = Config::default();
+
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA)],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallHash::<H>::rust(&mut invoke_context, VALS_VA, 0, RESULT_VA, 0, 0)
+    );
+    eprintln!("{name} empty -> {cu} CU");
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+    let mut group = c.benchmark_group(format!("hash_{name}"));
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("base_only", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallHash::<H>::rust(
+                    &mut invoke_context,
+                    black_box(VALS_VA),
+                    black_box(0),
+                    black_box(RESULT_VA),
+                    0,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------- driver
+
+macro_rules! for_each_hasher {
+    ($c:expr, $($hasher:ty => $name:literal),+ $(,)?) => {
+        $(
+            primitive_by_length::<$hasher>($c, $name);
+            syscall_base_only::<$hasher>($c, $name);
+            syscall_by_length::<$hasher>($c, $name);
+            syscall_by_slice_count::<$hasher>($c, $name);
+        )+
+    };
+}
+
+fn bench_hashes(c: &mut Criterion) {
+    for_each_hasher!(
+        c,
+        Sha256Hasher => "sha256",
+        Keccak256Hasher => "keccak256",
+        Blake3Hasher => "blake3",
+        Sha512Hasher => "sha512",
+    );
+}
+
+criterion_group!(benches, bench_hashes);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_poseidon.rs
+++ b/syscalls/benches/syscall_poseidon.rs
@@ -1,0 +1,184 @@
+//! `sol_poseidon`.
+//!
+//! Cost is `execution_cost.poseidon_cost(vals_len)`, which is quadratic in the
+//! number of inputs. The syscall hard-caps `vals_len` at 12, so the whole
+//! domain is measurable: this file sweeps every value from 1 to 12 and both
+//! endiannesses, giving 24 points against a two-parameter quadratic.
+//!
+//! Every input must be a canonical BN254 field element (32 bytes, less than r).
+//! A non-canonical input makes `poseidon::hashv` fail and the syscall return
+//! status 1 via the cheap error path, which `charged_cu!` catches.
+
+#[macro_use]
+mod common;
+
+use {
+    common::*,
+    criterion::{criterion_group, criterion_main, BenchmarkId},
+    solana_syscalls::SyscallPoseidon,
+    std::hint::black_box,
+};
+
+const VALS_VA: u64 = va(0);
+const RESULT_VA: u64 = va(1);
+const DATA_VA: u64 = va(2);
+
+/// The syscall rejects anything above this.
+const MAX_INPUTS: usize = 12;
+/// One BN254 field element.
+const FIELD_BYTES: usize = 32;
+/// `poseidon::HASH_BYTES`.
+const HASH_BYTES: usize = 32;
+
+/// `poseidon::Parameters::Bn254X5`, the only variant. The syscall does
+/// `u64::try_into()` and errors on anything else, so a wrong value here shows
+/// up immediately as a failed `charged_cu!` probe rather than silently
+/// benchmarking something else.
+const PARAM_BN254_X5: u64 = 0;
+/// `poseidon::Endianness::BigEndian` / `::LittleEndian`.
+const ENDIAN_BE: u64 = 0;
+const ENDIAN_LE: u64 = 1;
+
+/// `n` distinct canonical field elements.
+///
+/// Byte 0 and byte 31 are both zeroed so the value stays below the BN254 group
+/// order whichever endianness the syscall is told to use.
+fn field_elements(n: usize) -> Vec<u8> {
+    let mut out = vec![0u8; n * FIELD_BYTES];
+    for (i, chunk) in out.chunks_mut(FIELD_BYTES).enumerate() {
+        chunk.fill(0x11);
+        chunk[8..16].copy_from_slice(&(i as u64 + 1).to_le_bytes());
+        chunk[0] = 0;
+        chunk[FIELD_BYTES - 1] = 0;
+    }
+    out
+}
+
+fn bench_one(c: &mut Criterion, n: usize, le: bool) {
+    let endianness = if le { ENDIAN_LE } else { ENDIAN_BE };
+    let tag = if le { "le" } else { "be" };
+    let name = format!("poseidon_{tag}");
+
+    let data = field_elements(n);
+    let slices: Vec<VmSliceRaw> = (0..n)
+        .map(|i| VmSliceRaw {
+            ptr: DATA_VA + (i * FIELD_BYTES) as u64,
+            len: FIELD_BYTES as u64,
+        })
+        .collect();
+    let mut result = [0u8; HASH_BYTES];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of_slice(slices.as_slice()), VALS_VA),
+                MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                MemoryRegion::new(bytes_of_slice(data.as_slice()), DATA_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallPoseidon::rust(
+            &mut invoke_context,
+            PARAM_BN254_X5,
+            endianness,
+            VALS_VA,
+            n as u64,
+            RESULT_VA
+        )
+    );
+    eprintln!("poseidon_{tag} n={n} -> {cu} CU");
+
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let mut group = c.benchmark_group(name);
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_with_input(BenchmarkId::new("syscall", n), &n, |b, _| {
+        b.iter(|| {
+            black_box(
+                SyscallPoseidon::rust(
+                    &mut invoke_context,
+                    black_box(PARAM_BN254_X5),
+                    black_box(endianness),
+                    black_box(VALS_VA),
+                    black_box(n as u64),
+                    black_box(RESULT_VA),
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+/// Confirms the syscall rejects `vals_len = 13`. Not a benchmark: runs once
+/// and prints.
+fn probe_input_cap(le: bool) {
+    let over = MAX_INPUTS + 1;
+    let endianness = if le { ENDIAN_LE } else { ENDIAN_BE };
+    let data = field_elements(over);
+    let slices: Vec<VmSliceRaw> = (0..over)
+        .map(|i| VmSliceRaw {
+            ptr: DATA_VA + (i * FIELD_BYTES) as u64,
+            len: FIELD_BYTES as u64,
+        })
+        .collect();
+    let mut result = [0u8; HASH_BYTES];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of_slice(slices.as_slice()), VALS_VA),
+                MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+                MemoryRegion::new(bytes_of_slice(data.as_slice()), DATA_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let outcome = SyscallPoseidon::rust(
+        &mut invoke_context,
+        PARAM_BN254_X5,
+        endianness,
+        VALS_VA,
+        over as u64,
+        RESULT_VA,
+    );
+    match outcome {
+        Err(_) => eprintln!("poseidon input cap ENFORCED (vals_len={over} rejected)"),
+        Ok(status) => eprintln!(
+            "poseidon input cap NOT ENFORCED: vals_len={over} returned status {status}"
+        ),
+    }
+}
+
+fn bench_poseidon(c: &mut Criterion) {
+    probe_input_cap(false);
+    for le in [false, true] {
+        for n in 1..=MAX_INPUTS {
+            bench_one(c, n, le);
+        }
+    }
+}
+
+criterion_group!(benches, bench_poseidon);
+criterion_main!(benches);

--- a/syscalls/benches/syscall_secp256k1_recover.rs
+++ b/syscalls/benches/syscall_secp256k1_recover.rs
@@ -1,0 +1,136 @@
+//! Pilot bench: `sol_secp256k1_recover`.
+//!
+//! Flat-priced via `secp256k1_recover_cost`, one call, no generics. The point
+//! of this file is to prove the harness works, not to produce a result.
+
+#[macro_use]
+mod common;
+
+use {
+    common::*,
+    criterion::{criterion_group, criterion_main},
+    solana_syscalls::SyscallSecp256k1Recover,
+    std::hint::black_box,
+};
+
+const HASH_VA: u64 = va(0);
+const SIGNATURE_VA: u64 = va(1);
+const RESULT_VA: u64 = va(2);
+
+/// Build a signature that `libsecp256k1::recover` accepts, without needing the
+/// `hmac` feature that signing requires.
+///
+/// Recovery does identical work whether or not the signature came from a real
+/// key: parse `r` and `v` into a curve point `R`, then compute `r⁻¹(sR - eG)`.
+/// About half of all candidate `r` values are valid x-coordinates, so this
+/// lands within a couple of iterations.
+fn valid_vector() -> ([u8; 32], [u8; 64], u64) {
+    let message_hash = [0x11u8; 32];
+    let message = libsecp256k1::Message::parse(&message_hash);
+    let recovery_id = libsecp256k1::RecoveryId::parse(0).unwrap();
+
+    for seed in 0u32..1024 {
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..28].fill(0x11);
+        sig_bytes[28..32].copy_from_slice(&seed.to_be_bytes());
+        sig_bytes[32..].fill(0x22);
+
+        let Ok(signature) = libsecp256k1::Signature::parse_standard_slice(&sig_bytes) else {
+            continue;
+        };
+        if libsecp256k1::recover(&message, &signature, &recovery_id).is_ok() {
+            return (message_hash, sig_bytes, 0);
+        }
+    }
+    panic!("no recoverable signature found in 1024 candidates");
+}
+
+/// Layer A: the raw primitive, with no VM, no translation, no metering.
+fn bench_primitive(c: &mut Criterion) {
+    let (hash, signature, recovery_id) = valid_vector();
+    let message = libsecp256k1::Message::parse(&hash);
+    let signature = libsecp256k1::Signature::parse_standard_slice(&signature).unwrap();
+    let recovery_id = libsecp256k1::RecoveryId::parse(recovery_id as u8).unwrap();
+
+    let mut group = c.benchmark_group("secp256k1_recover");
+    configure(&mut group);
+    group.bench_function("primitive", |b| {
+        b.iter(|| {
+            black_box(
+                libsecp256k1::recover(
+                    black_box(&message),
+                    black_box(&signature),
+                    black_box(&recovery_id),
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+/// Layer B: the full syscall entry point, including memory translation,
+/// the compute meter, and the feature-gate checks.
+fn bench_syscall(c: &mut Criterion) {
+    let (hash, signature, recovery_id) = valid_vector();
+    let mut result = [0u8; 64];
+
+    let config = Config::default();
+    prepare_mockup!(invoke_context, SVMFeatureSet::all_enabled());
+
+    let memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(bytes_of(&hash), HASH_VA),
+                MemoryRegion::new(bytes_of(&signature), SIGNATURE_VA),
+                MemoryRegion::new(bytes_of_mut(&mut result), RESULT_VA),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+        .unwrap()
+    };
+    invoke_context
+        .memory_contexts
+        .mock_set_mapping_abi_v1(memory_mapping);
+
+    let cu = charged_cu!(
+        invoke_context,
+        SyscallSecp256k1Recover::rust(
+            &mut invoke_context,
+            HASH_VA,
+            recovery_id,
+            SIGNATURE_VA,
+            RESULT_VA,
+            0,
+        )
+    );
+    eprintln!("secp256k1_recover charges {cu} CU");
+
+    // Set the budget once, outside the loop. Resetting per iteration would
+    // time the reset. u64::MAX cannot be drained by any realistic sample count.
+    invoke_context.compute_meter.mock_set_remaining(u64::MAX);
+
+    let mut group = c.benchmark_group("secp256k1_recover");
+    configure(&mut group);
+    group.throughput(Throughput::Elements(cu));
+    group.bench_function("syscall", |b| {
+        b.iter(|| {
+            black_box(
+                SyscallSecp256k1Recover::rust(
+                    black_box(&mut invoke_context),
+                    HASH_VA,
+                    recovery_id,
+                    SIGNATURE_VA,
+                    RESULT_VA,
+                    0,
+                )
+                .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_primitive, bench_syscall);
+criterion_main!(benches);

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -173,7 +173,7 @@ impl From<CpiError> for SyscallError {
 
 type Error = Box<dyn std::error::Error>;
 
-trait HasherImpl {
+pub trait HasherImpl {
     const NAME: &'static str;
     type Output: AsRef<[u8]>;
 
@@ -185,10 +185,10 @@ trait HasherImpl {
     fn get_max_slices(compute_budget: &SVMTransactionExecutionBudget) -> u64;
 }
 
-struct Sha256Hasher(Hasher);
-struct Blake3Hasher(blake3::Hasher);
-struct Keccak256Hasher(keccak::Hasher);
-struct Sha512Hasher(sha512::Hasher);
+pub struct Sha256Hasher(Hasher);
+pub struct Blake3Hasher(blake3::Hasher);
+pub struct Keccak256Hasher(keccak::Hasher);
+pub struct Sha512Hasher(sha512::Hasher);
 
 impl HasherImpl for Sha256Hasher {
     const NAME: &'static str = "Sha256";


### PR DESCRIPTION
Just adding benches for all the cryptographic syscalls for local testing.

## Syscall execution benchmarks (isolated, criterion median)

Hardware: AMD EPYC 9354P. Times are the `syscall` benchmark median (≈ pure computation, no VM/tx envelope).

### alt_bn128
| Operation | Current CU | Median | ns/CU |
|---|---:|---:|---:|
| g1_add | 334 | 5.5 µs | 16.5 |
| g2_add | 535 | 8.4 µs | 15.8 |
| g1_mul (worst-case scalar r−1) | 3,840 | 77.5 µs | 20.2 |
| g2_mul (worst-case scalar r−1) | 15,670 | 360.8 µs | 23.0 |
| g1_compress | 130 | 1.0 µs | 7.4 |
| g1_decompress | 498 | 8.1 µs | 16.3 |
| g2_compress | 186 | 2.0 µs | 10.7 |
| g2_decompress | 13,710 | 26.6 µs | 1.9 |
| pairing (n=1) | 36,673 | 808 µs | 22.0 |
| pairing (n=8) | 122,864 | 3.70 ms | 30.1 |
| pairing (n=112) | 1,403,416 | 45.1 ms | 32.1 |

### curve25519
| Operation | Current CU | Median | ns/CU |
|---|---:|---:|---:|
| edwards validate | 159 | 4.1 µs | 25.9 |
| edwards add | 473 | 12.3 µs | 26.0 |
| edwards mul | 2,177 | 40.5 µs | 18.6 |
| edwards msm (n=16) | 13,643 | 114 µs | 8.4 |
| edwards msm (n=512) | 389,611 | 2.94 ms | 7.6 |
| ristretto add | 521 | 13.1 µs | 25.2 |
| ristretto mul | 2,208 | 41.1 µs | 18.6 |
| ristretto msm (n=16) | 14,123 | 122 µs | 8.6 |

### bls12_381 (uniformly ~34 ns/CU)
| Operation | Current CU | Median | ns/CU |
|---|---:|---:|---:|
| g1 add | 128 | 4.4 µs | 34.2 |
| g1 mul | 4,627 | 157 µs | 34.0 |
| g1 validate | 1,565 | 52.9 µs | 33.8 |
| g1 decompress | 2,100 | 71.0 µs | 33.8 |
| g2 mul | 8,255 | 281 µs | 34.1 |
| g2 decompress | 3,050 | 103 µs | 33.9 |
| pairing (n=1) | 25,445 | 869 µs | 34.2 |
| pairing (n=8) | 116,606 | 3.97 ms | 34.1 |

### big_mod_exp
| Operation | Current CU | Median | ns/CU |
|---|---:|---:|---:|
| n=32 | 1,804 | 24.3 µs | 13.5 |
| n=64 | 5,949 | 52.4 µs | 8.8 |
| n=256 | 51,541 | 618 µs | 12.0 |
| full (256B) | 410,776 | 4.77 ms | 11.6 |
| reduce (n=512, exp=1) | 9,281 | 1.0 µs | 0.1 |

### hash (sha256 / sha512 / keccak256 / blake3)
Same CU cost formula for all four algorithms: 85 CU base + 0.5 CU/byte + 10 CU per slice beyond the first. Only wall-clock time differs by algorithm so ns/CU below is purely a measure of relative hash speed.

| Algorithm | len (bytes) | Current CU | Median | ns/CU |
|---|---:|---:|---:|---:|
| sha256 | 0 (base) | 85 | 91.5 ns | 1.08 |
| sha256 | 16 | 95 | 100.3 ns | 1.06 |
| sha256 | 128 | 149 | 170.0 ns | 1.14 |
| sha256 | 1,024 | 597 | 651.8 ns | 1.09 |
| sha256 | 16,384 | 8,277 | 8.90 µs | 1.08 |
| sha256 | 65,536 | 32,853 | 35.24 µs | 1.07 |
| sha512 | 0 (base) | 85 | 474.2 ns | 5.58 |
| sha512 | 16 | 95 | 488.9 ns | 5.15 |
| sha512 | 128 | 149 | 904.8 ns | 6.07 |
| sha512 | 1,024 | 597 | 3.75 µs | 6.28 |
| sha512 | 16,384 | 8,277 | 52.33 µs | 6.32 |
| sha512 | 65,536 | 32,853 | 206.54 µs | 6.29 |
| keccak256 | 0 (base) | 85 | 692.2 ns | 8.14 |
| keccak256 | 16 | 95 | 706.0 ns | 7.43 |
| keccak256 | 128 | 149 | 687.1 ns | 4.61 |
| keccak256 | 1,024 | 597 | 4.91 µs | 8.22 |
| keccak256 | 16,384 | 8,277 | 75.07 µs | 9.07 |
| keccak256 | 65,536 | 32,853 | 295.21 µs | 8.99 |
| blake3 | 0 (base) | 85 | 125.9 ns | 1.48 |
| blake3 | 16 | 95 | 147.3 ns | 1.55 |
| blake3 | 128 | 149 | 199.8 ns | 1.34 |
| blake3 | 1,024 | 597 | 1.08 µs | 1.80 |
| blake3 | 16,384 | 8,277 | 2.66 µs | 0.32 |
| blake3 | 65,536 | 32,853 | 9.97 µs | 0.30 |

### poseidon (n = number of field elements, big-endian)
| n | Current CU | Median | ns/CU |
|---:|---:|---:|---:|
| 1 | 603 | 22.21 µs | 36.8 |
| 2 | 786 | 33.15 µs | 42.2 |
| 3 | 1,091 | 46.03 µs | 42.2 |
| 4 | 1,518 | 65.62 µs | 43.2 |
| 5 | 2,067 | 85.18 µs | 41.2 |
| 6 | 2,738 | 112.25 µs | 41.0 |
| 7 | 3,531 | 139.74 µs | 39.6 |
| 8 | 4,446 | 168.12 µs | 37.8 |
| 9 | 5,483 | 195.04 µs | 35.6 |
| 10 | 6,642 | 247.77 µs | 37.3 |
| 11 | 7,923 | 268.08 µs | 33.8 |
| 12 | 9,326 | 330.54 µs | 35.4 |
