### PR TITLE
feat(deps): bump agave-scheduler-bindings from 5.0.0 to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,8 +294,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4729a9b34a80022313a748b9d47f0f1bcb74a96975e8d633f43cd4da8446260f"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,8 +293,9 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadd1abed9cc620c70f5ff2f517317426a57f77c405e9de8bf09a2b29e629ad6"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "128915a413a9903e31b75240649562205b92a388" }
+agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997" }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = "5.0.0"
+agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "128915a413a9903e31b75240649562205b92a388" }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "a53f0acb64369b7719785f97134b3c2f3d06870e" }
+agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "fba9fcadc3c6742f15e2aa81b7b78f5223c5d279" }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997" }
+agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "6ccb2739f74eb6a249510fedd6a21780b09db114" }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "fba9fcadc3c6742f15e2aa81b7b78f5223c5d279" }
+agave-scheduler-bindings = "6.0.0"
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features =
 agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "6ccb2739f74eb6a249510fedd6a21780b09db114" }
+agave-scheduler-bindings = { git = "https://github.com/anza-xyz/agave-sdk", rev = "a53f0acb64369b7719785f97134b3c2f3d06870e" }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-transaction-view = "6.1.0"

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -676,8 +676,13 @@ impl BankingStage {
 mod external {
     use {
         super::*,
-        crate::banking_stage::consume_worker::external::ExternalWorker,
-        agave_scheduling_utils::handshake::{AgaveSession, AgaveWorkerSession},
+        crate::banking_stage::{
+            consume_worker::external::ExternalWorker,
+            transaction_scheduler::check_worker::external::ExternalCheckWorker,
+        },
+        agave_scheduling_utils::handshake::{
+            AgaveCheckWorkerSession, AgaveSession, AgaveWorkerSession,
+        },
         tpu_to_pack::BankingPacketReceivers,
     };
 
@@ -688,8 +693,7 @@ mod external {
                 flags: _,
                 tpu_to_pack,
                 progress_tracker,
-                pack_to_check_worker: _,
-                check_worker_to_pack: _,
+                check_workers,
                 workers,
             }: AgaveSession,
         ) -> Result<Vec<JoinHandle<()>>, ()> {
@@ -702,7 +706,7 @@ mod external {
             assert!(workers.len() <= BankingStage::max_num_workers().get());
 
             // Spawn the external consumer workers.
-            let mut threads = Vec::with_capacity(workers.len() + 2);
+            let mut threads = Vec::with_capacity(workers.len() + check_workers.len() + 2);
             let mut worker_metrics = Vec::with_capacity(workers.len());
             for (
                 index,
@@ -725,7 +729,6 @@ mod external {
                     worker_to_pack,
                     allocator,
                     self.poh_recorder.read().unwrap().shared_leader_state(),
-                    self.bank_forks.read().unwrap().sharable_banks(),
                 );
 
                 worker_metrics.push(consume_worker.metrics_handle());
@@ -735,6 +738,37 @@ mod external {
                         .spawn(move || {
                             if let Err(err) = consume_worker.run(pack_to_worker) {
                                 error!("External consume worker error; err={err}");
+                            }
+                        })
+                        .unwrap(),
+                );
+            }
+
+            for (
+                index,
+                AgaveCheckWorkerSession {
+                    allocator,
+                    pack_to_check_worker,
+                    check_worker_to_pack,
+                },
+            ) in check_workers.into_iter().enumerate()
+            {
+                let id = index as u32;
+                let check_worker = ExternalCheckWorker::new(
+                    self.worker_exit_signal.clone(),
+                    pack_to_check_worker,
+                    check_worker_to_pack,
+                    allocator,
+                    self.poh_recorder.read().unwrap().shared_leader_state(),
+                    self.bank_forks.read().unwrap().sharable_banks(),
+                );
+
+                threads.push(
+                    Builder::new()
+                        .name(format!("solEChWorker{id:02}"))
+                        .spawn(move || {
+                            if let Err(err) = check_worker.run() {
+                                error!("External check worker error; err={err}");
                             }
                         })
                         .unwrap(),

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -688,6 +688,8 @@ mod external {
                 flags: _,
                 tpu_to_pack,
                 progress_tracker,
+                pack_to_check_worker: _,
+                check_worker_to_pack: _,
                 workers,
             }: AgaveSession,
         ) -> Result<Vec<JoinHandle<()>>, ()> {

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -190,40 +190,25 @@ pub(crate) mod external {
             },
         },
         agave_scheduler_bindings::{
-            MAX_TRANSACTIONS_PER_MESSAGE, PackToWorkerMessage, SharablePubkeys,
-            TransactionResponseRegion, WorkerToPackMessage,
-            pack_message_flags::{self, check_flags, execution_flags},
-            processed_codes,
-            worker_message_types::{
-                CheckResponse, ExecutionResponse, fee_payer_balance_flags, not_included_reasons,
-                parsing_and_sanitization_flags, resolve_flags, status_check_flags,
-            },
+            ExecutionResponseRegion, ExecutionWorkerToPackMessage, MAX_TRANSACTIONS_PER_MESSAGE,
+            PackToExecutionWorkerMessage, execution_message_flags,
+            worker_message_types::{ExecutionResponse, not_included_reasons},
         },
         agave_scheduling_utils::{
             error::transaction_error_to_not_included_reason,
-            responses_region::{allocate_check_response_region, execution_responses_from_iter},
+            responses_region::execution_responses_from_iter,
             transaction_ptr::{TransactionPtr, TransactionPtrBatch},
         },
         agave_transaction_view::{
-            resolved_transaction_view::ResolvedTransactionView, result::TransactionViewError,
-            sanitize::SanitizeConfig, transaction_data::TransactionData,
-            transaction_view::SanitizedTransactionView,
+            resolved_transaction_view::ResolvedTransactionView, sanitize::SanitizeConfig,
         },
         arrayvec::ArrayVec,
-        solana_account::ReadableAccount,
-        solana_clock::Slot,
         solana_cost_model::cost_model::CostModel,
-        solana_pubkey::Pubkey,
-        solana_runtime::{
-            bank::Bank,
-            bank_forks::{BankPair, SharableBanks},
-        },
+        solana_runtime::bank::Bank,
         solana_runtime_transaction::{
             runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
         },
-        solana_svm_transaction::svm_message::SVMMessage,
-        solana_transaction::TransactionError,
-        std::{num::NonZeroUsize, ptr::NonNull},
+        std::num::NonZeroUsize,
     };
 
     #[derive(Debug, Error)]
@@ -237,17 +222,14 @@ pub(crate) mod external {
     pub(crate) struct ExternalWorker {
         exit: Arc<AtomicBool>,
         consumer: Consumer,
-        sender: shaq::spsc::Producer<WorkerToPackMessage>,
+        sender: shaq::spsc::Producer<ExecutionWorkerToPackMessage>,
         allocator: rts_alloc::Allocator,
 
         shared_leader_state: SharedLeaderState,
-        sharable_banks: SharableBanks,
         metrics: Arc<ConsumeWorkerMetrics>,
     }
 
     type Tx = RuntimeTransaction<ResolvedTransactionView<TransactionPtr>>;
-    type TxView = SanitizedTransactionView<TransactionPtr>;
-
     enum IterationResult {
         ProcessedMessage,
         Idle,
@@ -258,10 +240,9 @@ pub(crate) mod external {
             id: u32,
             exit: Arc<AtomicBool>,
             consumer: Consumer,
-            sender: shaq::spsc::Producer<WorkerToPackMessage>,
+            sender: shaq::spsc::Producer<ExecutionWorkerToPackMessage>,
             allocator: rts_alloc::Allocator,
             shared_leader_state: SharedLeaderState,
-            sharable_banks: SharableBanks,
         ) -> Self {
             Self {
                 exit,
@@ -269,7 +250,6 @@ pub(crate) mod external {
                 sender,
                 allocator,
                 shared_leader_state,
-                sharable_banks,
                 metrics: Arc::new(ConsumeWorkerMetrics::new(id)),
             }
         }
@@ -280,7 +260,7 @@ pub(crate) mod external {
 
         pub fn run(
             mut self,
-            mut receiver: shaq::spsc::Consumer<PackToWorkerMessage>,
+            mut receiver: shaq::spsc::Consumer<PackToExecutionWorkerMessage>,
         ) -> Result<(), ExternalConsumeWorkerError> {
             let mut should_drain_executes = false;
             let mut did_work = false;
@@ -310,7 +290,7 @@ pub(crate) mod external {
 
         fn iterate(
             &mut self,
-            receiver: &mut shaq::spsc::Consumer<PackToWorkerMessage>,
+            receiver: &mut shaq::spsc::Consumer<PackToExecutionWorkerMessage>,
             should_drain_executes: &mut bool,
         ) -> Result<IterationResult, ExternalConsumeWorkerError> {
             self.allocator.clean_remote_frees();
@@ -332,7 +312,7 @@ pub(crate) mod external {
         /// Return true if fetching a bank for execution timed out.
         fn process_message(
             &mut self,
-            message: &PackToWorkerMessage,
+            message: &PackToExecutionWorkerMessage,
             should_drain_executes: bool,
         ) -> Result<bool, ExternalConsumeWorkerError> {
             if !Self::validate_message(message) {
@@ -349,17 +329,13 @@ pub(crate) mod external {
                 .num_messages_processed
                 .fetch_add(1, Ordering::Relaxed);
 
-            if message.flags & pack_message_flags::EXECUTE != 0 {
-                self.execute_batch(message, should_drain_executes)
-            } else {
-                self.check_batch(message).map(|()| false)
-            }
+            self.execute_batch(message, should_drain_executes)
         }
 
         /// Return true if fetching a bank for execution timed out.
         fn execute_batch(
             &mut self,
-            message: &PackToWorkerMessage,
+            message: &PackToExecutionWorkerMessage,
             should_drain_executes: bool,
         ) -> Result<bool, ExternalConsumeWorkerError> {
             if should_drain_executes {
@@ -407,8 +383,8 @@ pub(crate) mod external {
 
             // Enforce all or nothing on translation_results.
             let execution_flags = ExecutionFlags {
-                drop_on_failure: message.flags & execution_flags::DROP_ON_FAILURE != 0,
-                all_or_nothing: message.flags & execution_flags::ALL_OR_NOTHING != 0,
+                drop_on_failure: message.flags & execution_message_flags::DROP_ON_FAILURE != 0,
+                all_or_nothing: message.flags & execution_message_flags::ALL_OR_NOTHING != 0,
             };
             if execution_flags.all_or_nothing && translation_results.len() != transactions.len() {
                 self.send_execution_response(
@@ -457,106 +433,14 @@ pub(crate) mod external {
             Ok(false)
         }
 
-        fn check_batch(
-            &mut self,
-            message: &PackToWorkerMessage,
-        ) -> Result<(), ExternalConsumeWorkerError> {
-            let BankPair {
-                root_bank,
-                working_bank,
-            } = self.sharable_banks.load();
-            // Prefer the leader bank over the highest working fork when leader
-            let working_bank = active_leader_state(&self.shared_leader_state)
-                .and_then(|leader_state| leader_state.working_bank().cloned())
-                .unwrap_or(working_bank);
-
-            if working_bank.slot() > message.max_working_slot {
-                return self.return_unprocessed_message(
-                    message,
-                    processed_codes::MAX_WORKING_SLOT_EXCEEDED,
-                );
-            }
-
-            // SAFETY: Assumption that external scheduler does not pass messages with batch regions
-            //         not pointing to valid regions in the allocator.
-            let batch = unsafe {
-                TransactionPtrBatch::from_sharable_transaction_batch_region(
-                    &message.batch,
-                    &self.allocator,
-                )
-            };
-
-            // Allocate space for all responses.
-            let (responses_ptr, responses) = allocate_check_response_region(
-                &self.allocator,
-                usize::from(message.batch.num_transactions),
-            )
-            .ok_or(ExternalConsumeWorkerError::AllocationFailure)?;
-
-            // SAFETY: responses_ptr is sufficiently sized and aligned.
-            let (parsing_results, parsed_transactions, response_slice) = unsafe {
-                Self::parse_transactions_and_populate_initial_check_responses(
-                    message,
-                    &batch,
-                    responses_ptr,
-                )
-            };
-
-            // Check fee-payer if requested.
-            if message.flags & check_flags::LOAD_FEE_PAYER_BALANCE != 0 {
-                Self::check_load_fee_payer_balance(
-                    &parsing_results,
-                    &parsed_transactions,
-                    response_slice,
-                    &working_bank,
-                );
-            }
-
-            // Do resolving next since we (currently) need resolved transactions for status checks.
-            let (parsing_and_resolve_results, txs, max_ages) =
-                Self::translate_transaction_batch(&batch, &root_bank);
-
-            if message.flags & check_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
-                self.check_resolve_pubkeys(
-                    &parsing_results,
-                    &parsing_and_resolve_results,
-                    &txs,
-                    &max_ages,
-                    response_slice,
-                    root_bank.slot(),
-                )?;
-            }
-
-            if message.flags & check_flags::STATUS_CHECKS != 0 {
-                Self::check_status_checks(
-                    &parsing_and_resolve_results,
-                    &txs,
-                    response_slice,
-                    &working_bank,
-                );
-            }
-
-            let response = WorkerToPackMessage {
-                batch: message.batch,
-                processed_code: agave_scheduler_bindings::processed_codes::PROCESSED,
-                responses,
-            };
-
-            self.sender
-                .try_write(response)
-                .map_err(|_| ExternalConsumeWorkerError::SenderDisconnected)?;
-
-            Ok(())
-        }
-
         fn send_execution_response(
             &mut self,
-            message: &PackToWorkerMessage,
+            message: &PackToExecutionWorkerMessage,
             iter: impl ExactSizeIterator<Item = ExecutionResponse>,
         ) -> Result<(), ExternalConsumeWorkerError> {
             let responses = execution_responses_from_iter(&self.allocator, iter)
                 .ok_or(ExternalConsumeWorkerError::AllocationFailure)?;
-            let response = WorkerToPackMessage {
+            let response = ExecutionWorkerToPackMessage {
                 batch: message.batch,
                 processed_code: agave_scheduler_bindings::processed_codes::PROCESSED,
                 responses,
@@ -628,7 +512,7 @@ pub(crate) mod external {
         /// reason.
         fn return_not_included_with_reason(
             &mut self,
-            message: &PackToWorkerMessage,
+            message: &PackToExecutionWorkerMessage,
             reason: u8,
             execution_slot: u64,
         ) -> Result<(), ExternalConsumeWorkerError> {
@@ -643,7 +527,7 @@ pub(crate) mod external {
             )
             .ok_or(ExternalConsumeWorkerError::AllocationFailure)?;
 
-            let response_message = WorkerToPackMessage {
+            let response_message = ExecutionWorkerToPackMessage {
                 batch: message.batch,
                 processed_code: agave_scheduler_bindings::processed_codes::PROCESSED,
                 responses: response_region,
@@ -658,106 +542,19 @@ pub(crate) mod external {
             Ok(())
         }
 
-        fn check_resolve_pubkeys(
-            &self,
-            parsing_results: &[Result<(), TransactionViewError>],
-            parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
-            txs: &[Tx],
-            max_ages: &[MaxAge],
-            responses: &mut [CheckResponse],
-            resolution_slot: Slot,
-        ) -> Result<(), ExternalConsumeWorkerError> {
-            assert_eq!(parsing_results.len(), parsing_and_resolve_results.len());
-            assert_eq!(parsing_results.len(), responses.len());
-
-            let mut resolved_transaction_iter = txs.iter();
-            let mut max_age_iter = max_ages.iter();
-            for (transaction_index, (parsing_result, parsing_and_resolve_results)) in
-                parsing_results
-                    .iter()
-                    .zip(parsing_and_resolve_results.iter())
-                    .enumerate()
-            {
-                if parsing_result.is_err() {
-                    continue;
-                }
-
-                let response = &mut responses[transaction_index];
-                response.resolve_flags |= resolve_flags::PERFORMED;
-                if parsing_and_resolve_results.is_err() {
-                    response.resolve_flags |= resolve_flags::FAILED;
-                    continue;
-                }
-
-                let transaction = resolved_transaction_iter.next().expect(
-                    "resolved_transaction_iter iterator must contain element for each sent parsed \
-                     transaction",
-                );
-                let max_age = max_age_iter.next().expect(
-                    "max_age_iter iterator must contain element for each sent parsed transaction",
-                );
-
-                // Address table lookups are sanitized to contain at least one account, so there
-                // are loaded keys exactly when account keys outnumber static account keys.
-                let account_keys = transaction.account_keys();
-                let num_static_account_keys = transaction.static_account_keys().len();
-                let (sharable_keys, alt_invalidation_slot) = if account_keys.len()
-                    > num_static_account_keys
-                {
-                    let num_pubkeys = account_keys.len().wrapping_sub(num_static_account_keys);
-                    let pubkeys_allocation = self
-                        .allocator
-                        .allocate(num_pubkeys.wrapping_mul(core::mem::size_of::<Pubkey>()) as u32)
-                        .ok_or(ExternalConsumeWorkerError::AllocationFailure)?
-                        .cast();
-                    // SAFETY: non-overlapping and appropriately sized.
-                    unsafe {
-                        Self::copy_loaded_addresses(
-                            account_keys.iter().skip(num_static_account_keys),
-                            pubkeys_allocation,
-                        )
-                    };
-                    // SAFETY: pubkeys_allocation was allocated by allocator
-                    let offset = unsafe { self.allocator.offset(pubkeys_allocation.cast()) };
-                    (
-                        SharablePubkeys {
-                            offset,
-                            num_pubkeys: num_pubkeys as u32,
-                        },
-                        max_age.alt_invalidation_slot,
-                    )
-                } else {
-                    (
-                        SharablePubkeys {
-                            offset: 0,
-                            num_pubkeys: 0,
-                        },
-                        u64::MAX,
-                    )
-                };
-
-                response.resolution_slot = resolution_slot;
-                response.resolved_pubkeys = sharable_keys;
-                response.min_alt_deactivation_slot = alt_invalidation_slot;
-            }
-
-            Ok(())
-        }
-
         fn return_unprocessed_message(
             &mut self,
-            message: &PackToWorkerMessage,
+            message: &PackToExecutionWorkerMessage,
             processed_code: u8,
         ) -> Result<(), ExternalConsumeWorkerError> {
             assert_ne!(
                 processed_code,
                 agave_scheduler_bindings::processed_codes::PROCESSED
             );
-            let response = WorkerToPackMessage {
+            let response = ExecutionWorkerToPackMessage {
                 batch: message.batch,
                 processed_code,
-                responses: TransactionResponseRegion {
-                    tag: 0,
+                responses: ExecutionResponseRegion {
                     num_transaction_responses: 0,
                     transaction_responses_offset: 0,
                 },
@@ -768,196 +565,6 @@ pub(crate) mod external {
                 .map_err(|_| ExternalConsumeWorkerError::SenderDisconnected)?;
 
             Ok(())
-        }
-
-        /// # Safety:
-        /// - `responses_ptr` must be aligned and sufficiently sized.
-        unsafe fn parse_transactions_and_populate_initial_check_responses<'a>(
-            message: &PackToWorkerMessage,
-            batch: &TransactionPtrBatch,
-            responses_ptr: NonNull<CheckResponse>,
-        ) -> (
-            ArrayVec<Result<(), TransactionViewError>, MAX_TRANSACTIONS_PER_MESSAGE>,
-            ArrayVec<TxView, MAX_TRANSACTIONS_PER_MESSAGE>,
-            &'a mut [CheckResponse],
-        ) {
-            let sanitize_config = sanitize_config();
-            let mut parsing_results = ArrayVec::new();
-            let mut parsed_transactions = ArrayVec::new();
-            for (tx_ptr, _) in batch.iter() {
-                // Parsing and basic sanitization checks
-                match SanitizedTransactionView::try_new_sanitized(tx_ptr, &sanitize_config) {
-                    Ok(view) => {
-                        parsing_results.push(Ok(()));
-                        parsed_transactions.push(view);
-                    }
-                    Err(err) => {
-                        parsing_results.push(Err(err));
-                    }
-                }
-            }
-
-            // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions
-            unsafe {
-                Self::check_populate_initial_messages(message, &parsing_results, responses_ptr)
-            };
-            // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions
-            //         initial messages populated immediately above, so not possible to have
-            //         uninitialized values either.
-            let response_slice = unsafe {
-                core::slice::from_raw_parts_mut(
-                    responses_ptr.as_ptr(),
-                    usize::from(message.batch.num_transactions),
-                )
-            };
-
-            (parsing_results, parsed_transactions, response_slice)
-        }
-
-        /// Write initial response value for each transaction.
-        /// This allows simpler modification of individual responses in further checks.
-        /// # Safety
-        /// - `responses_ptr` is valid ptr for a slice of [`CheckResponse`] with at least
-        ///   length `message.batch.num_transactions`
-        unsafe fn check_populate_initial_messages(
-            message: &PackToWorkerMessage,
-            parsing_results: &[Result<(), TransactionViewError>],
-            responses_ptr: NonNull<CheckResponse>,
-        ) {
-            // Populate initial responses with the result of parsing/sanitization.
-            assert_eq!(
-                parsing_results.len(),
-                usize::from(message.batch.num_transactions)
-            );
-            let initial_status_check_flags = if message.flags & check_flags::STATUS_CHECKS != 0 {
-                status_check_flags::REQUESTED
-            } else {
-                0
-            };
-            let initial_fee_payer_balance_flags =
-                if message.flags & check_flags::LOAD_FEE_PAYER_BALANCE != 0 {
-                    fee_payer_balance_flags::REQUESTED
-                } else {
-                    0
-                };
-            let initial_resolve_flags =
-                if message.flags & check_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
-                    resolve_flags::REQUESTED
-                } else {
-                    0
-                };
-            // Setup initial responses with requested checks.
-            // Values only filled in when check is performed.
-            for (transaction_index, parsing_result) in parsing_results.iter().enumerate() {
-                // NOTE: this includes resolution failures since this is a necessary check for further checks.
-                let parsing_and_sanitization_flags = if parsing_result.is_err() {
-                    parsing_and_sanitization_flags::FAILED
-                } else {
-                    0
-                };
-
-                // SAFETY: transaaction_index is in bounds.
-                unsafe {
-                    responses_ptr.add(transaction_index).write(CheckResponse {
-                        parsing_and_sanitization_flags,
-                        status_check_flags: initial_status_check_flags,
-                        fee_payer_balance_flags: initial_fee_payer_balance_flags,
-                        resolve_flags: initial_resolve_flags,
-                        included_slot: 0,
-                        balance_slot: 0,
-                        fee_payer_balance: 0,
-                        resolution_slot: 0,
-                        min_alt_deactivation_slot: 0,
-                        resolved_pubkeys: SharablePubkeys {
-                            offset: 0,
-                            num_pubkeys: 0,
-                        },
-                    })
-                };
-            }
-        }
-
-        fn check_load_fee_payer_balance<D: TransactionData>(
-            parsing_results: &[Result<(), TransactionViewError>],
-            parsed_transactions: &[SanitizedTransactionView<D>],
-            responses: &mut [CheckResponse],
-            working_bank: &Bank,
-        ) {
-            assert_eq!(responses.len(), parsing_results.len());
-
-            let mut parsed_transaction_iter = parsed_transactions.iter();
-            for (transaction_index, parsing_result) in parsing_results.iter().enumerate() {
-                if parsing_result.is_err() {
-                    continue;
-                }
-
-                let transaction = parsed_transaction_iter.next().expect(
-                    "parsed_transaction_iter iterator must contain element for each sent parsed \
-                     transaction",
-                );
-
-                let fee_payer_balance = working_bank
-                    .get_account_with_fixed_root(&transaction.static_account_keys()[0])
-                    .map(|account| account.lamports())
-                    .unwrap_or(0);
-
-                let response = &mut responses[transaction_index];
-                response.fee_payer_balance_flags |= fee_payer_balance_flags::PERFORMED;
-                response.fee_payer_balance = fee_payer_balance;
-                response.balance_slot = working_bank.slot();
-            }
-        }
-
-        fn check_status_checks<D: TransactionData>(
-            parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
-            txs: &[RuntimeTransaction<ResolvedTransactionView<D>>],
-            responses: &mut [CheckResponse],
-            working_bank: &Bank,
-        ) {
-            assert_eq!(parsing_and_resolve_results.len(), responses.len());
-
-            let mut error_counters = TransactionErrorMetrics::default();
-            let (status_check_results, included_slots) = working_bank
-                .check_transactions_with_processed_slots(
-                    txs,
-                    &[const { Ok(()) }; MAX_TRANSACTIONS_PER_MESSAGE],
-                    working_bank.max_processing_age(),
-                    true,
-                    true,
-                    &mut error_counters,
-                );
-            let included_slots = included_slots.expect("requested to collect processed slots");
-
-            let mut status_check_results_iter =
-                status_check_results.iter().zip(included_slots.iter());
-            for (transaction_index, parsing_and_resolve_result) in
-                parsing_and_resolve_results.iter().enumerate()
-            {
-                if parsing_and_resolve_result.is_err() {
-                    continue;
-                }
-                let (status_check_result, included_slot) = status_check_results_iter
-                    .next()
-                    .expect("status check results must have element for each sent transaction");
-
-                let check_response = &mut responses[transaction_index];
-                check_response.status_check_flags |= status_check_flags::PERFORMED;
-                match status_check_result {
-                    Err(TransactionError::BlockhashNotFound) => {
-                        check_response.status_check_flags |= status_check_flags::TOO_OLD;
-                    }
-                    Err(TransactionError::AlreadyProcessed) => {
-                        check_response.status_check_flags |= status_check_flags::ALREADY_PROCESSED;
-                        check_response.included_slot =
-                            included_slot.expect("included_slot must be set for already processed");
-                    }
-                    Err(TransactionError::UnsupportedVersion) => {
-                        check_response.status_check_flags |=
-                            status_check_flags::UNSUPPORTED_VERSION;
-                    }
-                    _ => {}
-                }
-            }
         }
 
         /// Translate batch of transactions into usable
@@ -1017,40 +624,18 @@ pub(crate) mod external {
             })
         }
 
-        /// # Safety
-        /// - destination is appropriately sized
-        /// - destination does not overlap with loaded_addresses allocation
-        unsafe fn copy_loaded_addresses<'a>(
-            loaded_addresses: impl Iterator<Item = &'a Pubkey>,
-            dest: NonNull<Pubkey>,
-        ) {
-            for (index, pubkey) in loaded_addresses.enumerate() {
-                unsafe { dest.add(index).write(*pubkey) };
-            }
-        }
-
         /// Returns `true` if a message is valid and can be processed.
-        fn validate_message(message: &PackToWorkerMessage) -> bool {
+        fn validate_message(message: &PackToExecutionWorkerMessage) -> bool {
             message.batch.num_transactions > 0
                 && usize::from(message.batch.num_transactions) <= MAX_TRANSACTIONS_PER_MESSAGE
                 && Self::validate_message_flags(message.flags)
         }
 
         fn validate_message_flags(flags: u16) -> bool {
-            if flags & pack_message_flags::EXECUTE != 0 {
-                const ALLOWED_EXECUTE_FLAGS: u16 = pack_message_flags::EXECUTE
-                    | execution_flags::DROP_ON_FAILURE
-                    | execution_flags::ALL_OR_NOTHING;
+            const ALLOWED_EXECUTE_FLAGS: u16 =
+                execution_message_flags::DROP_ON_FAILURE | execution_message_flags::ALL_OR_NOTHING;
 
-                flags & !ALLOWED_EXECUTE_FLAGS == 0
-            } else {
-                const ALLOWED_CHECK_BITS: u16 = pack_message_flags::CHECK
-                    | check_flags::STATUS_CHECKS
-                    | check_flags::LOAD_FEE_PAYER_BALANCE
-                    | check_flags::LOAD_ADDRESS_LOOKUP_TABLES;
-
-                flags != pack_message_flags::CHECK && flags & !ALLOWED_CHECK_BITS == 0
-            }
+            flags & !ALLOWED_EXECUTE_FLAGS == 0
         }
 
         fn response_from_commit_details(
@@ -1104,33 +689,25 @@ pub(crate) mod external {
         use {
             super::*,
             crate::banking_stage::{committer::Committer, tests::create_slow_genesis_config},
-            agave_scheduler_bindings::{SharableTransactionBatchRegion, worker_message_types},
+            agave_scheduler_bindings::{SharableTransactionBatchRegion, processed_codes},
             agave_scheduling_utils::{
                 handshake::{ClientLogon, client, server::Server},
-                responses_region::{CheckResponsesPtr, ExecutionResponsesPtr},
+                responses_region::ExecutionResponsesPtr,
             },
             crossbeam_channel::bounded,
-            solana_account::AccountSharedData,
             solana_genesis_config::GenesisConfig,
             solana_keypair::Keypair,
             solana_leader_schedule::SlotLeader,
             solana_ledger::genesis_utils::GenesisConfigInfo,
-            solana_message::v0::LoadedAddresses,
             solana_poh::{
                 record_channels::{RecordReceiver, record_channels},
                 transaction_recorder::TransactionRecorder,
             },
-            solana_runtime::{
-                bank_forks::BankForks, genesis_utils, vote_sender_types::ReplayVoteReceiver,
-            },
-            solana_sdk_ids::system_program,
-            solana_signer::Signer,
+            solana_pubkey::Pubkey,
+            solana_runtime::{bank_forks::BankForks, vote_sender_types::ReplayVoteReceiver},
             solana_system_transaction::transfer,
             solana_transaction::TransactionError,
-            std::{
-                collections::HashSet,
-                sync::{RwLock, atomic::AtomicBool},
-            },
+            std::sync::{RwLock, atomic::AtomicBool},
             test_case::test_case,
         };
 
@@ -1143,15 +720,15 @@ pub(crate) mod external {
             mint_keypair: Keypair,
             genesis_config: GenesisConfig,
             bank: Arc<Bank>,
-            bank_forks: Arc<RwLock<BankForks>>,
+            _bank_forks: Arc<RwLock<BankForks>>,
             _replay_vote_receiver: ReplayVoteReceiver,
             record_receiver: RecordReceiver,
             allocator: rts_alloc::Allocator,
-            pack_to_worker: shaq::spsc::Producer<PackToWorkerMessage>,
-            worker_to_pack: shaq::spsc::Consumer<WorkerToPackMessage>,
+            pack_to_worker: shaq::spsc::Producer<PackToExecutionWorkerMessage>,
+            worker_to_pack: shaq::spsc::Consumer<ExecutionWorkerToPackMessage>,
             shared_leader_state: SharedLeaderState,
             worker: ExternalWorker,
-            receiver: shaq::spsc::Consumer<PackToWorkerMessage>,
+            receiver: shaq::spsc::Consumer<PackToExecutionWorkerMessage>,
             should_drain_executes: bool,
         }
 
@@ -1170,7 +747,7 @@ pub(crate) mod external {
                 self.record_receiver.restart(self.bank.bank_id());
             }
 
-            fn send_message(&mut self, message: PackToWorkerMessage) {
+            fn send_message(&mut self, message: PackToExecutionWorkerMessage) {
                 self.pack_to_worker.try_write(message).unwrap();
             }
 
@@ -1182,36 +759,18 @@ pub(crate) mod external {
                 Ok(())
             }
 
-            fn recv_response(&mut self) -> WorkerToPackMessage {
+            fn recv_response(&mut self) -> ExecutionWorkerToPackMessage {
                 self.worker_to_pack.try_read().unwrap()
             }
 
             fn execution_responses(
                 &self,
-                region: &TransactionResponseRegion,
+                region: &ExecutionResponseRegion,
             ) -> Vec<ExecutionResponse> {
-                assert_eq!(region.tag, worker_message_types::EXECUTION_RESPONSE);
                 unsafe {
                     // SAFETY: `region` was produced by this worker using the same shared
-                    // allocator, and the tag assertion above guarantees the pointed-to
-                    // allocation contains `ExecutionResponse` values.
+                    // allocator and contains `ExecutionResponse` values.
                     let responses = ExecutionResponsesPtr::from_transaction_response_region(
-                        region,
-                        &self.allocator,
-                    );
-                    let decoded = responses.iter().copied().collect();
-                    responses.free(&self.allocator);
-                    decoded
-                }
-            }
-
-            fn check_responses(&self, region: &TransactionResponseRegion) -> Vec<CheckResponse> {
-                assert_eq!(region.tag, worker_message_types::CHECK_RESPONSE);
-                unsafe {
-                    // SAFETY: `region` was produced by this worker using the same shared
-                    // allocator, and the tag assertion above guarantees the pointed-to
-                    // allocation contains `CheckResponse` values.
-                    let responses = CheckResponsesPtr::from_transaction_response_region(
                         region,
                         &self.allocator,
                     );
@@ -1316,6 +875,7 @@ pub(crate) mod external {
 
             let logon = ClientLogon {
                 worker_count: 1,
+                check_worker_count: 1,
                 allocator_size: 64 * 1024 * 1024,
                 allocator_handles: 1,
                 tpu_to_pack_capacity: 16,
@@ -1346,14 +906,13 @@ pub(crate) mod external {
                 agave_worker.worker_to_pack,
                 agave_worker.allocator,
                 shared_leader_state.clone(),
-                bank_forks.read().unwrap().sharable_banks(),
             );
 
             ExternalTestFrame {
                 mint_keypair,
                 genesis_config,
                 bank,
-                bank_forks,
+                _bank_forks: bank_forks,
                 _replay_vote_receiver: replay_vote_receiver,
                 record_receiver,
                 allocator: client_session.allocators.pop().unwrap(),
@@ -1368,8 +927,8 @@ pub(crate) mod external {
 
         #[test]
         fn test_validate_message() {
-            let mut message = PackToWorkerMessage {
-                flags: agave_scheduler_bindings::pack_message_flags::EXECUTE,
+            let mut message = PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: u64::MAX,
                 batch: agave_scheduler_bindings::SharableTransactionBatchRegion {
                     num_transactions: 0,
@@ -1389,40 +948,23 @@ pub(crate) mod external {
             message.flags = u16::MAX;
             assert!(!ExternalWorker::validate_message(&message));
 
-            message.flags = pack_message_flags::EXECUTE;
+            message.flags = 0;
             assert!(ExternalWorker::validate_message(&message));
         }
 
         #[test]
         fn test_validate_message_flags() {
-            // Execute flags
+            assert!(ExternalWorker::validate_message_flags(0));
             assert!(ExternalWorker::validate_message_flags(
-                pack_message_flags::EXECUTE
-            ));
-            assert!(ExternalWorker::validate_message_flags(
-                pack_message_flags::EXECUTE | execution_flags::DROP_ON_FAILURE
+                execution_message_flags::DROP_ON_FAILURE
             ));
             assert!(ExternalWorker::validate_message_flags(
-                pack_message_flags::EXECUTE | execution_flags::ALL_OR_NOTHING
+                execution_message_flags::ALL_OR_NOTHING
             ));
             assert!(ExternalWorker::validate_message_flags(
-                pack_message_flags::EXECUTE
-                    | execution_flags::DROP_ON_FAILURE
-                    | execution_flags::ALL_OR_NOTHING
+                execution_message_flags::DROP_ON_FAILURE | execution_message_flags::ALL_OR_NOTHING
             ));
-            // Invalid execute flag
-            assert!(!ExternalWorker::validate_message_flags(
-                pack_message_flags::EXECUTE | (1 << 15)
-            ));
-
-            // Check flags
-            assert!(ExternalWorker::validate_message_flags(
-                pack_message_flags::CHECK
-                    | agave_scheduler_bindings::pack_message_flags::check_flags::LOAD_ADDRESS_LOOKUP_TABLES
-            ));
-            assert!(!ExternalWorker::validate_message_flags(
-                pack_message_flags::CHECK
-            ))
+            assert!(!ExternalWorker::validate_message_flags(1 << 15));
         }
 
         #[test]
@@ -1601,69 +1143,6 @@ pub(crate) mod external {
             )
         }
 
-        fn empty_check_responses(count: u8) -> Vec<CheckResponse> {
-            (0..count)
-                .map(|_| CheckResponse {
-                    parsing_and_sanitization_flags: 0,
-                    status_check_flags: 0,
-                    fee_payer_balance_flags: 0,
-                    resolve_flags: 0,
-                    included_slot: 0,
-                    balance_slot: 0,
-                    fee_payer_balance: 0,
-                    resolution_slot: 0,
-                    min_alt_deactivation_slot: 0,
-                    resolved_pubkeys: SharablePubkeys {
-                        offset: 0,
-                        num_pubkeys: 0,
-                    },
-                })
-                .collect()
-        }
-
-        #[test]
-        fn test_check_populate_initial_messages() {
-            let message = PackToWorkerMessage {
-                flags: pack_message_flags::CHECK | check_flags::LOAD_FEE_PAYER_BALANCE,
-                max_working_slot: 1,
-                batch: SharableTransactionBatchRegion {
-                    num_transactions: 3,
-                    transactions_offset: 0,
-                },
-            };
-
-            let mut responses = empty_check_responses(message.batch.num_transactions);
-            let responses_ptr = NonNull::new(responses.as_mut_ptr()).unwrap();
-
-            unsafe {
-                ExternalWorker::check_populate_initial_messages(
-                    &message,
-                    &[
-                        Ok(()),
-                        Err(TransactionViewError::ParseError),
-                        Err(TransactionViewError::SanitizeError),
-                    ],
-                    responses_ptr,
-                )
-            };
-
-            assert_eq!(responses[0].parsing_and_sanitization_flags, 0);
-            assert_eq!(
-                responses[1].parsing_and_sanitization_flags,
-                parsing_and_sanitization_flags::FAILED
-            );
-            assert_eq!(
-                responses[2].parsing_and_sanitization_flags,
-                parsing_and_sanitization_flags::FAILED
-            );
-            for response in responses.iter() {
-                assert_eq!(
-                    response.fee_payer_balance_flags,
-                    fee_payer_balance_flags::REQUESTED
-                );
-            }
-        }
-
         fn test_serialized_transaction(recent_blockhash: solana_hash::Hash) -> Vec<u8> {
             let tx = transfer(
                 &solana_keypair::Keypair::new(),
@@ -1672,128 +1151,6 @@ pub(crate) mod external {
                 recent_blockhash,
             );
             wincode::serialize(&tx).unwrap()
-        }
-
-        #[test]
-        fn test_check_load_fee_payer_balance() {
-            let genesis = genesis_utils::create_genesis_config(1_000_000_000);
-            let bank = Bank::new_for_tests(&genesis.genesis_config);
-
-            let tx1 = test_serialized_transaction(bank.confirmed_last_blockhash());
-            let tx2 = test_serialized_transaction(bank.confirmed_last_blockhash());
-
-            let parsing_results = [Ok(()), Err(TransactionViewError::ParseError), Ok(())];
-            let parsed_transactions = [
-                SanitizedTransactionView::try_new_sanitized(&tx1[..], &sanitize_config()).unwrap(),
-                SanitizedTransactionView::try_new_sanitized(&tx2[..], &sanitize_config()).unwrap(),
-            ];
-            bank.store_account(
-                &parsed_transactions[1].static_account_keys()[0],
-                &AccountSharedData::new(1_000_000_000, 0, &system_program::ID),
-            );
-            let mut responses = empty_check_responses(parsing_results.len() as u8);
-
-            ExternalWorker::check_load_fee_payer_balance(
-                &parsing_results[..],
-                &parsed_transactions[..],
-                &mut responses,
-                &bank,
-            );
-
-            // test-note: requested is not set by this function.
-            assert_eq!(
-                responses[0].fee_payer_balance_flags,
-                fee_payer_balance_flags::PERFORMED
-            );
-            assert_eq!(responses[0].balance_slot, bank.slot());
-            assert_eq!(responses[0].fee_payer_balance, 0);
-
-            assert_eq!(responses[1].fee_payer_balance_flags, 0);
-            assert_eq!(responses[1].balance_slot, 0);
-            assert_eq!(responses[1].fee_payer_balance, 0);
-
-            assert_eq!(
-                responses[2].fee_payer_balance_flags,
-                fee_payer_balance_flags::PERFORMED
-            );
-            assert_eq!(responses[2].balance_slot, bank.slot());
-            assert_eq!(responses[2].fee_payer_balance, 1_000_000_000);
-        }
-
-        #[test]
-        fn test_check_status_checks() {
-            let genesis = genesis_utils::create_genesis_config(1_000_000_000);
-            let (bank, _bank_forks) =
-                Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
-
-            let tx1 = test_serialized_transaction(bank.confirmed_last_blockhash());
-            let tx2 = test_serialized_transaction(solana_hash::Hash::new_unique());
-            let tx3 = test_serialized_transaction(bank.confirmed_last_blockhash());
-
-            fn to_resolved_view(
-                tx: &'_ [u8],
-            ) -> RuntimeTransaction<ResolvedTransactionView<&'_ [u8]>> {
-                RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
-                    RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
-                        SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config())
-                            .unwrap(),
-                        solana_transaction::sanitized::MessageHash::Compute,
-                        Some(false),
-                    )
-                    .unwrap(),
-                    None,
-                    &HashSet::new(),
-                )
-                .unwrap()
-            }
-
-            let parsing_and_resolve_results = [
-                Ok(()),
-                Err(PacketHandlingError::Sanitization),
-                Ok(()),
-                Ok(()),
-            ];
-            let parsed_transactions = [
-                to_resolved_view(&tx1[..]),
-                to_resolved_view(&tx2[..]),
-                to_resolved_view(&tx3[..]),
-            ];
-
-            // Process transaction 3.
-            bank.store_account(
-                &parsed_transactions[2].static_account_keys()[0],
-                &AccountSharedData::new(1_000_000_000, 0, &system_program::ID),
-            );
-            bank.process_transaction(&wincode::deserialize(&tx3).unwrap())
-                .unwrap();
-
-            let mut responses = empty_check_responses(parsing_and_resolve_results.len() as u8);
-
-            ExternalWorker::check_status_checks(
-                &parsing_and_resolve_results,
-                &parsed_transactions,
-                &mut responses,
-                &bank,
-            );
-
-            // test-note: requested is not set by this function.
-            assert_eq!(
-                responses[0].status_check_flags,
-                status_check_flags::PERFORMED
-            );
-
-            assert_eq!(responses[1].status_check_flags, 0);
-
-            assert_eq!(
-                responses[2].status_check_flags,
-                status_check_flags::PERFORMED | status_check_flags::TOO_OLD
-            );
-
-            assert_eq!(
-                responses[3].status_check_flags,
-                status_check_flags::PERFORMED | status_check_flags::ALREADY_PROCESSED
-            );
-            assert_eq!(responses[3].included_slot, bank.slot());
         }
 
         #[test]
@@ -1826,32 +1183,11 @@ pub(crate) mod external {
         }
 
         #[test]
-        fn test_copy_loaded_addresses() {
-            let loaded_addresses = LoadedAddresses {
-                writable: (0..5).map(|_| Pubkey::new_unique()).collect(),
-                readonly: (0..2).map(|_| Pubkey::new_unique()).collect(),
-            };
-            let mut buffer = vec![Pubkey::default(); 7];
-            unsafe {
-                ExternalWorker::copy_loaded_addresses(
-                    loaded_addresses
-                        .writable
-                        .iter()
-                        .chain(&loaded_addresses.readonly),
-                    NonNull::new(buffer.as_mut_ptr()).unwrap(),
-                )
-            };
-
-            assert_eq!(&loaded_addresses.writable, &buffer[0..5]);
-            assert_eq!(&loaded_addresses.readonly, &buffer[5..7]);
-        }
-
-        #[test]
         fn test_run_invalid_message() {
             let mut test_frame = setup_external_test_frame();
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: u64::MAX,
                 batch: SharableTransactionBatchRegion {
                     num_transactions: 0,
@@ -1867,7 +1203,7 @@ pub(crate) mod external {
             let batch = test_frame.allocate_batch(&[test_serialized_transaction(
                 test_frame.bank.confirmed_last_blockhash(),
             )]);
-            test_frame.send_message(PackToWorkerMessage {
+            test_frame.send_message(PackToExecutionWorkerMessage {
                 flags: u16::MAX,
                 max_working_slot: u64::MAX,
                 batch: batch.region,
@@ -1892,8 +1228,8 @@ pub(crate) mod external {
             ))
             .unwrap()]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: u64::MAX,
                 batch: batch.region,
             });
@@ -1922,8 +1258,8 @@ pub(crate) mod external {
                 test_frame.genesis_config.hash(),
             ))
             .unwrap()]);
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot() - 1,
                 batch: batch.region,
             });
@@ -1954,8 +1290,8 @@ pub(crate) mod external {
                 .unwrap(),
                 vec![0xff],
             ]);
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE | execution_flags::ALL_OR_NOTHING,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: execution_message_flags::ALL_OR_NOTHING,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch.region,
             });
@@ -1972,132 +1308,6 @@ pub(crate) mod external {
                 responses[1].not_included_reason,
                 not_included_reasons::SANITIZE_FAILURE
             );
-
-            test_frame.free_batch(batch);
-        }
-
-        #[test]
-        fn test_run_check_happy_path() {
-            let mut test_frame = setup_external_test_frame();
-            let fee_payer = Keypair::new();
-            let fee_payer_balance = 123_456;
-            test_frame.bank.store_account(
-                &fee_payer.pubkey(),
-                &AccountSharedData::new(fee_payer_balance, 0, &system_program::ID),
-            );
-
-            let batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
-                &fee_payer,
-                &Pubkey::new_unique(),
-                1,
-                test_frame.bank.confirmed_last_blockhash(),
-            ))
-            .unwrap()]);
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::CHECK
-                    | check_flags::STATUS_CHECKS
-                    | check_flags::LOAD_FEE_PAYER_BALANCE,
-                max_working_slot: test_frame.bank.slot(),
-                batch: batch.region,
-            });
-            test_frame.iterate().unwrap();
-            let response = test_frame.recv_response();
-            assert_eq!(response.processed_code, processed_codes::PROCESSED);
-            let responses = test_frame.check_responses(&response.responses);
-            assert_eq!(responses.len(), 1);
-            assert_eq!(
-                responses[0].status_check_flags,
-                status_check_flags::REQUESTED | status_check_flags::PERFORMED
-            );
-            assert_eq!(
-                responses[0].fee_payer_balance_flags,
-                fee_payer_balance_flags::REQUESTED | fee_payer_balance_flags::PERFORMED
-            );
-            assert_eq!(responses[0].balance_slot, test_frame.bank.slot());
-            assert_eq!(responses[0].fee_payer_balance, fee_payer_balance);
-
-            test_frame.free_batch(batch);
-        }
-
-        #[test]
-        fn test_run_check_max_working_slot_exceeded() {
-            let mut test_frame = setup_external_test_frame();
-            let batch = test_frame.allocate_batch(&[test_serialized_transaction(
-                test_frame.bank.confirmed_last_blockhash(),
-            )]);
-
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::CHECK | check_flags::STATUS_CHECKS,
-                max_working_slot: test_frame.bank.slot() - 1,
-                batch: batch.region,
-            });
-            test_frame.iterate().unwrap();
-            let response = test_frame.recv_response();
-            assert_eq!(
-                response.processed_code,
-                processed_codes::MAX_WORKING_SLOT_EXCEEDED
-            );
-            assert_eq!(response.responses.num_transaction_responses, 0);
-            assert_eq!(response.responses.transaction_responses_offset, 0);
-
-            test_frame.free_batch(batch);
-        }
-
-        #[test]
-        fn test_run_check_prefers_active_leader_bank() {
-            let mut test_frame = setup_external_test_frame();
-            let batch = test_frame.allocate_batch(&[test_serialized_transaction(
-                test_frame.bank.confirmed_last_blockhash(),
-            )]);
-
-            // Insert a higher fork bank so the highest working bank exceeds
-            // `max_working_slot` while the active leader bank does not.
-            let higher_bank = Bank::new_from_parent(
-                test_frame.bank.clone(),
-                SlotLeader::new_unique(),
-                test_frame.bank.slot() + 1,
-            );
-            test_frame.bank_forks.write().unwrap().insert(higher_bank);
-            test_frame.set_active_bank();
-
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::CHECK | check_flags::STATUS_CHECKS,
-                max_working_slot: test_frame.bank.slot(),
-                batch: batch.region,
-            });
-            test_frame.iterate().unwrap();
-            let response = test_frame.recv_response();
-            assert_eq!(response.processed_code, processed_codes::PROCESSED);
-            let responses = test_frame.check_responses(&response.responses);
-            assert_eq!(responses.len(), 1);
-
-            test_frame.free_batch(batch);
-        }
-
-        #[test]
-        fn test_run_check_resolve_without_loaded_addresses() {
-            let mut test_frame = setup_external_test_frame();
-            let batch = test_frame.allocate_batch(&[test_serialized_transaction(
-                test_frame.bank.confirmed_last_blockhash(),
-            )]);
-
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::CHECK | check_flags::LOAD_ADDRESS_LOOKUP_TABLES,
-                max_working_slot: test_frame.bank.slot(),
-                batch: batch.region,
-            });
-            test_frame.iterate().unwrap();
-            let response = test_frame.recv_response();
-            assert_eq!(response.processed_code, processed_codes::PROCESSED);
-            let responses = test_frame.check_responses(&response.responses);
-            assert_eq!(responses.len(), 1);
-            assert_eq!(
-                responses[0].resolve_flags,
-                resolve_flags::REQUESTED | resolve_flags::PERFORMED
-            );
-            assert_eq!(responses[0].resolution_slot, test_frame.bank.slot());
-            assert_eq!(responses[0].resolved_pubkeys.num_pubkeys, 0);
-            assert_eq!(responses[0].min_alt_deactivation_slot, u64::MAX);
 
             test_frame.free_batch(batch);
         }
@@ -2120,13 +1330,13 @@ pub(crate) mod external {
             ))
             .unwrap()]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch1.region,
             });
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch2.region,
             });
@@ -2169,8 +1379,8 @@ pub(crate) mod external {
             ))
             .unwrap()]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch.region,
             });
@@ -2219,8 +1429,8 @@ pub(crate) mod external {
                 .unwrap(),
             ]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch.region,
             });
@@ -2243,43 +1453,35 @@ pub(crate) mod external {
             let mut test_frame = setup_external_test_frame();
             test_frame.enable_execution();
 
-            let execute_batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
+            let first_batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
                 &test_frame.mint_keypair,
                 &Pubkey::new_unique(),
                 1,
                 test_frame.bank.confirmed_last_blockhash(),
             ))
             .unwrap()]);
