### PR TITLE
accounts-db: clamp index pre-allocation to the memory threshold

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -116,7 +116,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         let num_ages_to_distribute_scans = Age::MAX - storage.ages_to_stay_in_cache;
 
         let map_internal = if let Some(num_initial_accounts) = num_initial_accounts {
-            let capacity_per_bin = num_initial_accounts / storage.bins;
+            // Never reserve past the memory threshold: entries above it get evicted to disk, so the
+            // extra capacity would be memory the index limit is meant to bound.
+            let capacity_per_bin = (num_initial_accounts / storage.bins).min(
+                storage
+                    .threshold_entries_per_bin
+                    .as_ref()
+                    .map_or(usize::MAX, |thresholds| thresholds.target_entries),
+            );
             RwLock::new(HashMap::with_capacity_and_hasher(
                 capacity_per_bin,
                 ahash::RandomState::default(),
@@ -2320,6 +2327,37 @@ mod tests {
                 assert_eq!(total_capacity, 0);
             }
         }
+    }
+
+    /// A pre-allocation larger than the memory threshold must not reserve past it, otherwise we
+    /// would allocate memory that the index limit is meant to bound.
+    #[test]
+    fn test_new_with_num_initial_accounts_clamped_to_threshold() {
+        let num_bins = 1;
+        // A limit small enough that the clamped capacity is cheap to actually allocate
+        let bytes_per_entry = InMemAccountsIndex::<u64, u64>::size_of_uninitialized()
+            + InMemAccountsIndex::<u64, u64>::size_of_single_entry();
+        let config = AccountsIndexConfig {
+            bins: Some(num_bins),
+            index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                num_bytes: (2048 * bytes_per_entry) as u64,
+                num_entries_overhead: 300,
+                num_entries_to_evict: 200,
+            }),
+            ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
+        };
+        let holder = Arc::new(BucketMapHolder::new(num_bins, &config, 1));
+        let target_entries = holder
+            .threshold_entries_per_bin
+            .as_ref()
+            .unwrap()
+            .target_entries;
+
+        let index = InMemAccountsIndex::<u64, u64>::new(&holder, 0, Some(target_entries * 100));
+        let capacity = index.map_internal.read().unwrap().capacity();
+        assert!(capacity >= target_entries, "{capacity} < {target_entries}");
+        // one hashmap growth step of slack above the target, no more
+        assert!(capacity < target_entries * 2, "{capacity}");
     }
 
     /// Ensure `write_startup_info()` populates the in-mem index,


### PR DESCRIPTION
#### Problem
`num_initial_accounts` reserves in-mem capacity per bin without consulting the index memory limit. With `--accounts-index-limit` set, entries above the threshold get evicted to disk, so reserving beyond it allocates memory the limit is meant to bound, and undoes the power-of-two alignment that `target_entries` is chosen for.

#### Summary of Changes
- cap per-bin reserved capacity at `target_entries` when a threshold is set

#### Testing
Dedicated test that checks `InMemAccountsIndex` initialized with both an `index_limit` and `num_accounts`