### PR TITLE
votor_transport: do not activate the client before migration

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -331,6 +331,7 @@ impl Tvu {
             votor_peer_list_sender,
             sharable_banks.clone(),
             votor_peer_overrides,
+            migration_status.clone(),
         );
         let (votor_egress, endpoint) = QuicDatagramEndpoint::spawn(
             &votor_rt_handle,

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -1,6 +1,6 @@
 use {
     agave_bls_sigverify::bls_sigverifier::NUM_SLOTS_FOR_VERIFY,
-    agave_votor_messages::reward_certificate::NUM_SLOTS_FOR_REWARD,
+    agave_votor_messages::{migration::MigrationStatus, reward_certificate::NUM_SLOTS_FOR_REWARD},
     agave_votor_transport::{PeerList, PeerListSender},
     arc_swap::ArcSwap,
     crossbeam_channel::{RecvTimeoutError, Sender, bounded},
@@ -37,18 +37,36 @@ pub struct PeerListUpdater {
     /// `None` resolves the address from gossip like any other peer, `Some` forces it,
     /// which local-cluster tests use to blackhole peers or point them at a spy listener.
     peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
+    /// Used to hold off connecting to peers until migration.
+    migration_status: Arc<MigrationStatus>,
 }
 
 impl PeerListUpdater {
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_tests(
+        sharable_banks: SharableBanks,
+        peer_list_sender: PeerListSender,
+        peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
+    ) -> Self {
+        Self::new(
+            sharable_banks,
+            peer_list_sender,
+            peer_overrides,
+            Arc::new(MigrationStatus::post_migration_status()),
+        )
+    }
+
     pub fn new(
         sharable_banks: SharableBanks,
         peer_list_sender: PeerListSender,
         peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
+        migration_status: Arc<MigrationStatus>,
     ) -> Self {
         Self {
             sharable_banks,
             peer_list_sender,
             peer_overrides,
+            migration_status,
         }
     }
 
@@ -102,7 +120,8 @@ impl PeerListUpdater {
             peers.extend(next.keys());
         }
 
-        let push_enabled = peers.contains(my_identity);
+        let push_enabled =
+            peers.contains(my_identity) && !self.migration_status.is_pre_feature_activation();
         let overrides = self.peer_overrides.load();
         let mut new_peers: HashMap<_, _> = cluster_info
             .query_contact_infos(peers.iter().chain(overrides.keys()), |node| {
@@ -148,6 +167,7 @@ impl PeerListService {
         peer_list: PeerListSender,
         sharable_banks: SharableBanks,
         peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
+        migration_status: Arc<MigrationStatus>,
     ) -> Self {
         let (key_updater_sender, key_updater_receiver) = bounded(16);
         let key_updater = Arc::new(PeerListKeyUpdater {
@@ -156,8 +176,12 @@ impl PeerListService {
         let thread_hdl = Builder::new()
             .name("solVotorPeerUpd".to_string())
             .spawn(move || {
-                let peer_list_updater =
-                    PeerListUpdater::new(sharable_banks, peer_list, peer_overrides);
+                let peer_list_updater = PeerListUpdater::new(
+                    sharable_banks,
+                    peer_list,
+                    peer_overrides,
+                    migration_status,
+                );
 
                 info!("AlpenglowPeerListService has started");
                 let mut my_identity = cluster_info.id();
@@ -356,7 +380,7 @@ mod tests {
         );
 
         let (sender, receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             sender,
             Arc::default(),
@@ -386,7 +410,7 @@ mod tests {
             create_bank_forks_and_cluster_info(num_nodes, num_zero_stake_nodes, slot_num);
 
         let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
             Arc::default(),
@@ -438,7 +462,7 @@ mod tests {
         // A zero-stake peer, which only an override can admit.
         let overridden = node_pubkeys[1];
         let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
             gossip_resolved_overrides([overridden]),
@@ -490,7 +514,7 @@ mod tests {
             "redundant_peer must not be self"
         );
         let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
             gossip_resolved_overrides([unstaked_peer, redundant_peer]),
@@ -527,7 +551,7 @@ mod tests {
 
         let absent = Pubkey::new_unique();
         let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
             gossip_resolved_overrides([absent]),
@@ -553,7 +577,7 @@ mod tests {
         let staked_peer = node_pubkeys[num_zero_stake_nodes + 1];
         let pinned = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65001);
         let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
-        let svc = PeerListUpdater::new(
+        let svc = PeerListUpdater::new_for_tests(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
             Arc::new(ArcSwap::from_pointee(HashMap::from([(

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -366,6 +366,7 @@ mod tests {
         agave_votor_messages::{
             certificate::{Certificate, CertificateType},
             consensus_message::{ConsensusMessage, VoteMessage},
+            migration::MigrationStatus,
             vote::Vote,
         },
         agave_votor_transport::{
@@ -607,6 +608,7 @@ mod tests {
                 spy_listener.0,
                 Some(spy_listener.1),
             )]))),
+            Arc::new(MigrationStatus::post_migration_status()),
         );
         (
             VotingService::new(


### PR DESCRIPTION
#### Problem

Votor-transport logs failed connection attempts. In 4.3 it is active by default, and will try to connect to other peers assuming they run 4.3 already (which they do not today). As a result we get CPU burn + a bunch of irrelevant spam in logs.

#### Summary of Changes

Prevent client from activating before alpenglow feature is activated.

#### Testing

CI, mds1. 