-            let fee_payer = Keypair::new();
-            let fee_payer_balance = 654_321;
-            test_frame.bank.store_account(
-                &fee_payer.pubkey(),
-                &AccountSharedData::new(fee_payer_balance, 0, &system_program::ID),
-            );
-            let check_batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
-                &fee_payer,
+            let second_batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
+                &test_frame.mint_keypair,
                 &Pubkey::new_unique(),
                 1,
                 test_frame.bank.confirmed_last_blockhash(),
             ))
             .unwrap()]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
-                batch: execute_batch.region,
+                batch: first_batch.region,
             });
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::CHECK
-                    | check_flags::STATUS_CHECKS
-                    | check_flags::LOAD_FEE_PAYER_BALANCE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
-                batch: check_batch.region,
+                batch: second_batch.region,
             });
 
             test_frame.iterate().unwrap();
             let first = test_frame.recv_response();
-            assert_eq!(first.batch, execute_batch.region);
+            assert_eq!(first.batch, first_batch.region);
             let first_responses = test_frame.execution_responses(&first.responses);
             assert_eq!(first_responses.len(), 1);
             assert_eq!(
@@ -2288,17 +1490,16 @@ pub(crate) mod external {
             );
 
             let second = test_frame.recv_response();
-            assert_eq!(second.batch, check_batch.region);
-            let second_responses = test_frame.check_responses(&second.responses);
+            assert_eq!(second.batch, second_batch.region);
+            let second_responses = test_frame.execution_responses(&second.responses);
             assert_eq!(second_responses.len(), 1);
             assert_eq!(
-                second_responses[0].fee_payer_balance_flags,
-                fee_payer_balance_flags::REQUESTED | fee_payer_balance_flags::PERFORMED
+                second_responses[0].not_included_reason,
+                not_included_reasons::NONE
             );
-            assert_eq!(second_responses[0].fee_payer_balance, fee_payer_balance);
 
-            test_frame.free_batch(execute_batch);
-            test_frame.free_batch(check_batch);
+            test_frame.free_batch(first_batch);
+            test_frame.free_batch(second_batch);
         }
 
         #[test]
