### PR TITLE
Abort scans promptly when their bank is removed

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2628,7 +2628,7 @@ impl AccountsDb {
         F: FnMut(Option<(&Pubkey, AccountSharedData, Slot)>),
     {
         // Register this scan so that slots needed by the scan are not cleaned out from under us.
-        let scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
+        let mut scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
             .ok_or(ScanError::SlotRemoved {
                 slot: ancestors.max_slot(),
                 bank_id,
@@ -2650,7 +2650,7 @@ impl AccountsDb {
         let cached_pubkeys = self.accounts_cache.cached_pubkeys();
         let mut cached_versions = ahash::HashMap::with_capacity(cached_pubkeys.len());
         for pubkey in cached_pubkeys {
-            if config.is_aborted() {
+            if config.is_aborted() || scan_guard.is_bank_removed() {
                 break;
             }
 
@@ -2689,13 +2689,13 @@ impl AccountsDb {
                 });
                 scan_func(account_slot)
             },
-            || config.is_aborted(),
+            || config.is_aborted() || scan_guard.is_bank_removed(),
         );
 
         // Step 3: Call scan_func on cache-only entries — pubkeys that exist in the cache but not
         // in the accounts index at all.
         for (pubkey, (cached_account, slot)) in cached_versions {
-            if config.is_aborted() {
+            if config.is_aborted() || scan_guard.is_bank_removed() {
                 break;
             }
             scan_func(Some((&pubkey, cached_account.account.clone(), slot)));
@@ -2735,7 +2735,7 @@ impl AccountsDb {
         }
 
         // Register this scan so that slots needed by the scan are not cleaned out from under us.
-        let scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
+        let mut scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
             .ok_or(ScanError::SlotRemoved {
                 slot: ancestors.max_slot(),
                 bank_id,
@@ -2752,7 +2752,7 @@ impl AccountsDb {
         };
 
         for pubkey in self.accounts_index.get_index_key_pubkeys(&index_key) {
-            if config.is_aborted() {
+            if config.is_aborted() || scan_guard.is_bank_removed() {
                 break;
             }
             if let Some((account, slot)) = self.do_load(
@@ -3551,14 +3551,13 @@ impl AccountsDb {
         );
 
         // Mark down these slots are about to be purged so that new attempts to scan these
-        // banks fail, and any ongoing scans over these slots will detect that they should abort
-        // their results
-        {
-            let mut locked_removed_bank_ids = self.scan_tracker.removed_bank_ids.lock().unwrap();
-            for (_slot, remove_bank_id) in remove_slots.iter() {
-                locked_removed_bank_ids.insert(*remove_bank_id);
-            }
-        }
+        // banks fail, and any ongoing scans over these slots abort promptly, releasing the
+        // bank references their callers hold
+        self.scan_tracker.mark_banks_removed(
+            remove_slots
+                .iter()
+                .map(|(_slot, remove_bank_id)| *remove_bank_id),
+        );
 
         let remove_unrooted_purge_stats = PurgeStats::default();
         self.purge_slots_from_cache(

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -696,6 +696,89 @@ fn test_remove_unrooted_slot_purges_secondary_index_for_cache_only_account() {
     );
 }
 
+/// A scan whose bank is removed via `remove_unrooted_slots` mid-scan aborts at the next account
+/// instead of scanning to completion.
+/// Removing some *other* bank must not abort the scan.
+#[test_case(1, Err(ScanError::SlotRemoved { slot: 1, bank_id: 1 }), 1; "abort_bank_aborts_scan")]
+#[test_case(2, Ok(()), 10; "abort_other_bank_no_effect")]
+fn test_remove_unrooted_slots_aborts_ongoing_scan(
+    removed_bank_id: BankId,
+    expected_result: Result<(), ScanError>,
+    expected_visits: usize,
+) {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let slot = 1;
+    let bank_id = 1;
+    let num_accounts = 10;
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+    let pubkeys: Vec<_> = (0..num_accounts).map(|_| Pubkey::new_unique()).collect();
+    let accounts: Vec<_> = pubkeys.iter().map(|pubkey| (pubkey, &account)).collect();
+    db.store_for_tests((slot, accounts.as_slice()));
+
+    let mut visited = 0;
+    let result = db.scan_accounts(
+        &Ancestors::from(vec![slot, 0]),
+        bank_id,
+        |scan_result| {
+            if scan_result.is_some() {
+                visited += 1;
+                if visited == 1 {
+                    // dump the fork mid-scan, as ReplayStage does for a duplicate fork
+                    db.remove_unrooted_slots(&[(slot, removed_bank_id)]);
+                }
+            }
+        },
+        &ScanConfig::default(),
+    );
+    assert_eq!(result, expected_result);
+    assert_eq!(visited, expected_visits);
+}
+
+/// An index scan whose bank is removed via `remove_unrooted_slots` mid-scan aborts at the next account
+/// instead of scanning to completion.
+#[test]
+fn test_index_scan_accounts_aborts_when_bank_removed() {
+    let db = AccountsDb {
+        account_indexes: program_id_index_enabled(),
+        ..AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG)
+    };
+    let slot = 1;
+    let bank_id = 1;
+    let num_accounts = 10;
+    let owner = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &owner);
+    let pubkeys: Vec<_> = (0..num_accounts).map(|_| Pubkey::new_unique()).collect();
+    let accounts: Vec<_> = pubkeys.iter().map(|pubkey| (pubkey, &account)).collect();
+    db.store_for_tests((slot, accounts.as_slice()));
+    db.add_root_and_flush_write_cache(slot);
+    // all of them are reachable through the secondary index, so a scan that doesn't abort
+    // visits every one
+    assert_eq!(
+        db.accounts_index
+            .get_index_key_size(&AccountIndex::ProgramId, &owner),
+        Some(num_accounts as usize)
+    );
+
+    let mut visited = 0;
+    let result = db.index_scan_accounts(
+        &Ancestors::from(vec![slot]),
+        bank_id,
+        IndexKey::ProgramId(owner),
+        |scan_result| {
+            if scan_result.is_some() {
+                visited += 1;
+                if visited == 1 {
+                    db.scan_tracker.mark_banks_removed([bank_id]);
+                }
+            }
+        },
+        &ScanConfig::default(),
+    );
+    assert_eq!(result, Err(ScanError::SlotRemoved { slot, bank_id }));
+    // Guarantee that the abort occurred without visiting all pubkeys
+    assert_eq!(visited, 1);
+}
+
 /// A pubkey deferred to clean by `remove_unrooted_slots` can be stored again, rooted and flushed
 /// before the next clean handles it. The key is alive in the primary index at that point and no
 /// longer in the write cache, clean must not purge its secondary index entry.

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -350,7 +350,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         ancestors: &Ancestors,
         max_root: Slot,
         mut func: F,
-        should_abort: impl Fn() -> bool,
+        mut should_abort: impl FnMut() -> bool,
     ) where
         F: FnMut(&Pubkey, (&T, Slot)),
     {

--- a/accounts-db/src/accounts_scan.rs
+++ b/accounts-db/src/accounts_scan.rs
@@ -70,6 +70,9 @@ pub struct ScanTracker {
     // on any of these slots fails. This is safe to purge once the associated Bank is dropped and
     // scanning the fork with that Bank at the tip is no longer possible.
     pub removed_bank_ids: Mutex<HashSet<BankId>>,
+    /// Number of total bank removals. Used by scans to determine if they need to check if the
+    /// bank they are scanning on is being removed.
+    bank_removals: AtomicU64,
     /// # scans active currently
     pub active_scans: AtomicUsize,
     /// # of slots between latest max and latest scan
@@ -84,6 +87,17 @@ impl ScanTracker {
     pub fn min_ongoing_scan_root(&self) -> Option<Slot> {
         Self::min_ongoing_scan_root_from_btree(&self.ongoing_scan_roots.read().unwrap())
     }
+
+    /// Mark `bank_ids` as removed: new scan attempts on them fail, and in-flight scans on them
+    /// abort at their next account.
+    pub(crate) fn mark_banks_removed(&self, bank_ids: impl IntoIterator<Item = BankId>) {
+        let mut removed_bank_ids = self.removed_bank_ids.lock().unwrap();
+        for bank_id in bank_ids {
+            removed_bank_ids.insert(bank_id);
+        }
+        // Needs to be bumped while holding the removed_bank_ids lock
+        self.bank_removals.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 /// Guard that protects account state during an accounts scan.
@@ -95,6 +109,7 @@ pub(crate) struct ScanGuard<'a> {
     scan_tracker: &'a ScanTracker,
     max_root: Slot,
     scan_bank_id: BankId,
+    bank_removals_at_last_check: u64,
 }
 
 impl<'a> ScanGuard<'a> {
@@ -109,12 +124,15 @@ impl<'a> ScanGuard<'a> {
         scan_bank_id: BankId,
         max_root_inclusive_fn: impl FnOnce() -> Slot,
     ) -> Option<Self> {
-        {
+        // Need to read bank_removals_at_last_check while holding the lock to protect against aborts
+        // after the first check
+        let bank_removals_at_last_check = {
             let locked_removed_bank_ids = scan_tracker.removed_bank_ids.lock().unwrap();
             if locked_removed_bank_ids.contains(&scan_bank_id) {
                 return None;
             }
-        }
+            scan_tracker.bank_removals.load(Ordering::Relaxed)
+        };
 
         let max_root_inclusive = {
             let mut w_ongoing_scan_roots = scan_tracker
@@ -148,7 +166,25 @@ impl<'a> ScanGuard<'a> {
             scan_tracker,
             max_root: max_root_inclusive,
             scan_bank_id,
+            bank_removals_at_last_check,
         })
+    }
+
+    /// Checks if the bank being scanned is removed
+    pub(crate) fn is_bank_removed(&mut self) -> bool {
+        // Fast path: No banks have been removed since the last check.
+        let bank_removals = self.scan_tracker.bank_removals.load(Ordering::Relaxed);
+        if bank_removals == self.bank_removals_at_last_check {
+            return false;
+        }
+
+        // If any bank has been removed, check to see if the bank being scanned has been removed
+        self.bank_removals_at_last_check = bank_removals;
+        self.scan_tracker
+            .removed_bank_ids
+            .lock()
+            .unwrap()
+            .contains(&self.scan_bank_id)
     }
 
     /// The inclusive max root pinned by this scan guard.
@@ -356,6 +392,20 @@ mod tests {
         // guard should still have cleaned up
         assert_eq!(tracker.active_scans.load(Ordering::Relaxed), 0);
         assert!(tracker.min_ongoing_scan_root().is_none());
+    }
+
+    #[test]
+    fn test_is_bank_removed_only_for_removed_bank() {
+        let tracker = ScanTracker::default();
+        let mut guard_on_removed_bank = ScanGuard::try_new(&tracker, 1, || 10).unwrap();
+        let mut guard_on_other_bank = ScanGuard::try_new(&tracker, 2, || 10).unwrap();
+        assert!(!guard_on_removed_bank.is_bank_removed());
+        assert!(!guard_on_other_bank.is_bank_removed());
+
+        tracker.mark_banks_removed([1]);
+
+        assert!(guard_on_removed_bank.is_bank_removed());
+        assert!(!guard_on_other_bank.is_bank_removed());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
When a bank is removed, any scans on that bank continue even though they will eventually error out. This also holds the bank until the scan is completed.

#### Summary of Changes
- Add an abort counter in the scan tracker, increment it everytime an abort occurs
- When scanning a bank, check the abort counter. If it has changed since the last check, then check to see if the bank the scan is occurring on has been aborted. 
- This avoid contention on the mutex when multiple scans are in progress. 

#### Testing
I ran this on a running validator, and periodically injected scan_accounts. I didn't run baseline because the abort would be hours...
```
[2026-08-27T23:10:43.808545610Z INFO  solana_core::scan_abort_injection] scan abort injection: slot 442208225 bank id 34075: scan visited 52995 accounts in 55.445687ms and returned SlotRemoved { slot: 442208225, bank_id: 34075 }; clear_bank took 10.647134ms; scan returned 19.961061ms after the clear was requested; bank dropped Some(19.961522ms) after
[2026-08-27T23:15:44.164187540Z INFO  solana_core::scan_abort_injection] scan abort injection: slot 442209046 bank id 34897: scan visited 25354 accounts in 56.329233ms and returned SlotRemoved { slot: 442209046, bank_id: 34897 }; clear_bank took 30.772972ms; scan returned 33.215027ms after the clear was requested; bank dropped Some(267.283321ms) after
[2026-08-27T23:20:44.264520917Z INFO  solana_core::scan_abort_injection] scan abort injection: slot 442209866 bank id 35718: scan visited 33687 accounts in 30.129934ms and returned SlotRemoved { slot: 442209866, bank_id: 35718 }; clear_bank took 1.459191ms; scan returned 5.135197ms after the clear was requested; bank dropped Some(5.135557ms) after
[2026-08-27T23:25:44.371931632Z INFO  solana_core::scan_abort_injection] scan abort injection: slot 442210690 bank id 36543: scan visited 49453 accounts in 44.954806ms and returned SlotRemoved { slot: 442210690, bank_id: 36543 }; clear_bank took 2.213721ms; scan returned 5.563788ms after the clear was requested; bank dropped Some(5.564028ms) after
```

Fixes #