@@ -2314,8 +1515,8 @@ pub(crate) mod external {
             ))
             .unwrap()]);
 
-            test_frame.send_message(PackToWorkerMessage {
-                flags: pack_message_flags::EXECUTE,
+            test_frame.send_message(PackToExecutionWorkerMessage {
+                flags: 0,
                 max_working_slot: test_frame.bank.slot(),
                 batch: batch.region,
             });

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1323,6 +1323,8 @@ pub(crate) mod external {
                 pack_to_worker_capacity: 16,
                 worker_to_pack_capacity: 16,
                 flags: 0,
+                pack_to_check_worker_capacity: 16,
+                check_worker_to_pack_capacity: 16,
             };
             let (mut agave_session, files) = Server::setup_session(logon).unwrap();
             let mut client_session = client::setup_session(&logon, files).unwrap();

--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -7,7 +7,7 @@ use {
     agave_votor::slot_clock::SharedAlpenglowSlotClock,
     agave_votor_messages::migration::MigrationStatus,
     solana_clock::{BankId, Slot},
-    solana_cost_model::cost_tracker::SharedBlockCost,
+    solana_cost_model::cost_tracker::{SharedAllocatedAccountsDataSize, SharedBlockCost},
     solana_poh::poh_recorder::SharedLeaderState,
     solana_runtime::leader_schedule_utils::last_of_consecutive_leader_slots,
     std::{
@@ -59,6 +59,7 @@ struct ProgressTracker {
 
     last_observed_bank_id: Option<BankId>,
     limit_and_shared_block_cost: Option<(u64, SharedBlockCost)>,
+    limit_and_shared_allocated_accounts_data_size: Option<(u64, SharedAllocatedAccountsDataSize)>,
 }
 
 impl ProgressTracker {
@@ -80,6 +81,7 @@ impl ProgressTracker {
 
             last_observed_bank_id: None,
             limit_and_shared_block_cost: None,
+            limit_and_shared_allocated_accounts_data_size: None,
         }
     }
 
@@ -156,13 +158,17 @@ impl ProgressTracker {
             .unwrap_or((u64::MAX, u64::MAX));
         let progress_message = if let Some(working_bank) = leader_state.working_bank() {
             let bank_id = working_bank.bank_id();
-            // If new bank grab the cost tracker lock to get limit and shared cost.
+            // If new bank grab the cost tracker lock to get limits and shared costs.
             // This avoids needing to lock except on bank switches.
             if self.last_observed_bank_id != Some(bank_id) {
                 let cost_tracker = working_bank.read_cost_tracker().unwrap();
                 self.limit_and_shared_block_cost = Some((
                     cost_tracker.get_block_limit(),
                     cost_tracker.shared_block_cost(),
+                ));
+                self.limit_and_shared_allocated_accounts_data_size = Some((
+                    cost_tracker.get_allocated_data_size_limit(),
+                    cost_tracker.shared_allocated_accounts_data_size(),
                 ));
                 self.last_observed_bank_id = Some(bank_id);
             }
@@ -191,12 +197,15 @@ impl ProgressTracker {
                 next_leader_slot: next_leader_range_start,
                 leader_range_end: next_leader_range_end,
                 remaining_cost_units: self.remaining_block_cost(),
+                remaining_allocated_accounts_data_size: self
+                    .remaining_allocated_accounts_data_size(),
                 latest_blockhash: working_bank.last_blockhash().to_bytes(),
                 target_bank_time_ms: target_bank_time_ms(working_bank.ns_per_slot),
             }
         } else {
             self.last_observed_bank_id = None;
             self.limit_and_shared_block_cost = None;
+            self.limit_and_shared_allocated_accounts_data_size = None;
             let (current_slot, current_slot_progress) =
                 if self.migration_status.is_alpenglow_enabled() {
                     let slot_info = self.alpenglow_slot_clock.load()?;
@@ -229,6 +238,7 @@ impl ProgressTracker {
                 next_leader_slot: next_leader_range_start,
                 leader_range_end: next_leader_range_end,
                 remaining_cost_units: 0,
+                remaining_allocated_accounts_data_size: 0,
                 latest_blockhash: [0; 32],
                 target_bank_time_ms: 0,
             }
@@ -242,6 +252,16 @@ impl ProgressTracker {
         self.limit_and_shared_block_cost
             .as_ref()
             .map(|(limit, shared_block_cost)| limit.saturating_sub(shared_block_cost.load()))
+            .unwrap_or(0)
+    }
+
+    /// If leader get the remaining allocated accounts data size. Otherwise 0.
+    fn remaining_allocated_accounts_data_size(&self) -> u64 {
+        self.limit_and_shared_allocated_accounts_data_size
+            .as_ref()
+            .map(|(limit, shared_allocated_accounts_data_size)| {
+                limit.saturating_sub(shared_allocated_accounts_data_size.load())
+            })
             .unwrap_or(0)
     }
 }
@@ -369,6 +389,8 @@ mod tests {
         assert_eq!(message.next_leader_slot, u64::MAX);
         assert_eq!(message.leader_range_end, u64::MAX);
         assert_eq!(message.epoch, 0);
+        assert_eq!(message.remaining_cost_units, 0);
+        assert_eq!(message.remaining_allocated_accounts_data_size, 0);
         assert_eq!(message.latest_blockhash, [0; 32]);
         assert_eq!(message.target_bank_time_ms, 0);
 
@@ -467,6 +489,12 @@ mod tests {
         assert_eq!(message.leader_range_end, 7);
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.epoch, bank.epoch());
+        assert_eq!(
+            message.remaining_allocated_accounts_data_size,
+            bank.read_cost_tracker()
+                .unwrap()
+                .get_allocated_data_size_limit()
+        );
         assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
         assert_eq!(
             message.target_bank_time_ms,
@@ -678,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn test_progress_tracker_remaining_block_cost() {
+    fn test_progress_tracker_remaining_costs() {
         let mut progress_tracker = ProgressTracker::new(
             Arc::default(),
             SharedLeaderState::new(0, None, None),
@@ -690,6 +718,7 @@ mod tests {
 
         // No bank - no block cost set (0).
         assert_eq!(0, progress_tracker.remaining_block_cost());
+        assert_eq!(0, progress_tracker.remaining_allocated_accounts_data_size());
 
         let block_limit = 10_000;
         progress_tracker.limit_and_shared_block_cost = Some((block_limit, SharedBlockCost::new(0)));
@@ -697,6 +726,24 @@ mod tests {
         progress_tracker.limit_and_shared_block_cost =
             Some((block_limit, SharedBlockCost::new(block_limit / 2)));
         assert_eq!(block_limit / 2, progress_tracker.remaining_block_cost());
+
+        let allocated_accounts_data_size_limit = 20_000;
+        progress_tracker.limit_and_shared_allocated_accounts_data_size = Some((
+            allocated_accounts_data_size_limit,
+            SharedAllocatedAccountsDataSize::new(0),
+        ));
+        assert_eq!(
+            allocated_accounts_data_size_limit,
+            progress_tracker.remaining_allocated_accounts_data_size()
+        );
+        progress_tracker.limit_and_shared_allocated_accounts_data_size = Some((
+            allocated_accounts_data_size_limit,
+            SharedAllocatedAccountsDataSize::new(allocated_accounts_data_size_limit / 2),
+        ));
+        assert_eq!(
+            allocated_accounts_data_size_limit / 2,
+            progress_tracker.remaining_allocated_accounts_data_size()
+        );
     }
 
     #[test]

--- a/core/src/banking_stage/progress_tracker.rs
+++ b/core/src/banking_stage/progress_tracker.rs
@@ -192,6 +192,7 @@ impl ProgressTracker {
                 leader_range_end: next_leader_range_end,
                 remaining_cost_units: self.remaining_block_cost(),
                 latest_blockhash: working_bank.last_blockhash().to_bytes(),
+                target_bank_time_ms: target_bank_time_ms(working_bank.ns_per_slot),
             }
         } else {
             self.last_observed_bank_id = None;
@@ -229,6 +230,7 @@ impl ProgressTracker {
                 leader_range_end: next_leader_range_end,
                 remaining_cost_units: 0,
                 latest_blockhash: [0; 32],
+                target_bank_time_ms: 0,
             }
         };
 
@@ -242,6 +244,11 @@ impl ProgressTracker {
             .map(|(limit, shared_block_cost)| limit.saturating_sub(shared_block_cost.load()))
             .unwrap_or(0)
     }
+}
+
+fn target_bank_time_ms(ns_per_slot: u128) -> u16 {
+    let milliseconds = ns_per_slot.wrapping_div(1_000_000);
+    u16::try_from(milliseconds).unwrap_or(u16::MAX)
 }
 
 fn alpenglow_progress(elapsed: Duration, slot_duration: Duration) -> u8 {
@@ -363,6 +370,7 @@ mod tests {
         assert_eq!(message.leader_range_end, u64::MAX);
         assert_eq!(message.epoch, 0);
         assert_eq!(message.latest_blockhash, [0; 32]);
+        assert_eq!(message.target_bank_time_ms, 0);
 
         let expected_tick_height = 2 * ticks_per_slot;
         shared_leader_state.store(Arc::new(LeaderState::new(
@@ -380,6 +388,7 @@ mod tests {
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.epoch, 0);
         assert_eq!(message.latest_blockhash, [0; 32]);
+        assert_eq!(message.target_bank_time_ms, 0);
 
         // Next leader slot is in the future - should be NOT_LEADER.
         shared_leader_state.store(Arc::new(LeaderState::new(
@@ -397,6 +406,7 @@ mod tests {
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.epoch, 0);
         assert_eq!(message.latest_blockhash, [0; 32]);
+        assert_eq!(message.target_bank_time_ms, 0);
 
         // In leader slot but no bank yet - should be LEADER_STARTING.
         // leader_first_tick_height is at start of slot 4, and we're at tick_height
@@ -420,6 +430,7 @@ mod tests {
         assert_eq!(message.current_slot_progress, 1);
         assert_eq!(message.epoch, 0);
         assert_eq!(message.latest_blockhash, [0; 32]);
+        assert_eq!(message.target_bank_time_ms, 0);
 
         // Slot boundary mid-window: tick_height one tick before leader_first_tick_height.
         let slot_5_boundary = 5 * ticks_per_slot;
@@ -457,6 +468,10 @@ mod tests {
         assert_eq!(message.current_slot_progress, 0);
         assert_eq!(message.epoch, bank.epoch());
         assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
+        assert_eq!(
+            message.target_bank_time_ms,
+            target_bank_time_ms(bank.ns_per_slot)
+        );
 
         bank.fill_bank_with_ticks_for_tests();
         assert!(bank.is_complete());
@@ -475,6 +490,10 @@ mod tests {
         assert_eq!(message.current_slot_progress, 100);
         assert_eq!(message.epoch, bank.epoch());
         assert_eq!(message.latest_blockhash, bank.last_blockhash().to_bytes());
+        assert_eq!(
+            message.target_bank_time_ms,
+            target_bank_time_ms(bank.ns_per_slot)
+        );
 
         // Child bank past the first epoch boundary - epoch should advance.
         let child_bank = Arc::new(Bank::new_from_parent(
@@ -500,6 +519,10 @@ mod tests {
         assert_eq!(
             message.latest_blockhash,
             child_bank.last_blockhash().to_bytes()
+        );
+        assert_eq!(
+            message.target_bank_time_ms,
+            target_bank_time_ms(child_bank.ns_per_slot)
         );
     }
 

--- a/core/src/banking_stage/transaction_scheduler/check_worker.rs
+++ b/core/src/banking_stage/transaction_scheduler/check_worker.rs
@@ -119,3 +119,934 @@ mod tests {
             .for_each(|handle| assert!(handle.join().is_ok()));
     }
 }
+
+pub(crate) mod external {
+    use {
+        crate::banking_stage::{
+            scheduler_messages::MaxAge,
+            transaction_scheduler::receive_and_buffer::{
+                PacketHandlingError, translate_to_runtime_view,
+            },
+        },
+        agave_scheduler_bindings::{
+            CheckResponseRegion, CheckWorkerToPackMessage, MAX_TRANSACTIONS_PER_MESSAGE,
+            PackToCheckWorkerMessage, SharablePubkeys, check_message_flags, processed_codes,
+            worker_message_types::{
+                CheckResponse, fee_payer_balance_flags, parsing_and_sanitization_flags,
+                resolve_flags, status_check_flags,
+            },
+        },
+        agave_scheduling_utils::{
+            responses_region::allocate_check_response_region,
+            transaction_ptr::{TransactionPtr, TransactionPtrBatch},
+        },
+        agave_transaction_view::{
+            resolved_transaction_view::ResolvedTransactionView, result::TransactionViewError,
+            sanitize::SanitizeConfig, transaction_data::TransactionData,
+            transaction_view::SanitizedTransactionView,
+        },
+        arrayvec::ArrayVec,
+        solana_account::ReadableAccount,
+        solana_clock::Slot,
+        solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
+        solana_pubkey::Pubkey,
+        solana_runtime::{
+            bank::Bank,
+            bank_forks::{BankPair, SharableBanks},
+        },
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        },
+        solana_svm::transaction_error_metrics::TransactionErrorMetrics,
+        solana_svm_transaction::svm_message::{SVMMessage, SVMStaticMessage},
+        solana_transaction::TransactionError,
+        std::{
+            ptr::NonNull,
+            sync::{
+                Arc,
+                atomic::{AtomicBool, Ordering},
+            },
+            time::Duration,
+        },
+        thiserror::Error,
+    };
+
+    type Tx = RuntimeTransaction<ResolvedTransactionView<TransactionPtr>>;
+    type TxView = SanitizedTransactionView<TransactionPtr>;
+
+    #[derive(Debug, Error)]
+    pub(crate) enum ExternalCheckWorkerError {
+        #[error("Sender disconnected")]
+        SenderDisconnected,
+        #[error("Allocation failed")]
+        AllocationFailure,
+    }
+
+    pub(crate) enum IterationResult {
+        ProcessedMessage,
+        Idle,
+    }
+
+    #[allow(dead_code)]
+    pub(crate) struct ExternalCheckWorker {
+        exit: Arc<AtomicBool>,
+        receiver: shaq::mpmc::Consumer<PackToCheckWorkerMessage>,
+        sender: shaq::mpmc::Producer<CheckWorkerToPackMessage>,
+        allocator: rts_alloc::Allocator,
+
+        shared_leader_state: SharedLeaderState,
+        sharable_banks: SharableBanks,
+    }
+
+    #[allow(dead_code)]
+    impl ExternalCheckWorker {
+        const RECEIVE_TIMEOUT: Duration = Duration::from_millis(10);
+
+        pub fn new(
+            exit: Arc<AtomicBool>,
+            receiver: shaq::mpmc::Consumer<PackToCheckWorkerMessage>,
+            sender: shaq::mpmc::Producer<CheckWorkerToPackMessage>,
+            allocator: rts_alloc::Allocator,
+            shared_leader_state: SharedLeaderState,
+            sharable_banks: SharableBanks,
+        ) -> Self {
+            Self {
+                exit,
+                receiver,
+                sender,
+                allocator,
+                shared_leader_state,
+                sharable_banks,
+            }
+        }
+
+        pub fn run(mut self) -> Result<(), ExternalCheckWorkerError> {
+            while !self.exit.load(Ordering::Relaxed) {
+                self.iterate(Self::RECEIVE_TIMEOUT)?;
+            }
+
+            Ok(())
+        }
+
+        pub(crate) fn iterate(
+            &mut self,
+            timeout: Duration,
+        ) -> Result<IterationResult, ExternalCheckWorkerError> {
+            self.allocator.clean_remote_frees();
+
+            match self.receiver.read_timeout(timeout) {
+                Ok(message) => {
+                    self.process_message(&message)?;
+                    Ok(IterationResult::ProcessedMessage)
+                }
+                Err(shaq::error::WaitError::Timeout) => Ok(IterationResult::Idle),
+            }
+        }
+
+        fn process_message(
+            &mut self,
+            message: &PackToCheckWorkerMessage,
+        ) -> Result<(), ExternalCheckWorkerError> {
+            if !Self::validate_message(message) {
+                return self.return_unprocessed_message(message, processed_codes::INVALID);
+            }
+
+            self.check_batch(message)
+        }
+
+        fn check_batch(
+            &mut self,
+            message: &PackToCheckWorkerMessage,
+        ) -> Result<(), ExternalCheckWorkerError> {
+            let BankPair {
+                root_bank,
+                working_bank,
+            } = self.sharable_banks.load();
+            // Prefer the leader bank over the highest working fork when leader.
+            let working_bank = active_leader_state(&self.shared_leader_state)
+                .and_then(|leader_state| leader_state.working_bank().cloned())
+                .unwrap_or(working_bank);
+
+            // SAFETY: Assumption that external scheduler does not pass messages with batch regions
+            //         not pointing to valid regions in the allocator.
+            let batch = unsafe {
+                TransactionPtrBatch::from_sharable_transaction_batch_region(
+                    &message.batch,
+                    &self.allocator,
+                )
+            };
+
+            let (responses_ptr, responses) = allocate_check_response_region(
+                &self.allocator,
+                usize::from(message.batch.num_transactions),
+            )
+            .ok_or(ExternalCheckWorkerError::AllocationFailure)?;
+
+            // SAFETY: responses_ptr is sufficiently sized and aligned.
+            let (parsing_results, parsed_transactions, response_slice) = unsafe {
+                Self::parse_transactions_and_populate_initial_check_responses(
+                    message,
+                    &batch,
+                    responses_ptr,
+                )
+            };
+
+            if message.flags & check_message_flags::LOAD_FEE_PAYER_BALANCE != 0 {
+                Self::check_load_fee_payer_balance(
+                    &parsing_results,
+                    &parsed_transactions,
+                    response_slice,
+                    &working_bank,
+                );
+            }
+
+            // Do resolving next since we (currently) need resolved transactions for status checks.
+            let (parsing_and_resolve_results, txs, max_ages) =
+                Self::translate_transaction_batch(&batch, &root_bank);
+
+            if message.flags & check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
+                self.check_resolve_pubkeys(
+                    &parsing_results,
+                    &parsing_and_resolve_results,
+                    &txs,
+                    &max_ages,
+                    response_slice,
+                    root_bank.slot(),
+                )?;
+            }
+
+            if message.flags & check_message_flags::STATUS_CHECKS != 0 {
+                Self::check_status_checks(
+                    &parsing_and_resolve_results,
+                    &txs,
+                    response_slice,
+                    &working_bank,
+                );
+            }
+
+            self.sender
+                .try_write(CheckWorkerToPackMessage {
+                    batch: message.batch,
+                    processed_code: processed_codes::PROCESSED,
+                    responses,
+                })
+                .map_err(|_| ExternalCheckWorkerError::SenderDisconnected)?;
+
+            Ok(())
+        }
+
+        fn check_resolve_pubkeys(
+            &self,
+            parsing_results: &[Result<(), TransactionViewError>],
+            parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
+            txs: &[Tx],
+            max_ages: &[MaxAge],
+            responses: &mut [CheckResponse],
+            resolution_slot: Slot,
+        ) -> Result<(), ExternalCheckWorkerError> {
+            assert_eq!(parsing_results.len(), parsing_and_resolve_results.len());
+            assert_eq!(parsing_results.len(), responses.len());
+
+            let mut resolved_transaction_iter = txs.iter();
+            let mut max_age_iter = max_ages.iter();
+            for (transaction_index, (parsing_result, parsing_and_resolve_results)) in
+                parsing_results
+                    .iter()
+                    .zip(parsing_and_resolve_results.iter())
+                    .enumerate()
+            {
+                if parsing_result.is_err() {
+                    continue;
+                }
+
+                let response = &mut responses[transaction_index];
+                response.resolve_flags |= resolve_flags::PERFORMED;
+                if parsing_and_resolve_results.is_err() {
+                    response.resolve_flags |= resolve_flags::FAILED;
+                    continue;
+                }
+
+                let transaction = resolved_transaction_iter.next().expect(
+                    "resolved_transaction_iter iterator must contain element for each sent parsed \
+                     transaction",
+                );
+                let max_age = max_age_iter.next().expect(
+                    "max_age_iter iterator must contain element for each sent parsed transaction",
+                );
+
+                // Address table lookups are sanitized to contain at least one account, so there
+                // are loaded keys exactly when account keys outnumber static account keys.
+                let account_keys = transaction.account_keys();
+                let num_static_account_keys = transaction.static_account_keys().len();
+                let (sharable_keys, alt_invalidation_slot) = if account_keys.len()
+                    > num_static_account_keys
+                {
+                    let num_pubkeys = account_keys.len().wrapping_sub(num_static_account_keys);
+                    let pubkeys_allocation = self
+                        .allocator
+                        .allocate(num_pubkeys.wrapping_mul(core::mem::size_of::<Pubkey>()) as u32)
+                        .ok_or(ExternalCheckWorkerError::AllocationFailure)?
+                        .cast();
+                    // SAFETY: non-overlapping and appropriately sized.
+                    unsafe {
+                        Self::copy_loaded_addresses(
+                            account_keys.iter().skip(num_static_account_keys),
+                            pubkeys_allocation,
+                        )
+                    };
+                    // SAFETY: pubkeys_allocation was allocated by allocator.
+                    let offset = unsafe { self.allocator.offset(pubkeys_allocation.cast()) };
+                    (
+                        SharablePubkeys {
+                            offset,
+                            num_pubkeys: num_pubkeys as u32,
+                        },
+                        max_age.alt_invalidation_slot,
+                    )
+                } else {
+                    (
+                        SharablePubkeys {
+                            offset: 0,
+                            num_pubkeys: 0,
+                        },
+                        u64::MAX,
+                    )
+                };
+
+                response.resolution_slot = resolution_slot;
+                response.resolved_pubkeys = sharable_keys;
+                response.min_alt_deactivation_slot = alt_invalidation_slot;
+            }
+
+            Ok(())
+        }
+
+        fn return_unprocessed_message(
+            &mut self,
+            message: &PackToCheckWorkerMessage,
+            processed_code: u8,
+        ) -> Result<(), ExternalCheckWorkerError> {
+            assert_ne!(processed_code, processed_codes::PROCESSED);
+
+            self.sender
+                .try_write(CheckWorkerToPackMessage {
+                    batch: message.batch,
+                    processed_code,
+                    responses: CheckResponseRegion {
+                        num_transaction_responses: 0,
+                        transaction_responses_offset: 0,
+                    },
+                })
+                .map_err(|_| ExternalCheckWorkerError::SenderDisconnected)?;
+
+            Ok(())
+        }
+
+        /// # Safety:
+        /// - `responses_ptr` must be aligned and sufficiently sized.
+        unsafe fn parse_transactions_and_populate_initial_check_responses<'a>(
+            message: &PackToCheckWorkerMessage,
+            batch: &TransactionPtrBatch,
+            responses_ptr: NonNull<CheckResponse>,
+        ) -> (
+            ArrayVec<Result<(), TransactionViewError>, MAX_TRANSACTIONS_PER_MESSAGE>,
+            ArrayVec<TxView, MAX_TRANSACTIONS_PER_MESSAGE>,
+            &'a mut [CheckResponse],
+        ) {
+            let sanitize_config = sanitize_config();
+            let mut parsing_results = ArrayVec::new();
+            let mut parsed_transactions = ArrayVec::new();
+            for (tx_ptr, _) in batch.iter() {
+                match SanitizedTransactionView::try_new_sanitized(tx_ptr, &sanitize_config) {
+                    Ok(view) => {
+                        parsing_results.push(Ok(()));
+                        parsed_transactions.push(view);
+                    }
+                    Err(err) => {
+                        parsing_results.push(Err(err));
+                    }
+                }
+            }
+
+            // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions.
+            unsafe {
+                Self::check_populate_initial_messages(message, &parsing_results, responses_ptr)
+            };
+            // SAFETY: `response_ptr` is valid and of length message.batch.num_transactions.
+            let response_slice = unsafe {
+                core::slice::from_raw_parts_mut(
+                    responses_ptr.as_ptr(),
+                    usize::from(message.batch.num_transactions),
+                )
+            };
+
+            (parsing_results, parsed_transactions, response_slice)
+        }
+
+        /// # Safety
+        /// - `responses_ptr` is valid ptr for a slice of [`CheckResponse`] with at least
+        ///   length `message.batch.num_transactions`.
+        unsafe fn check_populate_initial_messages(
+            message: &PackToCheckWorkerMessage,
+            parsing_results: &[Result<(), TransactionViewError>],
+            responses_ptr: NonNull<CheckResponse>,
+        ) {
+            assert_eq!(
+                parsing_results.len(),
+                usize::from(message.batch.num_transactions)
+            );
+            let initial_status_check_flags =
+                if message.flags & check_message_flags::STATUS_CHECKS != 0 {
+                    status_check_flags::REQUESTED
+                } else {
+                    0
+                };
+            let initial_fee_payer_balance_flags =
+                if message.flags & check_message_flags::LOAD_FEE_PAYER_BALANCE != 0 {
+                    fee_payer_balance_flags::REQUESTED
+                } else {
+                    0
+                };
+            let initial_resolve_flags =
+                if message.flags & check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
+                    resolve_flags::REQUESTED
+                } else {
+                    0
+                };
+
+            for (transaction_index, parsing_result) in parsing_results.iter().enumerate() {
+                let parsing_and_sanitization_flags = if parsing_result.is_err() {
+                    parsing_and_sanitization_flags::FAILED
+                } else {
+                    0
+                };
+
+                // SAFETY: transaction_index is in bounds.
+                unsafe {
+                    responses_ptr.add(transaction_index).write(CheckResponse {
+                        parsing_and_sanitization_flags,
+                        status_check_flags: initial_status_check_flags,
+                        fee_payer_balance_flags: initial_fee_payer_balance_flags,
+                        resolve_flags: initial_resolve_flags,
+                        included_slot: 0,
+                        balance_slot: 0,
+                        fee_payer_balance: 0,
+                        resolution_slot: 0,
+                        min_alt_deactivation_slot: 0,
+                        resolved_pubkeys: SharablePubkeys {
+                            offset: 0,
+                            num_pubkeys: 0,
+                        },
+                    })
+                };
+            }
+        }
+
+        fn validate_message(message: &PackToCheckWorkerMessage) -> bool {
+            message.batch.num_transactions > 0
+                && usize::from(message.batch.num_transactions) <= MAX_TRANSACTIONS_PER_MESSAGE
+                && Self::validate_message_flags(message.flags)
+        }
+
+        fn validate_message_flags(flags: u16) -> bool {
+            const ALLOWED_CHECK_FLAGS: u16 = check_message_flags::STATUS_CHECKS
+                | check_message_flags::LOAD_FEE_PAYER_BALANCE
+                | check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES;
+
+            flags != 0 && flags & !ALLOWED_CHECK_FLAGS == 0
+        }
+
+        fn check_load_fee_payer_balance<D: TransactionData>(
+            parsing_results: &[Result<(), TransactionViewError>],
+            parsed_transactions: &[SanitizedTransactionView<D>],
+            responses: &mut [CheckResponse],
+            working_bank: &Bank,
+        ) {
+            assert_eq!(responses.len(), parsing_results.len());
+
+            let mut parsed_transaction_iter = parsed_transactions.iter();
+            for (transaction_index, parsing_result) in parsing_results.iter().enumerate() {
+                if parsing_result.is_err() {
+                    continue;
+                }
+
+                let transaction = parsed_transaction_iter.next().expect(
+                    "parsed_transaction_iter iterator must contain element for each sent parsed \
+                     transaction",
+                );
+
+                let fee_payer_balance = working_bank
+                    .get_account_with_fixed_root(transaction.fee_payer())
+                    .map(|account| account.lamports())
+                    .unwrap_or(0);
+
+                let response = &mut responses[transaction_index];
+                response.fee_payer_balance_flags |= fee_payer_balance_flags::PERFORMED;
+                response.fee_payer_balance = fee_payer_balance;
+                response.balance_slot = working_bank.slot();
+            }
+        }
+
+        fn check_status_checks<D: TransactionData>(
+            parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
+            txs: &[RuntimeTransaction<ResolvedTransactionView<D>>],
+            responses: &mut [CheckResponse],
+            working_bank: &Bank,
+        ) {
+            assert_eq!(parsing_and_resolve_results.len(), responses.len());
+
+            let mut error_counters = TransactionErrorMetrics::default();
+            let (status_check_results, included_slots) = working_bank
+                .check_transactions_with_processed_slots(
+                    txs,
+                    &[const { Ok(()) }; MAX_TRANSACTIONS_PER_MESSAGE],
+                    working_bank.max_processing_age(),
+                    true,
+                    true,
+                    &mut error_counters,
+                );
+            let included_slots = included_slots.expect("requested to collect processed slots");
+
+            let mut status_check_results_iter =
+                status_check_results.iter().zip(included_slots.iter());
+            for (transaction_index, parsing_and_resolve_result) in
+                parsing_and_resolve_results.iter().enumerate()
+            {
+                if parsing_and_resolve_result.is_err() {
+                    continue;
+                }
+                let (status_check_result, included_slot) = status_check_results_iter
+                    .next()
+                    .expect("status check results must have element for each sent transaction");
+
+                let check_response = &mut responses[transaction_index];
+                check_response.status_check_flags |= status_check_flags::PERFORMED;
+                match status_check_result {
+                    Err(TransactionError::BlockhashNotFound) => {
+                        check_response.status_check_flags |= status_check_flags::TOO_OLD;
+                    }
+                    Err(TransactionError::AlreadyProcessed) => {
+                        check_response.status_check_flags |= status_check_flags::ALREADY_PROCESSED;
+                        check_response.included_slot =
+                            included_slot.expect("included_slot must be set for already processed");
+                    }
+                    Err(TransactionError::UnsupportedVersion) => {
+                        check_response.status_check_flags |=
+                            status_check_flags::UNSUPPORTED_VERSION;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        fn translate_transaction_batch(
+            batch: &TransactionPtrBatch,
+            bank: &Bank,
+        ) -> (
+            ArrayVec<Result<(), PacketHandlingError>, MAX_TRANSACTIONS_PER_MESSAGE>,
+            ArrayVec<Tx, MAX_TRANSACTIONS_PER_MESSAGE>,
+            ArrayVec<MaxAge, MAX_TRANSACTIONS_PER_MESSAGE>,
+        ) {
+            let sanitize_config = sanitize_config();
+            let transaction_account_lock_limit = bank.get_transaction_account_lock_limit();
+
+            let mut translation_results = ArrayVec::new();
+            let mut transactions = ArrayVec::new();
+            let mut max_ages = ArrayVec::new();
+            for (transaction_ptr, _) in batch.iter() {
+                match Self::translate_transaction(
+                    transaction_ptr,
+                    bank,
+                    transaction_account_lock_limit,
+                    &sanitize_config,
+                ) {
+                    Ok((tx, max_age)) => {
+                        transactions.push(tx);
+                        max_ages.push(max_age);
+                        translation_results.push(Ok(()));
+                    }
+                    Err(err) => translation_results.push(Err(err)),
+                }
+            }
+
+            (translation_results, transactions, max_ages)
+        }
+
+        fn translate_transaction(
+            transaction_ptr: TransactionPtr,
+            bank: &Bank,
+            transaction_account_lock_limit: usize,
+            sanitize_config: &SanitizeConfig,
+        ) -> Result<(Tx, MaxAge), PacketHandlingError> {
+            translate_to_runtime_view(
+                transaction_ptr,
+                bank,
+                transaction_account_lock_limit,
+                sanitize_config,
+            )
+            .map(|(view, deactivation_slot)| {
+                (
+                    view,
+                    MaxAge {
+                        sanitized_epoch: bank.epoch(),
+                        alt_invalidation_slot: deactivation_slot,
+                    },
+                )
+            })
+        }
+
+        /// # Safety
+        /// - destination is appropriately sized
+        /// - destination does not overlap with loaded_addresses allocation
+        unsafe fn copy_loaded_addresses<'a>(
+            loaded_addresses: impl Iterator<Item = &'a Pubkey>,
+            dest: NonNull<Pubkey>,
+        ) {
+            for (index, pubkey) in loaded_addresses.enumerate() {
+                unsafe { dest.add(index).write(*pubkey) };
+            }
+        }
+    }
+
+    /// Returns an active leader state if available, otherwise None.
+    fn active_leader_state(
+        shared_leader_state: &SharedLeaderState,
+    ) -> Option<arc_swap::Guard<Arc<LeaderState>>> {
+        let guard = shared_leader_state.load();
+        if guard
+            .as_ref()
+            .working_bank()
+            .map(|bank| bank.is_complete())
+            .unwrap_or(true)
+        {
+            None
+        } else {
+            Some(guard)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use {
+            super::*,
+            crate::banking_stage::tests::create_slow_genesis_config,
+            agave_scheduler_bindings::{SharableTransactionBatchRegion, SharableTransactionRegion},
+            agave_scheduling_utils::{
+                handshake::{ClientLogon, client, server::Server},
+                responses_region::CheckResponsesPtr,
+            },
+            solana_account::AccountSharedData,
+            solana_keypair::Keypair,
+            solana_leader_schedule::SlotLeader,
+            solana_ledger::genesis_utils::GenesisConfigInfo,
+            solana_runtime::{bank::Bank, bank_forks::BankForks},
+            solana_sdk_ids::system_program,
+            solana_signer::Signer,
+            solana_system_transaction::transfer,
+            std::{
+                sync::{Arc, RwLock},
+                time::Duration,
+            },
+        };
+
+        struct SharedBatch {
+            region: SharableTransactionBatchRegion,
+            transactions: Vec<SharableTransactionRegion>,
+        }
+
+        struct CheckWorkerTestFrame {
+            bank: Arc<Bank>,
+            _bank_forks: Arc<RwLock<BankForks>>,
+            allocator: rts_alloc::Allocator,
+            pack_to_check_worker: shaq::mpmc::Producer<PackToCheckWorkerMessage>,
+            check_worker_to_pack: shaq::mpmc::Consumer<CheckWorkerToPackMessage>,
+            worker: ExternalCheckWorker,
+        }
+
+        impl CheckWorkerTestFrame {
+            fn send_message(&self, message: PackToCheckWorkerMessage) {
+                self.pack_to_check_worker.try_write(message).unwrap();
+            }
+
+            fn iterate(&mut self) -> Result<(), ExternalCheckWorkerError> {
+                let result = self.worker.iterate(Duration::ZERO)?;
+                assert!(matches!(result, IterationResult::ProcessedMessage));
+                Ok(())
+            }
+
+            fn iterate_idle(&mut self) -> Result<(), ExternalCheckWorkerError> {
+                let result = self.worker.iterate(Duration::ZERO)?;
+                assert!(matches!(result, IterationResult::Idle));
+                Ok(())
+            }
+
+            fn recv_response(&self) -> CheckWorkerToPackMessage {
+                self.check_worker_to_pack
+                    .read_timeout(Duration::from_secs(1))
+                    .unwrap()
+            }
+
+            fn check_responses(&self, region: &CheckResponseRegion) -> Vec<CheckResponse> {
+                unsafe {
+                    // SAFETY: `region` was produced by this worker using the same shared allocator,
+                    // and the pointed-to allocation contains `CheckResponse` values.
+                    let responses = CheckResponsesPtr::from_transaction_response_region(
+                        region,
+                        &self.allocator,
+                    );
+                    let decoded = responses.iter().copied().collect();
+                    responses.free(&self.allocator);
+                    decoded
+                }
+            }
+
+            fn allocate_batch(&self, transactions: &[Vec<u8>]) -> SharedBatch {
+                type Batch<'a> = TransactionPtrBatch<'a>;
+                assert!(transactions.len() <= MAX_TRANSACTIONS_PER_MESSAGE);
+
+                let batch_ptr = self
+                    .allocator
+                    .allocate(Batch::TRANSACTION_META_END as u32)
+                    .unwrap();
+                // SAFETY: `batch_ptr` came from this allocator immediately above, so translating it
+                // back to an offset in the same allocator is valid.
+                let batch_offset = unsafe { self.allocator.offset(batch_ptr) };
+                let tx_ptr = batch_ptr.cast::<SharableTransactionRegion>();
+
+                let mut sharable_transactions = Vec::with_capacity(transactions.len());
+                for (index, transaction) in transactions.iter().enumerate() {
+                    let tx_allocation = self
+                        .allocator
+                        .allocate(transaction.len().try_into().unwrap())
+                        .unwrap();
+                    unsafe {
+                        // SAFETY: `tx_allocation` points to a fresh allocation of exactly
+                        // `transaction.len()` bytes, and `transaction.as_ptr()` is readable for that
+                        // same length. The regions do not overlap.
+                        std::ptr::copy_nonoverlapping(
+                            transaction.as_ptr(),
+                            tx_allocation.as_ptr(),
+                            transaction.len(),
+                        );
+                    }
+                    let tx_region = SharableTransactionRegion {
+                        // SAFETY: `tx_allocation` came from this allocator immediately above, so
+                        // translating it back to an offset in the same allocator is valid.
+                        offset: unsafe { self.allocator.offset(tx_allocation) },
+                        length: transaction.len().try_into().unwrap(),
+                    };
+                    unsafe {
+                        // SAFETY: the batch allocation is sized for
+                        // `TransactionPtrBatch::TRANSACTION_META_END`, which includes space for up to
+                        // `MAX_TRANSACTIONS_PER_MESSAGE` transaction headers, and the assert above
+                        // guarantees `index` is in-bounds.
+                        tx_ptr.add(index).write(tx_region)
+                    };
+                    sharable_transactions.push(tx_region);
+                }
+
+                SharedBatch {
+                    region: SharableTransactionBatchRegion {
+                        num_transactions: transactions.len().try_into().unwrap(),
+                        transactions_offset: batch_offset,
+                    },
+                    transactions: sharable_transactions,
+                }
+            }
+
+            fn free_batch(&self, batch: SharedBatch) {
+                for tx in batch.transactions {
+                    unsafe {
+                        // SAFETY: each `tx.offset` was allocated by this allocator in
+                        // `allocate_batch`, and `SharedBatch` owns each allocation exactly once.
+                        self.allocator
+                            .free(self.allocator.ptr_from_offset(tx.offset));
+                    }
+                }
+                unsafe {
+                    // SAFETY: `transactions_offset` is the batch container allocation created by
+                    // `allocate_batch`, and `SharedBatch` owns it exclusively here.
+                    self.allocator.free(
+                        self.allocator
+                            .ptr_from_offset(batch.region.transactions_offset),
+                    );
+                }
+            }
+        }
+
+        fn setup_check_worker_test_frame() -> CheckWorkerTestFrame {
+            let GenesisConfigInfo { genesis_config, .. } = create_slow_genesis_config(10_000);
+            let (root_bank, _root_bank_forks) =
+                Bank::new_with_bank_forks_for_tests(&genesis_config);
+            let child_bank = Bank::new_from_parent(root_bank, SlotLeader::new_unique(), 1);
+            let (bank, bank_forks) = child_bank.wrap_with_bank_forks_for_tests();
+
+            let logon = ClientLogon {
+                worker_count: 1,
+                check_worker_count: 1,
+                allocator_size: 64 * 1024 * 1024,
+                allocator_handles: 1,
+                tpu_to_pack_capacity: 16,
+                progress_tracker_capacity: 16,
+                pack_to_worker_capacity: 16,
+                worker_to_pack_capacity: 16,
+                flags: 0,
+                pack_to_check_worker_capacity: 16,
+                check_worker_to_pack_capacity: 16,
+            };
+            let (_agave_session, files) = Server::setup_session(logon).unwrap();
+            let mut client_session = client::setup_session(&logon, files).unwrap();
+            let allocator = client_session.allocators.pop().unwrap();
+
+            let (pack_to_check_worker, receiver) = shaq::mpmc::pair(16).unwrap();
+            let (check_worker_to_pack, response_receiver) = shaq::mpmc::pair(16).unwrap();
+            let worker_allocator = rts_alloc::Allocator::join_from_existing(&allocator)
+                .expect("join allocator from test allocator");
+            let shared_leader_state = SharedLeaderState::new(0, None, None);
+            let worker = ExternalCheckWorker::new(
+                Arc::new(AtomicBool::new(false)),
+                receiver,
+                check_worker_to_pack,
+                worker_allocator,
+                shared_leader_state,
+                bank_forks.read().unwrap().sharable_banks(),
+            );
+
+            CheckWorkerTestFrame {
+                bank,
+                _bank_forks: bank_forks,
+                allocator,
+                pack_to_check_worker,
+                check_worker_to_pack: response_receiver,
+                worker,
+            }
+        }
+
+        fn test_serialized_transaction(recent_blockhash: solana_hash::Hash) -> Vec<u8> {
+            wincode::serialize(&transfer(
+                &Keypair::new(),
+                &Pubkey::new_unique(),
+                1,
+                recent_blockhash,
+            ))
+            .unwrap()
+        }
+
+        #[test]
+        fn test_idle_timeout() {
+            let mut test_frame = setup_check_worker_test_frame();
+            test_frame.iterate_idle().unwrap();
+        }
+
+        #[test]
+        fn test_invalid_message() {
+            let mut test_frame = setup_check_worker_test_frame();
+
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: check_message_flags::STATUS_CHECKS,
+                batch: SharableTransactionBatchRegion {
+                    num_transactions: 0,
+                    transactions_offset: 0,
+                },
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            assert_eq!(response.processed_code, processed_codes::INVALID);
+            assert_eq!(response.responses.num_transaction_responses, 0);
+            assert_eq!(response.responses.transaction_responses_offset, 0);
+
+            let batch = test_frame.allocate_batch(&[test_serialized_transaction(
+                test_frame.bank.confirmed_last_blockhash(),
+            )]);
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: u16::MAX,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            assert_eq!(response.processed_code, processed_codes::INVALID);
+            assert_eq!(response.responses.num_transaction_responses, 0);
+            assert_eq!(response.responses.transaction_responses_offset, 0);
+
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: 0,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            assert_eq!(response.processed_code, processed_codes::INVALID);
+            assert_eq!(response.responses.num_transaction_responses, 0);
+            assert_eq!(response.responses.transaction_responses_offset, 0);
+
+            test_frame.free_batch(batch);
+        }
+
+        #[test]
+        fn test_happy_path() {
+            let mut test_frame = setup_check_worker_test_frame();
+            let fee_payer = Keypair::new();
+            let fee_payer_balance = 123_456;
+            test_frame.bank.store_account(
+                &fee_payer.pubkey(),
+                &AccountSharedData::new(fee_payer_balance, 0, &system_program::ID),
+            );
+
+            let batch = test_frame.allocate_batch(&[wincode::serialize(&transfer(
+                &fee_payer,
+                &Pubkey::new_unique(),
+                1,
+                test_frame.bank.confirmed_last_blockhash(),
+            ))
+            .unwrap()]);
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: check_message_flags::STATUS_CHECKS
+                    | check_message_flags::LOAD_FEE_PAYER_BALANCE,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            assert_eq!(response.processed_code, processed_codes::PROCESSED);
+            let responses = test_frame.check_responses(&response.responses);
+            assert_eq!(responses.len(), 1);
+            assert_eq!(
+                responses[0].status_check_flags,
+                status_check_flags::REQUESTED | status_check_flags::PERFORMED
+            );
+            assert_eq!(
+                responses[0].fee_payer_balance_flags,
+                fee_payer_balance_flags::REQUESTED | fee_payer_balance_flags::PERFORMED
+            );
+            assert_eq!(responses[0].balance_slot, test_frame.bank.slot());
+            assert_eq!(responses[0].fee_payer_balance, fee_payer_balance);
+
+            test_frame.free_batch(batch);
+        }
+
+        #[test]
+        fn test_resolve_without_loaded_addresses() {
+            let mut test_frame = setup_check_worker_test_frame();
+            let batch = test_frame.allocate_batch(&[test_serialized_transaction(
+                test_frame.bank.confirmed_last_blockhash(),
+            )]);
+
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            assert_eq!(response.processed_code, processed_codes::PROCESSED);
+            let responses = test_frame.check_responses(&response.responses);
+            assert_eq!(responses.len(), 1);
+            assert_eq!(
+                responses[0].resolve_flags,
+                resolve_flags::REQUESTED | resolve_flags::PERFORMED
+            );
+            assert_eq!(responses[0].resolution_slot, test_frame.bank.slot());
+            assert_eq!(responses[0].resolved_pubkeys.num_pubkeys, 0);
+            assert_eq!(responses[0].min_alt_deactivation_slot, u64::MAX);
+
+            test_frame.free_batch(batch);
+        }
+    }
+}

--- a/core/src/banking_stage/transaction_scheduler/check_worker.rs
+++ b/core/src/banking_stage/transaction_scheduler/check_worker.rs
@@ -133,7 +133,7 @@ pub(crate) mod external {
             PackToCheckWorkerMessage, SharablePubkeys, check_message_flags, processed_codes,
             worker_message_types::{
                 CheckResponse, fee_payer_balance_flags, parsing_and_sanitization_flags,
-                resolve_flags, status_check_flags,
+                resolve_flags, scheduling_details_flags, status_check_flags,
             },
         },
         agave_scheduling_utils::{
@@ -148,6 +148,7 @@ pub(crate) mod external {
         arrayvec::ArrayVec,
         solana_account::ReadableAccount,
         solana_clock::Slot,
+        solana_cost_model::cost_model::CostModel,
         solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
         solana_pubkey::Pubkey,
         solana_runtime::{
@@ -156,6 +157,7 @@ pub(crate) mod external {
         },
         solana_runtime_transaction::{
             runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+            transaction_meta::TransactionMeta,
         },
         solana_svm::transaction_error_metrics::TransactionErrorMetrics,
         solana_svm_transaction::svm_message::{SVMMessage, SVMStaticMessage},
@@ -304,6 +306,16 @@ pub(crate) mod external {
             let (parsing_and_resolve_results, txs, max_ages) =
                 Self::translate_transaction_batch(&batch, &root_bank);
 
+            if message.flags & check_message_flags::CALCULATE_SCHEDULING_DETAILS != 0 {
+                Self::check_scheduling_details(
+                    &parsing_results,
+                    &parsing_and_resolve_results,
+                    &txs,
+                    response_slice,
+                    &working_bank,
+                );
+            }
+
             if message.flags & check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES != 0 {
                 self.check_resolve_pubkeys(
                     &parsing_results,
@@ -360,6 +372,9 @@ pub(crate) mod external {
                 }
 
                 let response = &mut responses[transaction_index];
+                if response.scheduling_details_flags & scheduling_details_flags::FAILED != 0 {
+                    continue;
+                }
                 response.resolve_flags |= resolve_flags::PERFORMED;
                 if parsing_and_resolve_results.is_err() {
                     response.resolve_flags |= resolve_flags::FAILED;
@@ -513,6 +528,12 @@ pub(crate) mod external {
                 } else {
                     0
                 };
+            let initial_scheduling_details_flags =
+                if message.flags & check_message_flags::CALCULATE_SCHEDULING_DETAILS != 0 {
+                    scheduling_details_flags::REQUESTED
+                } else {
+                    0
+                };
 
             for (transaction_index, parsing_result) in parsing_results.iter().enumerate() {
                 let parsing_and_sanitization_flags = if parsing_result.is_err() {
@@ -528,7 +549,12 @@ pub(crate) mod external {
                         status_check_flags: initial_status_check_flags,
                         fee_payer_balance_flags: initial_fee_payer_balance_flags,
                         resolve_flags: initial_resolve_flags,
+                        scheduling_details_flags: initial_scheduling_details_flags,
                         included_slot: 0,
+                        transaction_fee: 0,
+                        prioritization_fee: 0,
+                        estimated_cost_units: 0,
+                        allocated_accounts_data_size: 0,
                         balance_slot: 0,
                         fee_payer_balance: 0,
                         resolution_slot: 0,
@@ -551,7 +577,8 @@ pub(crate) mod external {
         fn validate_message_flags(flags: u16) -> bool {
             const ALLOWED_CHECK_FLAGS: u16 = check_message_flags::STATUS_CHECKS
                 | check_message_flags::LOAD_FEE_PAYER_BALANCE
-                | check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES;
+                | check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES
+                | check_message_flags::CALCULATE_SCHEDULING_DETAILS;
 
             flags != 0 && flags & !ALLOWED_CHECK_FLAGS == 0
         }
@@ -584,6 +611,63 @@ pub(crate) mod external {
                 response.fee_payer_balance_flags |= fee_payer_balance_flags::PERFORMED;
                 response.fee_payer_balance = fee_payer_balance;
                 response.balance_slot = working_bank.slot();
+            }
+        }
+
+        fn check_scheduling_details(
+            parsing_results: &[Result<(), TransactionViewError>],
+            parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
+            txs: &[Tx],
+            responses: &mut [CheckResponse],
+            working_bank: &Bank,
+        ) {
+            assert_eq!(parsing_results.len(), parsing_and_resolve_results.len());
+            assert_eq!(parsing_results.len(), responses.len());
+
+            let mut resolved_transaction_iter = txs.iter();
+            for (transaction_index, (parsing_result, parsing_and_resolve_result)) in parsing_results
+                .iter()
+                .zip(parsing_and_resolve_results.iter())
+                .enumerate()
+            {
+                if parsing_result.is_err() {
+                    continue;
+                }
+
+                let response = &mut responses[transaction_index];
+                response.scheduling_details_flags |= scheduling_details_flags::PERFORMED;
+                if parsing_and_resolve_result.is_err() {
+                    response.scheduling_details_flags |= scheduling_details_flags::FAILED;
+                    continue;
+                }
+
+                let transaction = resolved_transaction_iter.next().expect(
+                    "resolved_transaction_iter must contain an element for each successfully \
+                     translated transaction",
+                );
+                let Ok(configuration) =
+                    transaction.transaction_configuration(&working_bank.feature_set)
+                else {
+                    response.scheduling_details_flags |= scheduling_details_flags::FAILED;
+                    continue;
+                };
+
+                let fee_details = solana_fee::calculate_fee_details(
+                    transaction,
+                    working_bank.fee_structure().lamports_per_signature,
+                    configuration.priority_fee_lamports,
+                    working_bank.fee_features(),
+                );
+                response.transaction_fee = fee_details.transaction_fee();
+                response.prioritization_fee = fee_details.prioritization_fee();
+                let cost = CostModel::calculate_cost_for_executed_transaction(
+                    transaction,
+                    u64::from(configuration.compute_unit_limit),
+                    configuration.loaded_accounts_data_size_limit,
+                    &working_bank.feature_set,
+                );
+                response.estimated_cost_units = cost.sum();
+                response.allocated_accounts_data_size = cost.allocated_accounts_data_size();
             }
         }
 
@@ -736,13 +820,16 @@ pub(crate) mod external {
                 responses_region::CheckResponsesPtr,
             },
             solana_account::AccountSharedData,
+            solana_compute_budget_interface::ComputeBudgetInstruction,
             solana_keypair::Keypair,
             solana_leader_schedule::SlotLeader,
             solana_ledger::genesis_utils::GenesisConfigInfo,
+            solana_message::Message,
             solana_runtime::{bank::Bank, bank_forks::BankForks},
             solana_sdk_ids::system_program,
             solana_signer::Signer,
             solana_system_transaction::transfer,
+            solana_transaction::Transaction,
             std::{
                 sync::{Arc, RwLock},
                 time::Duration,
@@ -1018,6 +1105,95 @@ pub(crate) mod external {
             );
             assert_eq!(responses[0].balance_slot, test_frame.bank.slot());
             assert_eq!(responses[0].fee_payer_balance, fee_payer_balance);
+            assert_eq!(responses[0].scheduling_details_flags, 0);
+
+            test_frame.free_batch(batch);
+        }
+
+        #[test]
+        fn test_scheduling_details() {
+            let mut test_frame = setup_check_worker_test_frame();
+            let fee_payer = Keypair::new();
+            let allocated_account = Keypair::new();
+            let allocated_accounts_data_size = 1_234;
+            let transaction = Transaction::new(
+                &[&fee_payer, &allocated_account],
+                Message::new(
+                    &[
+                        solana_system_interface::instruction::create_account(
+                            &fee_payer.pubkey(),
+                            &allocated_account.pubkey(),
+                            1,
+                            allocated_accounts_data_size,
+                            &Pubkey::new_unique(),
+                        ),
+                        ComputeBudgetInstruction::set_compute_unit_price(1_000_000),
+                    ],
+                    Some(&fee_payer.pubkey()),
+                ),
+                test_frame.bank.confirmed_last_blockhash(),
+            );
+            let batch = test_frame.allocate_batch(&[wincode::serialize(&transaction).unwrap()]);
+
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: check_message_flags::CALCULATE_SCHEDULING_DETAILS,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            let responses = test_frame.check_responses(&response.responses);
+
+            assert_eq!(responses.len(), 1);
+            assert_eq!(
+                responses[0].scheduling_details_flags,
+                scheduling_details_flags::REQUESTED | scheduling_details_flags::PERFORMED
+            );
+            assert_eq!(
+                responses[0].transaction_fee,
+                2 * test_frame.bank.fee_structure().lamports_per_signature
+            );
+            assert!(responses[0].prioritization_fee > 0);
+            assert!(responses[0].estimated_cost_units > 0);
+            assert_eq!(
+                responses[0].allocated_accounts_data_size,
+                allocated_accounts_data_size
+            );
+
+            test_frame.free_batch(batch);
+        }
+
+        #[test]
+        fn test_scheduling_details_failure_skips_pubkey_resolution() {
+            let mut test_frame = setup_check_worker_test_frame();
+            let fee_payer = Keypair::new();
+            let transaction = Transaction::new(
+                &[&fee_payer],
+                Message::new(
+                    &[ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0)],
+                    Some(&fee_payer.pubkey()),
+                ),
+                test_frame.bank.confirmed_last_blockhash(),
+            );
+            let batch = test_frame.allocate_batch(&[wincode::serialize(&transaction).unwrap()]);
+
+            test_frame.send_message(PackToCheckWorkerMessage {
+                flags: check_message_flags::CALCULATE_SCHEDULING_DETAILS
+                    | check_message_flags::LOAD_ADDRESS_LOOKUP_TABLES,
+                batch: batch.region,
+            });
+            test_frame.iterate().unwrap();
+            let response = test_frame.recv_response();
+            let responses = test_frame.check_responses(&response.responses);
+
+            assert_eq!(responses.len(), 1);
+            assert_eq!(
+                responses[0].scheduling_details_flags,
+                scheduling_details_flags::REQUESTED
+                    | scheduling_details_flags::PERFORMED
+                    | scheduling_details_flags::FAILED
+            );
+            assert_eq!(responses[0].resolve_flags, resolve_flags::REQUESTED);
+            assert_eq!(responses[0].resolved_pubkeys.num_pubkeys, 0);
 
             test_frame.free_batch(batch);
         }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -115,7 +115,7 @@ pub struct CostTracker {
     cost_by_writable_accounts: HashMap<Pubkey, u64, ahash::RandomState>,
     block_cost: SharedBlockCost,
     transaction_count: Saturating<u64>,
-    allocated_accounts_data_size: Saturating<u64>,
+    allocated_accounts_data_size: SharedAllocatedAccountsDataSize,
     transaction_signature_count: Saturating<u64>,
     secp256k1_instruction_signature_count: Saturating<u64>,
     ed25519_instruction_signature_count: Saturating<u64>,
@@ -136,7 +136,7 @@ impl Default for CostTracker {
             ),
             block_cost: SharedBlockCost::new(0),
             transaction_count: Saturating(0),
-            allocated_accounts_data_size: Saturating(0),
+            allocated_accounts_data_size: SharedAllocatedAccountsDataSize::new(0),
             transaction_signature_count: Saturating(0),
             secp256k1_instruction_signature_count: Saturating(0),
             ed25519_instruction_signature_count: Saturating(0),
@@ -217,10 +217,12 @@ impl CostTracker {
             return Err(CostTrackerError::WouldExceedAccountMaxLimit);
         }
 
-        let allocated_accounts_data_size =
-            self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
+        let allocated_accounts_data_size = self
+            .allocated_accounts_data_size
+            .load()
+            .saturating_add(tx_cost.allocated_accounts_data_size());
 
-        if allocated_accounts_data_size.0 > self.limits.allocated_data_size {
+        if allocated_accounts_data_size > self.limits.allocated_data_size {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
         }
 
@@ -254,7 +256,8 @@ impl CostTracker {
         }
 
         // every check passed: publish the block-level state
-        self.allocated_accounts_data_size = allocated_accounts_data_size;
+        self.allocated_accounts_data_size
+            .store(allocated_accounts_data_size);
         self.transaction_count += 1;
         self.transaction_signature_count += tx_cost.num_transaction_signatures();
         self.secp256k1_instruction_signature_count +=
@@ -331,6 +334,10 @@ impl CostTracker {
         self.block_cost.clone()
     }
 
+    pub fn shared_allocated_accounts_data_size(&self) -> SharedAllocatedAccountsDataSize {
+        self.allocated_accounts_data_size.clone()
+    }
+
     pub fn transaction_count(&self) -> u64 {
         self.transaction_count.0
     }
@@ -343,7 +350,7 @@ impl CostTracker {
             number_of_accounts: self.number_of_accounts(),
             costliest_account,
             costliest_account_cost,
-            allocated_accounts_data_size: self.allocated_accounts_data_size.0,
+            allocated_accounts_data_size: self.allocated_accounts_data_size.load(),
             transaction_signature_count: self.transaction_signature_count.0,
             secp256k1_instruction_signature_count: self.secp256k1_instruction_signature_count.0,
             ed25519_instruction_signature_count: self.ed25519_instruction_signature_count.0,
@@ -378,7 +385,11 @@ impl CostTracker {
     fn remove_transaction_cost(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
         let cost = tx_cost.sum();
         self.sub_transaction_execution_cost(tx_cost, cost);
-        self.allocated_accounts_data_size -= tx_cost.allocated_accounts_data_size();
+        self.allocated_accounts_data_size.store(
+            self.allocated_accounts_data_size
+                .load()
+                .saturating_sub(tx_cost.allocated_accounts_data_size()),
+        );
         self.transaction_count -= 1;
         self.transaction_signature_count -= tx_cost.num_transaction_signatures();
         self.secp256k1_instruction_signature_count -=
@@ -454,6 +465,25 @@ impl SharedBlockCost {
 
     fn fetch_sub(&self, value: u64) -> u64 {
         self.0.fetch_sub(value, Ordering::Release)
+    }
+
+    pub fn load(&self) -> u64 {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Wrapper around the allocated accounts data size to allow fast sharing of the value without
+/// locking. Value is read-only outside of cost-tracker.
+#[derive(Debug, Clone)]
+pub struct SharedAllocatedAccountsDataSize(Arc<AtomicU64>);
+
+impl SharedAllocatedAccountsDataSize {
+    pub fn new(value: u64) -> Self {
+        Self(Arc::new(AtomicU64::new(value)))
+    }
+
+    fn store(&self, value: u64) {
+        self.0.store(value, Ordering::Release);
     }
 
     pub fn load(&self) -> u64 {
@@ -578,9 +608,10 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost);
-        let old = testee.allocated_accounts_data_size;
+        let shared_allocated_accounts_data_size = testee.shared_allocated_accounts_data_size();
+        let old = shared_allocated_accounts_data_size.load();
         assert!(testee.try_add(&tx_cost).is_ok());
-        assert_eq!(old.0 + 1, testee.allocated_accounts_data_size.0);
+        assert_eq!(old + 1, shared_allocated_accounts_data_size.load());
     }
 
     #[test]
@@ -1024,14 +1055,14 @@ mod tests {
         assert_eq!(1, cost_tracker.transaction_count.0);
         assert_eq!(1, cost_tracker.number_of_accounts());
         assert_eq!(cost, cost_tracker.block_cost());
-        assert_eq!(0, cost_tracker.allocated_accounts_data_size.0);
+        assert_eq!(0, cost_tracker.allocated_accounts_data_size.load());
 
         cost_tracker.remove_transaction_cost(&tx_cost);
         // assert cost_tracker is reverted to default
         assert_eq!(0, cost_tracker.transaction_count.0);
         assert_eq!(0, cost_tracker.number_of_accounts());
         assert_eq!(0, cost_tracker.block_cost());
-        assert_eq!(0, cost_tracker.allocated_accounts_data_size.0);
+        assert_eq!(0, cost_tracker.allocated_accounts_data_size.load());
         let stats = cost_tracker.stats();
         assert_eq!(stats.block_cost, 0);
         assert_eq!(stats.transaction_count, 0);

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -306,8 +306,9 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadd1abed9cc620c70f5ff2f517317426a57f77c405e9de8bf09a2b29e629ad6"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -307,8 +307,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4729a9b34a80022313a748b9d47f0f1bcb74a96975e8d633f43cd4da8446260f"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -222,8 +222,9 @@ dependencies = [
 
 [[package]]
 name = "agave-scheduler-bindings"
-version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadd1abed9cc620c70f5ff2f517317426a57f77c405e9de8bf09a2b29e629ad6"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=a53f0acb64369b7719785f97134b3c2f3d06870e#a53f0acb64369b7719785f97134b3c2f3d06870e"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=fba9fcadc3c6742f15e2aa81b7b78f5223c5d279#fba9fcadc3c6742f15e2aa81b7b78f5223c5d279"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=6ccb2739f74eb6a249510fedd6a21780b09db114#6ccb2739f74eb6a249510fedd6a21780b09db114"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997#c7ae1a6a99a018d2c8bffa7bb6f779225f4e7997"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -223,8 +223,7 @@ dependencies = [
 [[package]]
 name = "agave-scheduler-bindings"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4729a9b34a80022313a748b9d47f0f1bcb74a96975e8d633f43cd4da8446260f"
+source = "git+https://github.com/anza-xyz/agave-sdk?rev=128915a413a9903e31b75240649562205b92a388#128915a413a9903e31b75240649562205b92a388"
 
 [[package]]
 name = "agave-scheduling-utils"

--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -3,6 +3,7 @@ use {
         ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession,
         shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
     },
+    agave_scheduler_bindings::{PackToWorkerMessage, WorkerToPackMessage},
     libc::CMSG_LEN,
     nix::sys::socket::{self, ControlMessageOwned, MsgFlags, UnixAddr},
     rts_alloc::Allocator,
@@ -19,7 +20,7 @@ use {
 };
 
 /// Number of global shared memory objects (in addition to per worker objects).
-const GLOBAL_SHMEM: usize = 3;
+const GLOBAL_SHMEM: usize = 5;
 
 /// The maximum size in bytes of the control message containing the queues assuming [`MAX_WORKERS`]
 /// is respected.
@@ -138,7 +139,14 @@ pub fn setup_session(
         return Err(ClientHandshakeError::ProtocolViolation);
     }
     let (global_files, worker_files) = files.split_at(GLOBAL_SHMEM);
-    let [allocator_file, tpu_to_pack_file, progress_tracker_file] = global_files else {
+    let [
+        allocator_file,
+        tpu_to_pack_file,
+        progress_tracker_file,
+        pack_to_check_worker_file,
+        check_worker_to_pack_file,
+    ] = global_files
+    else {
         unreachable!();
     };
 
@@ -161,6 +169,14 @@ pub fn setup_session(
         allocators,
         tpu_to_pack: unsafe { shaq::spsc::Consumer::join(tpu_to_pack_file)? },
         progress_tracker: unsafe { shaq::spsc::Consumer::join(progress_tracker_file)? },
+        // SAFETY: the server initialized this FD as a matching MPMC consumer.
+        pack_to_check_worker: unsafe {
+            shaq::mpmc::Producer::<PackToWorkerMessage>::join(pack_to_check_worker_file)?
+        },
+        // SAFETY: the server initialized this FD as a matching MPMC producer.
+        check_worker_to_pack: unsafe {
+            shaq::mpmc::Consumer::<WorkerToPackMessage>::join(check_worker_to_pack_file)?
+        },
         workers: worker_files
             .chunks(2)
             .map(|window| {

--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -3,7 +3,7 @@ use {
         ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession,
         shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
     },
-    agave_scheduler_bindings::{PackToWorkerMessage, WorkerToPackMessage},
+    agave_scheduler_bindings::{CheckWorkerToPackMessage, PackToCheckWorkerMessage},
     libc::CMSG_LEN,
     nix::sys::socket::{self, ControlMessageOwned, MsgFlags, UnixAddr},
     rts_alloc::Allocator,
@@ -171,11 +171,11 @@ pub fn setup_session(
         progress_tracker: unsafe { shaq::spsc::Consumer::join(progress_tracker_file)? },
         // SAFETY: the server initialized this FD as a matching MPMC consumer.
         pack_to_check_worker: unsafe {
-            shaq::mpmc::Producer::<PackToWorkerMessage>::join(pack_to_check_worker_file)?
+            shaq::mpmc::Producer::<PackToCheckWorkerMessage>::join(pack_to_check_worker_file)?
         },
         // SAFETY: the server initialized this FD as a matching MPMC producer.
         check_worker_to_pack: unsafe {
-            shaq::mpmc::Consumer::<WorkerToPackMessage>::join(check_worker_to_pack_file)?
+            shaq::mpmc::Consumer::<CheckWorkerToPackMessage>::join(check_worker_to_pack_file)?
         },
         workers: worker_files
             .chunks(2)

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -1,12 +1,15 @@
 use {
     crate::handshake::{
-        AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession, ClientLogon,
+        AgaveCheckWorkerSession, AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession,
+        ClientLogon,
         shared::{
             AgaveSession, GLOBAL_ALLOCATORS, LOGON_FAILURE, LOGON_SUCCESS, MAX_ALLOCATOR_HANDLES,
             MAX_WORKERS, VERSION,
         },
     },
-    agave_scheduler_bindings::{PackToWorkerMessage, WorkerToPackMessage},
+    agave_scheduler_bindings::{
+        CheckWorkerToPackMessage, PackToCheckWorkerMessage, PackToExecutionWorkerMessage,
+    },
     nix::sys::socket::{self, ControlMessage, MsgFlags, UnixAddr},
     rts_alloc::Allocator,
     std::{
@@ -132,6 +135,12 @@ impl Server {
             return Err(AgaveHandshakeError::WorkerCount(logon.worker_count));
         }
 
+        if !(1..=MAX_WORKERS).contains(&logon.check_worker_count) {
+            return Err(AgaveHandshakeError::CheckWorkerCount(
+                logon.check_worker_count,
+            ));
+        }
+
         // Hard limit allocator handles to 128.
         if !(1..=MAX_ALLOCATOR_HANDLES).contains(&logon.allocator_handles) {
             return Err(AgaveHandshakeError::AllocatorHandles(
@@ -145,8 +154,8 @@ impl Server {
     pub fn setup_session(
         logon: ClientLogon,
     ) -> Result<(AgaveSession, Vec<File>), AgaveHandshakeError> {
-        // Setup the allocator in shared memory (`worker_count` & `allocator_handles` have been
-        // validated so this won't panic).
+        // Setup the allocator in shared memory (`worker_count`, `check_worker_count`, and
+        // `allocator_handles` have been validated so this won't panic).
         let (allocator_file, tpu_to_pack_allocator) = Self::create_allocator(&logon)?;
 
         // Setup the global queues.
@@ -154,13 +163,29 @@ impl Server {
             Self::create_producer(logon.tpu_to_pack_capacity, true)?;
         let (progress_tracker_file, progress_tracker) =
             Self::create_producer(logon.progress_tracker_capacity, false)?;
-        let (pack_to_check_worker_file, pack_to_check_worker) =
-            Self::create_mpmc_consumer::<PackToWorkerMessage>(logon.pack_to_check_worker_capacity)?;
-        let (check_worker_to_pack_file, check_worker_to_pack) =
-            Self::create_mpmc_producer::<WorkerToPackMessage>(
-                logon.check_worker_to_pack_capacity,
-                true,
-            )?;
+        let (pack_to_check_worker_file, _) = Self::create_mpmc_consumer::<PackToCheckWorkerMessage>(
+            logon.pack_to_check_worker_capacity,
+        )?;
+        let (check_worker_to_pack_file, _) = Self::create_mpmc_producer::<CheckWorkerToPackMessage>(
+            logon.check_worker_to_pack_capacity,
+            true,
+        )?;
+
+        let check_workers = (0..logon.check_worker_count)
+            .map(|_| {
+                Ok(AgaveCheckWorkerSession {
+                    allocator: Allocator::join(&allocator_file)?,
+                    // SAFETY: this file was initialized above using the same message type.
+                    pack_to_check_worker: unsafe {
+                        shaq::mpmc::Consumer::join(&pack_to_check_worker_file)?
+                    },
+                    // SAFETY: this file was initialized above using the same message type.
+                    check_worker_to_pack: unsafe {
+                        shaq::mpmc::Producer::join(&check_worker_to_pack_file)?
+                    },
+                })
+            })
+            .collect::<Result<Vec<_>, AgaveHandshakeError>>()?;
 
         // Setup the worker sessions.
         let (worker_files, workers) = (0..logon.worker_count).try_fold(
@@ -192,8 +217,7 @@ impl Server {
                     producer: tpu_to_pack_queue,
                 },
                 progress_tracker,
-                pack_to_check_worker,
-                check_worker_to_pack,
+                check_workers,
                 workers,
             },
             [
@@ -212,6 +236,8 @@ impl Server {
     fn create_allocator(logon: &ClientLogon) -> Result<(File, Allocator), RtsAllocError> {
         let allocator_count = GLOBAL_ALLOCATORS
             .checked_add(logon.worker_count)
+            .unwrap()
+            .checked_add(logon.check_worker_count)
             .unwrap()
             .checked_add(logon.allocator_handles)
             .unwrap();
@@ -259,10 +285,11 @@ impl Server {
 
     fn create_consumer(
         capacity: usize,
-    ) -> Result<(File, shaq::spsc::Consumer<PackToWorkerMessage>), ShaqError> {
+    ) -> Result<(File, shaq::spsc::Consumer<PackToExecutionWorkerMessage>), ShaqError> {
         let create = |huge: bool| {
             let file = Self::create_shmem(huge)?;
-            let minimum_file_size = shaq::spsc::minimum_file_size::<PackToWorkerMessage>(capacity);
+            let minimum_file_size =
+                shaq::spsc::minimum_file_size::<PackToExecutionWorkerMessage>(capacity);
             let file_size = Self::align_file_size(minimum_file_size, huge);
 
             // SAFETY: uniquely creating as consumer.

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -6,7 +6,7 @@ use {
             MAX_WORKERS, VERSION,
         },
     },
-    agave_scheduler_bindings::PackToWorkerMessage,
+    agave_scheduler_bindings::{PackToWorkerMessage, WorkerToPackMessage},
     nix::sys::socket::{self, ControlMessage, MsgFlags, UnixAddr},
     rts_alloc::Allocator,
     std::{
@@ -154,6 +154,13 @@ impl Server {
             Self::create_producer(logon.tpu_to_pack_capacity, true)?;
         let (progress_tracker_file, progress_tracker) =
             Self::create_producer(logon.progress_tracker_capacity, false)?;
+        let (pack_to_check_worker_file, pack_to_check_worker) =
+            Self::create_mpmc_consumer::<PackToWorkerMessage>(logon.pack_to_check_worker_capacity)?;
+        let (check_worker_to_pack_file, check_worker_to_pack) =
+            Self::create_mpmc_producer::<WorkerToPackMessage>(
+                logon.check_worker_to_pack_capacity,
+                true,
+            )?;
 
         // Setup the worker sessions.
         let (worker_files, workers) = (0..logon.worker_count).try_fold(
@@ -185,12 +192,20 @@ impl Server {
                     producer: tpu_to_pack_queue,
                 },
                 progress_tracker,
+                pack_to_check_worker,
+                check_worker_to_pack,
                 workers,
             },
-            [allocator_file, tpu_to_pack_file, progress_tracker_file]
-                .into_iter()
-                .chain(worker_files)
-                .collect(),
+            [
+                allocator_file,
+                tpu_to_pack_file,
+                progress_tracker_file,
+                pack_to_check_worker_file,
+                check_worker_to_pack_file,
+            ]
+            .into_iter()
+            .chain(worker_files)
+            .collect(),
         ))
     }
 
@@ -256,6 +271,42 @@ impl Server {
         };
 
         // Try to create with huge pages, fallback to regular pages.
+        create(true).or_else(|_| create(false))
+    }
+
+    fn create_mpmc_producer<T>(
+        capacity: usize,
+        huge: bool,
+    ) -> Result<(File, shaq::mpmc::Producer<T>), ShaqError> {
+        let create = |huge: bool| {
+            let file = Self::create_shmem(huge)?;
+            let minimum_file_size = shaq::mpmc::minimum_file_size::<T>(capacity);
+            let file_size = Self::align_file_size(minimum_file_size, huge);
+
+            // SAFETY: uniquely creating as producer.
+            unsafe { shaq::mpmc::Producer::create(&file, file_size) }
+                .map(|producer| (file, producer))
+        };
+
+        match huge {
+            true => create(true).or_else(|_| create(false)),
+            false => create(false),
+        }
+    }
+
+    fn create_mpmc_consumer<T>(
+        capacity: usize,
+    ) -> Result<(File, shaq::mpmc::Consumer<T>), ShaqError> {
+        let create = |huge: bool| {
+            let file = Self::create_shmem(huge)?;
+            let minimum_file_size = shaq::mpmc::minimum_file_size::<T>(capacity);
+            let file_size = Self::align_file_size(minimum_file_size, huge);
+
+            // SAFETY: uniquely creating as consumer.
+            unsafe { shaq::mpmc::Consumer::create(&file, file_size) }
+                .map(|consumer| (file, consumer))
+        };
+
         create(true).or_else(|_| create(false))
     }
 

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -38,6 +38,10 @@ pub struct ClientLogon {
     pub worker_to_pack_capacity: usize,
     /// Flags that control the behavior of the new scheduling session.
     pub flags: u16,
+    /// The minimum capacity of the scheduler-to-check-worker queue in messages.
+    pub pack_to_check_worker_capacity: usize,
+    /// The minimum capacity of the check-worker-to-scheduler queue in messages.
+    pub check_worker_to_pack_capacity: usize,
     // NB: If adding more fields please ensure:
     // - The fields are zeroable.
     // - If possible the fields are backwards compatible:
@@ -66,6 +70,8 @@ pub struct ClientSession {
     pub allocators: Vec<Allocator>,
     pub tpu_to_pack: shaq::spsc::Consumer<TpuToPackMessage>,
     pub progress_tracker: shaq::spsc::Consumer<ProgressMessage>,
+    pub pack_to_check_worker: shaq::mpmc::Producer<PackToWorkerMessage>,
+    pub check_worker_to_pack: shaq::mpmc::Consumer<WorkerToPackMessage>,
     pub workers: Vec<ClientWorkerSession>,
 }
 
@@ -97,6 +103,8 @@ pub struct AgaveSession {
     pub flags: u16,
     pub tpu_to_pack: AgaveTpuToPackSession,
     pub progress_tracker: shaq::spsc::Producer<ProgressMessage>,
+    pub pack_to_check_worker: shaq::mpmc::Consumer<PackToWorkerMessage>,
+    pub check_worker_to_pack: shaq::mpmc::Producer<WorkerToPackMessage>,
     pub workers: Vec<AgaveWorkerSession>,
 }
 

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -1,6 +1,7 @@
 use {
     agave_scheduler_bindings::{
-        PackToWorkerMessage, ProgressMessage, TpuToPackMessage, WorkerToPackMessage,
+        CheckWorkerToPackMessage, ExecutionWorkerToPackMessage, PackToCheckWorkerMessage,
+        PackToExecutionWorkerMessage, ProgressMessage, TpuToPackMessage,
     },
     rts_alloc::Allocator,
     thiserror::Error,
@@ -24,6 +25,8 @@ pub(crate) const GLOBAL_ALLOCATORS: usize = 1;
 pub struct ClientLogon {
     /// The number of Agave worker threads that will be spawned to handle packing requests.
     pub worker_count: usize,
+    /// The number of Agave check worker threads that will be spawned to handle check requests.
+    pub check_worker_count: usize,
     /// The minimum allocator file size in bytes, this is shared by all allocator handles.
     pub allocator_size: usize,
     /// The number of [`rts_alloc::Allocator`] handles the external process is requesting.
@@ -70,15 +73,15 @@ pub struct ClientSession {
     pub allocators: Vec<Allocator>,
     pub tpu_to_pack: shaq::spsc::Consumer<TpuToPackMessage>,
     pub progress_tracker: shaq::spsc::Consumer<ProgressMessage>,
-    pub pack_to_check_worker: shaq::mpmc::Producer<PackToWorkerMessage>,
-    pub check_worker_to_pack: shaq::mpmc::Consumer<WorkerToPackMessage>,
+    pub pack_to_check_worker: shaq::mpmc::Producer<PackToCheckWorkerMessage>,
+    pub check_worker_to_pack: shaq::mpmc::Consumer<CheckWorkerToPackMessage>,
     pub workers: Vec<ClientWorkerSession>,
 }
 
 /// A per worker scheduling session.
 pub struct ClientWorkerSession {
-    pub pack_to_worker: shaq::spsc::Producer<PackToWorkerMessage>,
-    pub worker_to_pack: shaq::spsc::Consumer<WorkerToPackMessage>,
+    pub pack_to_worker: shaq::spsc::Producer<PackToExecutionWorkerMessage>,
+    pub worker_to_pack: shaq::spsc::Consumer<ExecutionWorkerToPackMessage>,
 }
 
 /// Potential errors that can occur during the client's side of the handshake.
@@ -103,8 +106,7 @@ pub struct AgaveSession {
     pub flags: u16,
     pub tpu_to_pack: AgaveTpuToPackSession,
     pub progress_tracker: shaq::spsc::Producer<ProgressMessage>,
-    pub pack_to_check_worker: shaq::mpmc::Consumer<PackToWorkerMessage>,
-    pub check_worker_to_pack: shaq::mpmc::Producer<WorkerToPackMessage>,
+    pub check_workers: Vec<AgaveCheckWorkerSession>,
     pub workers: Vec<AgaveWorkerSession>,
 }
 
@@ -117,8 +119,15 @@ pub struct AgaveTpuToPackSession {
 /// Shared memory objects for a single banking worker.
 pub struct AgaveWorkerSession {
     pub allocator: Allocator,
-    pub pack_to_worker: shaq::spsc::Consumer<PackToWorkerMessage>,
-    pub worker_to_pack: shaq::spsc::Producer<WorkerToPackMessage>,
+    pub pack_to_worker: shaq::spsc::Consumer<PackToExecutionWorkerMessage>,
+    pub worker_to_pack: shaq::spsc::Producer<ExecutionWorkerToPackMessage>,
+}
+
+/// Shared memory objects for a single check worker.
+pub struct AgaveCheckWorkerSession {
+    pub allocator: Allocator,
+    pub pack_to_check_worker: shaq::mpmc::Consumer<PackToCheckWorkerMessage>,
+    pub check_worker_to_pack: shaq::mpmc::Producer<CheckWorkerToPackMessage>,
 }
 
 /// Potential errors that can occur during the Agave side of the handshake.
@@ -138,6 +147,8 @@ pub enum AgaveHandshakeError {
     Version { server: u64, client: u64 },
     #[error("Worker count; count={0}")]
     WorkerCount(usize),
+    #[error("Check worker count; count={0}")]
+    CheckWorkerCount(usize),
     #[error("Allocator handles; count={0}")]
     AllocatorHandles(usize),
     #[error("Rts alloc; err={0:?}")]

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -70,6 +70,20 @@ fn message_passing_on_all_queues() {
             .try_write(progress_tracker)
             .unwrap();
 
+        // Receive a pack_to_check_worker message.
+        let msg = loop {
+            if let Some(msg) = session.pack_to_check_worker.try_read() {
+                break msg;
+            }
+        };
+        assert_eq!(msg, pack_to_worker);
+
+        // Send a check_worker_to_pack message.
+        session
+            .check_worker_to_pack
+            .try_write(worker_to_pack)
+            .unwrap();
+
         // Receive pack_to_worker messages.
         for (i, worker) in session.workers.iter_mut().enumerate() {
             let msg = loop {
@@ -112,6 +126,8 @@ fn message_passing_on_all_queues() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         )
@@ -132,6 +148,20 @@ fn message_passing_on_all_queues() {
             };
         };
         assert_eq!(msg, progress_tracker);
+
+        // Send a pack_to_check_worker message.
+        session
+            .pack_to_check_worker
+            .try_write(pack_to_worker)
+            .unwrap();
+
+        // Receive a check_worker_to_pack message.
+        let msg = loop {
+            if let Some(msg) = session.check_worker_to_pack.try_read() {
+                break msg;
+            }
+        };
+        assert_eq!(msg, worker_to_pack);
 
         // Send pack_to_worker messages.
         for (i, worker) in session.workers.iter_mut().enumerate() {
@@ -169,6 +199,43 @@ fn message_passing_on_all_queues() {
 }
 
 #[test]
+fn check_worker_queues_use_dedicated_capacities() {
+    const CHECK_REQUEST_CAPACITY: usize = 1 << 18;
+    const CHECK_RESPONSE_CAPACITY: usize = 1 << 19;
+
+    let logon = ClientLogon {
+        worker_count: 1,
+        allocator_size: 64 * 1024 * 1024,
+        allocator_handles: 1,
+        tpu_to_pack_capacity: 2,
+        progress_tracker_capacity: 2,
+        pack_to_worker_capacity: 2,
+        worker_to_pack_capacity: 2,
+        flags: 0,
+        pack_to_check_worker_capacity: CHECK_REQUEST_CAPACITY,
+        check_worker_to_pack_capacity: CHECK_RESPONSE_CAPACITY,
+    };
+    let (_agave, files) = Server::setup_session(logon).unwrap();
+
+    assert!(
+        files[3].metadata().unwrap().len()
+            >= u64::try_from(shaq::mpmc::minimum_file_size::<PackToWorkerMessage>(
+                CHECK_REQUEST_CAPACITY
+            ))
+            .unwrap()
+    );
+    assert!(
+        files[4].metadata().unwrap().len()
+            >= u64::try_from(shaq::mpmc::minimum_file_size::<WorkerToPackMessage>(
+                CHECK_RESPONSE_CAPACITY
+            ))
+            .unwrap()
+    );
+
+    crate::handshake::client::setup_session(&logon, files).unwrap();
+}
+
+#[test]
 fn accept_worker_count_max() {
     let ipc = NamedTempFile::new().unwrap();
     std::fs::remove_file(ipc.path()).unwrap();
@@ -190,6 +257,8 @@ fn accept_worker_count_max() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );
@@ -225,6 +294,8 @@ fn reject_worker_count_low() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );
@@ -263,6 +334,8 @@ fn reject_worker_count_high() {
                 pack_to_worker_capacity: 1024,
                 worker_to_pack_capacity: 1024,
                 flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
             },
             Duration::from_secs(1),
         );

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -36,6 +36,7 @@ fn message_passing_on_all_queues() {
         next_leader_slot: 12,
         leader_range_end: 16,
         remaining_cost_units: 12_000_000,
+        remaining_allocated_accounts_data_size: 20_000_000,
         latest_blockhash: [42; 32],
         target_bank_time_ms: 0,
     };

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -4,9 +4,10 @@ use {
         shared::MAX_WORKERS,
     },
     agave_scheduler_bindings::{
-        PackToWorkerMessage, ProgressMessage, SharableTransactionBatchRegion,
-        SharableTransactionRegion, TpuToPackMessage, TransactionResponseRegion,
-        WorkerToPackMessage,
+        CheckResponseRegion, CheckWorkerToPackMessage, ExecutionResponseRegion,
+        ExecutionWorkerToPackMessage, PackToCheckWorkerMessage, PackToExecutionWorkerMessage,
+        ProgressMessage, SharableTransactionBatchRegion, SharableTransactionRegion,
+        TpuToPackMessage,
     },
     std::time::Duration,
     tempfile::NamedTempFile,
@@ -37,22 +38,28 @@ fn message_passing_on_all_queues() {
         remaining_cost_units: 12_000_000,
         latest_blockhash: [42; 32],
     };
-    let pack_to_worker = PackToWorkerMessage {
-        flags: 123,
+    let batch = SharableTransactionBatchRegion {
+        num_transactions: 5,
+        transactions_offset: 100,
+    };
+    let pack_to_check_worker = PackToCheckWorkerMessage { flags: 123, batch };
+    let pack_to_worker = PackToExecutionWorkerMessage {
+        flags: 1,
         max_working_slot: 100,
-        batch: SharableTransactionBatchRegion {
-            num_transactions: 5,
-            transactions_offset: 100,
+        batch,
+    };
+    let check_worker_to_pack = CheckWorkerToPackMessage {
+        batch,
+        processed_code: agave_scheduler_bindings::processed_codes::PROCESSED,
+        responses: CheckResponseRegion {
+            num_transaction_responses: 2,
+            transaction_responses_offset: 1,
         },
     };
-    let worker_to_pack = WorkerToPackMessage {
-        batch: SharableTransactionBatchRegion {
-            num_transactions: 5,
-            transactions_offset: 100,
-        },
+    let worker_to_pack = ExecutionWorkerToPackMessage {
+        batch,
         processed_code: agave_scheduler_bindings::processed_codes::PROCESSED,
-        responses: TransactionResponseRegion {
-            tag: 3,
+        responses: ExecutionResponseRegion {
             num_transaction_responses: 2,
             transaction_responses_offset: 1,
         },
@@ -70,19 +77,44 @@ fn message_passing_on_all_queues() {
             .try_write(progress_tracker)
             .unwrap();
 
-        // Receive a pack_to_check_worker message.
-        let msg = loop {
-            if let Some(msg) = session.pack_to_check_worker.try_read() {
-                break msg;
-            }
-        };
-        assert_eq!(msg, pack_to_worker);
+        assert_eq!(session.check_workers.len(), 2);
 
-        // Send a check_worker_to_pack message.
-        session
-            .check_worker_to_pack
-            .try_write(worker_to_pack)
-            .unwrap();
+        // Receive pack_to_check_worker messages.
+        let mut check_messages = Vec::new();
+        while check_messages.len() < session.check_workers.len() {
+            for worker in &session.check_workers {
+                if let Some(msg) = worker.pack_to_check_worker.try_read() {
+                    check_messages.push(msg);
+                }
+            }
+        }
+        assert_eq!(
+            check_messages,
+            vec![
+                pack_to_check_worker,
+                PackToCheckWorkerMessage {
+                    batch: SharableTransactionBatchRegion {
+                        num_transactions: pack_to_check_worker.batch.num_transactions + 1,
+                        ..pack_to_check_worker.batch
+                    },
+                    ..pack_to_check_worker
+                }
+            ]
+        );
+
+        // Send check_worker_to_pack messages.
+        for (i, worker) in session.check_workers.iter().enumerate() {
+            worker
+                .check_worker_to_pack
+                .try_write(CheckWorkerToPackMessage {
+                    batch: SharableTransactionBatchRegion {
+                        num_transactions: check_worker_to_pack.batch.num_transactions + i as u8,
+                        ..check_worker_to_pack.batch
+                    },
+                    ..check_worker_to_pack
+                })
+                .unwrap();
+        }
 
         // Receive pack_to_worker messages.
         for (i, worker) in session.workers.iter_mut().enumerate() {
@@ -92,7 +124,7 @@ fn message_passing_on_all_queues() {
                 }
             };
             assert_eq!(
-                PackToWorkerMessage {
+                PackToExecutionWorkerMessage {
                     max_working_slot: pack_to_worker.max_working_slot + i as u64,
                     ..pack_to_worker
                 },
@@ -104,7 +136,7 @@ fn message_passing_on_all_queues() {
         for (i, worker) in session.workers.iter_mut().enumerate() {
             worker
                 .worker_to_pack
-                .try_write(WorkerToPackMessage {
+                .try_write(ExecutionWorkerToPackMessage {
                     batch: SharableTransactionBatchRegion {
                         num_transactions: worker_to_pack.batch.num_transactions + i as u8,
                         ..worker_to_pack.batch
@@ -119,6 +151,7 @@ fn message_passing_on_all_queues() {
             ipc,
             ClientLogon {
                 worker_count: 4,
+                check_worker_count: 2,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
                 tpu_to_pack_capacity: 65536,
@@ -149,25 +182,46 @@ fn message_passing_on_all_queues() {
         };
         assert_eq!(msg, progress_tracker);
 
-        // Send a pack_to_check_worker message.
-        session
-            .pack_to_check_worker
-            .try_write(pack_to_worker)
-            .unwrap();
+        // Send pack_to_check_worker messages.
+        for i in 0..2 {
+            session
+                .pack_to_check_worker
+                .try_write(PackToCheckWorkerMessage {
+                    batch: SharableTransactionBatchRegion {
+                        num_transactions: pack_to_check_worker.batch.num_transactions + i,
+                        ..pack_to_check_worker.batch
+                    },
+                    ..pack_to_check_worker
+                })
+                .unwrap();
+        }
 
-        // Receive a check_worker_to_pack message.
-        let msg = loop {
+        // Receive check_worker_to_pack messages.
+        let mut check_messages = Vec::new();
+        while check_messages.len() < 2 {
             if let Some(msg) = session.check_worker_to_pack.try_read() {
-                break msg;
+                check_messages.push(msg);
             }
-        };
-        assert_eq!(msg, worker_to_pack);
+        }
+        assert_eq!(
+            check_messages,
+            vec![
+                check_worker_to_pack,
+                CheckWorkerToPackMessage {
+                    batch: SharableTransactionBatchRegion {
+                        num_transactions: check_worker_to_pack.batch.num_transactions + 1,
+                        ..check_worker_to_pack.batch
+                    },
+                    ..check_worker_to_pack
+                }
+            ]
+        );
 
         // Send pack_to_worker messages.
         for (i, worker) in session.workers.iter_mut().enumerate() {
             worker
                 .pack_to_worker
-                .try_write(PackToWorkerMessage {
+                .try_write(PackToExecutionWorkerMessage {
                     max_working_slot: pack_to_worker.max_working_slot + i as u64,
                     ..pack_to_worker
                 })
@@ -182,7 +236,7 @@ fn message_passing_on_all_queues() {
                 }
             };
             assert_eq!(
-                WorkerToPackMessage {
+                ExecutionWorkerToPackMessage {
                     batch: SharableTransactionBatchRegion {
                         num_transactions: worker_to_pack.batch.num_transactions + i as u8,
                         ..worker_to_pack.batch
@@ -205,6 +259,7 @@ fn check_worker_queues_use_dedicated_capacities() {
 
     let logon = ClientLogon {
         worker_count: 1,
+        check_worker_count: 1,
         allocator_size: 64 * 1024 * 1024,
         allocator_handles: 1,
         tpu_to_pack_capacity: 2,
@@ -219,14 +274,14 @@ fn check_worker_queues_use_dedicated_capacities() {
 
     assert!(
         files[3].metadata().unwrap().len()
-            >= u64::try_from(shaq::mpmc::minimum_file_size::<PackToWorkerMessage>(
+            >= u64::try_from(shaq::mpmc::minimum_file_size::<PackToCheckWorkerMessage>(
                 CHECK_REQUEST_CAPACITY
             ))
             .unwrap()
     );
     assert!(
         files[4].metadata().unwrap().len()
-            >= u64::try_from(shaq::mpmc::minimum_file_size::<WorkerToPackMessage>(
+            >= u64::try_from(shaq::mpmc::minimum_file_size::<CheckWorkerToPackMessage>(
                 CHECK_RESPONSE_CAPACITY
             ))
             .unwrap()
@@ -250,6 +305,7 @@ fn accept_worker_count_max() {
             ipc,
             ClientLogon {
                 worker_count: MAX_WORKERS,
+                check_worker_count: 1,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
                 tpu_to_pack_capacity: 65536,
@@ -287,6 +343,7 @@ fn reject_worker_count_low() {
             ipc,
             ClientLogon {
                 worker_count: 0,
+                check_worker_count: 1,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
                 tpu_to_pack_capacity: 65536,
@@ -327,6 +384,7 @@ fn reject_worker_count_high() {
             ipc,
             ClientLogon {
                 worker_count: 100,
+                check_worker_count: 1,
                 allocator_size: 1024 * 1024 * 1024,
                 allocator_handles: 3,
                 tpu_to_pack_capacity: 65536,
@@ -343,6 +401,88 @@ fn reject_worker_count_high() {
             panic!();
         };
         assert_eq!(reason, "Worker count; count=100");
+    });
+
+    client_handle.join().unwrap();
+    server_handle.join().unwrap();
+}
+
+#[test]
+fn reject_check_worker_count_low() {
+    let ipc = NamedTempFile::new().unwrap();
+    std::fs::remove_file(ipc.path()).unwrap();
+    let mut server = Server::new(ipc.path()).unwrap();
+
+    let server_handle = std::thread::spawn(move || {
+        let res = server.accept();
+        let Err(AgaveHandshakeError::CheckWorkerCount(count)) = res else {
+            panic!();
+        };
+        assert_eq!(count, 0);
+    });
+    let client_handle = std::thread::spawn(move || {
+        let res = connect(
+            ipc,
+            ClientLogon {
+                worker_count: 1,
+                check_worker_count: 0,
+                allocator_size: 1024 * 1024 * 1024,
+                allocator_handles: 3,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
+                flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
+            },
+            Duration::from_secs(1),
+        );
+        let Err(ClientHandshakeError::Rejected(reason)) = res else {
+            panic!();
+        };
+        assert_eq!(reason, "Check worker count; count=0");
+    });
+
+    client_handle.join().unwrap();
+    server_handle.join().unwrap();
+}
+
+#[test]
+fn reject_check_worker_count_high() {
+    let ipc = NamedTempFile::new().unwrap();
+    std::fs::remove_file(ipc.path()).unwrap();
+    let mut server = Server::new(ipc.path()).unwrap();
+
+    let server_handle = std::thread::spawn(move || {
+        let res = server.accept();
+        let Err(AgaveHandshakeError::CheckWorkerCount(count)) = res else {
+            panic!();
+        };
+        assert_eq!(count, 100);
+    });
+    let client_handle = std::thread::spawn(move || {
+        let res = connect(
+            ipc,
+            ClientLogon {
+                worker_count: 1,
+                check_worker_count: 100,
+                allocator_size: 1024 * 1024 * 1024,
+                allocator_handles: 3,
+                tpu_to_pack_capacity: 65536,
+                progress_tracker_capacity: 256,
+                pack_to_worker_capacity: 1024,
+                worker_to_pack_capacity: 1024,
+                flags: 0,
+                pack_to_check_worker_capacity: 1024,
+                check_worker_to_pack_capacity: 1024,
+            },
+            Duration::from_secs(1),
+        );
+        let Err(ClientHandshakeError::Rejected(reason)) = res else {
+            panic!();
+        };
+        assert_eq!(reason, "Check worker count; count=100");
     });
 
     client_handle.join().unwrap();

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -37,6 +37,7 @@ fn message_passing_on_all_queues() {
         leader_range_end: 16,
         remaining_cost_units: 12_000_000,
         latest_blockhash: [42; 32],
+        target_bank_time_ms: 0,
     };
     let batch = SharableTransactionBatchRegion {
         num_transactions: 5,

--- a/scheduling-utils/src/responses_region.rs
+++ b/scheduling-utils/src/responses_region.rs
@@ -1,59 +1,68 @@
 use {
     agave_scheduler_bindings::{
-        TransactionResponseRegion,
-        worker_message_types::{
-            self, CHECK_RESPONSE, CheckResponse, EXECUTION_RESPONSE, ExecutionResponse,
-        },
+        CheckResponseRegion, ExecutionResponseRegion,
+        worker_message_types::{CheckResponse, ExecutionResponse},
     },
     rts_alloc::Allocator,
     std::ptr::NonNull,
 };
 
-/// Prepare a [`TransactionResponseRegion`] with [`ExecutionResponse`].
+/// Prepare an [`ExecutionResponseRegion`] with [`ExecutionResponse`].
 pub fn execution_responses_from_iter(
     allocator: &Allocator,
     iter: impl ExactSizeIterator<Item = ExecutionResponse>,
-) -> Option<TransactionResponseRegion> {
-    // SAFETY: EXECUTION_RESPONSE -> ExecutionResponse
-    unsafe { from_iterator(allocator, EXECUTION_RESPONSE, iter) }
+) -> Option<ExecutionResponseRegion> {
+    let num_transaction_responses = iter.len();
+    let (response_ptr, transaction_responses_offset) =
+        allocate_response_region(allocator, num_transaction_responses)?;
+    write_responses(response_ptr, iter);
+
+    Some(ExecutionResponseRegion {
+        num_transaction_responses: num_transaction_responses as u8,
+        transaction_responses_offset,
+    })
 }
 
-/// Prepare a [`TransactionResponseRegion`] with [`CheckResponse`].
+/// Prepare a [`CheckResponseRegion`] with [`CheckResponse`].
 pub fn resolve_responses_from_iter(
     allocator: &Allocator,
     iter: impl ExactSizeIterator<Item = CheckResponse>,
-) -> Option<TransactionResponseRegion> {
-    // SAFETY: CHECK_RESPONSE -> CheckResponse
-    unsafe { from_iterator(allocator, CHECK_RESPONSE, iter) }
+) -> Option<CheckResponseRegion> {
+    let num_transaction_responses = iter.len();
+    let (response_ptr, transaction_responses_offset) =
+        allocate_response_region(allocator, num_transaction_responses)?;
+    write_responses(response_ptr, iter);
+
+    Some(CheckResponseRegion {
+        num_transaction_responses: num_transaction_responses as u8,
+        transaction_responses_offset,
+    })
 }
 
-/// Allocate region a [`TransactionResponseRegion`] with [`CheckResponse`].
+/// Allocate a [`CheckResponseRegion`] with [`CheckResponse`].
 /// Each [`CheckResponse`] is not yet populated and must be populated by the
 /// caller.
 pub fn allocate_check_response_region(
     allocator: &Allocator,
     num_transaction_responses: usize,
-) -> Option<(NonNull<CheckResponse>, TransactionResponseRegion)> {
-    // SAFETY: CHECK_RESPONSE -> CheckResponse
-    unsafe {
-        allocate_response_region::<CheckResponse>(
-            allocator,
-            CHECK_RESPONSE,
-            num_transaction_responses,
-        )
-    }
+) -> Option<(NonNull<CheckResponse>, CheckResponseRegion)> {
+    let (response_ptr, transaction_responses_offset) =
+        allocate_response_region(allocator, num_transaction_responses)?;
+
+    Some((
+        response_ptr,
+        CheckResponseRegion {
+            num_transaction_responses: num_transaction_responses as u8,
+            transaction_responses_offset,
+        },
+    ))
 }
 
 /// Allocate a response region.
-///
-/// # Safety
-/// - T must be a valid response type
-/// - `tag` must match the `T`
-unsafe fn allocate_response_region<T: Sized>(
+fn allocate_response_region<T: Sized>(
     allocator: &Allocator,
-    tag: u8,
     num_transaction_responses: usize,
-) -> Option<(NonNull<T>, TransactionResponseRegion)> {
+) -> Option<(NonNull<T>, usize)> {
     let size = num_transaction_responses.wrapping_mul(core::mem::size_of::<T>());
     let response_ptr = allocator.allocate(size as u32)?.cast::<T>();
     debug_assert!(
@@ -64,35 +73,14 @@ unsafe fn allocate_response_region<T: Sized>(
     // SAFETY: `response_ptr` was allocated from the allocator.
     let transaction_responses_offset = unsafe { allocator.offset(response_ptr.cast()) };
 
-    Some((
-        response_ptr,
-        TransactionResponseRegion {
-            tag,
-            num_transaction_responses: num_transaction_responses as u8,
-            transaction_responses_offset,
-        },
-    ))
+    Some((response_ptr, transaction_responses_offset))
 }
 
-/// Prepare a [`TransactionResponseRegion`] from an iterator.
-///
-/// # Safety
-/// - T must be a valid response type
-/// - `tag` must match the `T`
-unsafe fn from_iterator<T: Sized>(
-    allocator: &Allocator,
-    tag: u8,
-    iter: impl ExactSizeIterator<Item = T>,
-) -> Option<TransactionResponseRegion> {
-    let num_transaction_responses = iter.len();
-    let (response_ptr, region) =
-        unsafe { allocate_response_region(allocator, tag, num_transaction_responses)? };
+fn write_responses<T: Sized>(response_ptr: NonNull<T>, iter: impl ExactSizeIterator<Item = T>) {
     for (index, response) in iter.enumerate() {
         // SAFETY: `response_ptr` is sufficiently sized to fit the response vector.
         unsafe { response_ptr.add(index).write(response) };
     }
-
-    Some(region)
 }
 
 #[derive(Debug)]
@@ -117,19 +105,15 @@ impl CheckResponsesPtr {
         Self { ptr, count }
     }
 
-    /// Constructs the pointer from a [`TransactionResponseRegion`].
+    /// Constructs the pointer from a [`CheckResponseRegion`].
     ///
     /// # Safety
     ///
-    /// - The provided [`TransactionResponseRegion`] must be of type
-    ///   [`worker_message_types::CHECK_RESPONSE`].
     /// - The allocation pointed to by this region must be valid and not previously freed.
     pub unsafe fn from_transaction_response_region(
-        transaction_response_region: &TransactionResponseRegion,
+        transaction_response_region: &CheckResponseRegion,
         allocator: &Allocator,
     ) -> Self {
-        debug_assert!(transaction_response_region.tag == worker_message_types::CHECK_RESPONSE);
-
         Self {
             // SAFETY: `transaction_response_region.transaction_responses_offset` was allocated by `allocator`.
             ptr: unsafe {
@@ -187,19 +171,15 @@ impl ExecutionResponsesPtr {
         Self { ptr, count }
     }
 
-    /// Constructs the pointer from a [`TransactionResponseRegion`].
+    /// Constructs the pointer from an [`ExecutionResponseRegion`].
     ///
     /// # Safety
     ///
-    /// - The provided [`TransactionResponseRegion`] must be of type
-    ///   [`worker_message_types::EXECUTION_RESPONSE`].
     /// - The allocation pointed to by this region must be valid and not previously freed.
     pub unsafe fn from_transaction_response_region(
-        transaction_response_region: &TransactionResponseRegion,
+        transaction_response_region: &ExecutionResponseRegion,
         allocator: &Allocator,
     ) -> Self {
-        debug_assert!(transaction_response_region.tag == worker_message_types::EXECUTION_RESPONSE);
-
         Self {
             // SAFETY: `transaction_response_region.transaction_responses_offset` was allocated by `allocator`.
             ptr: unsafe {


### PR DESCRIPTION
#### Problem
- scheduler-bindings 6.0.0 has been released with changes: https://github.com/anza-xyz/agave-sdk/releases/tag/agave-scheduler-bindings%40v6.0.0

#### Summary of Changes
- Bump to scheduler-bindings 6.0.0:
	- add MPMC check queues
	- split check and execution workers
	- publish target bank time
	- return scheduling details from check workers
	- publish remaining account data allocation
	- use tagged agave-scheduler-bindings 6.0.0 

#### Testing
- Updated version of our external scheduler

Fixes #
