### PR TITLE
gossip ContactInfo dump into file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8592,6 +8592,7 @@ dependencies = [
  "agave-logger",
  "clap 2.33.3",
  "log",
+ "serde_json",
  "solana-clap-utils",
  "solana-gossip",
  "solana-net-utils",

--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -27,6 +27,7 @@ agave-unstable-api = []
 agave-logger = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
+serde_json = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-gossip = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/gossip-cli/src/main.rs
+++ b/gossip-cli/src/main.rs
@@ -7,11 +7,13 @@ use {
         value_t_or_exit, values_t,
     },
     log::{info, warn},
+    serde_json::{Map, Value, json},
     solana_clap_utils::{
         hidden_unless_forced,
         input_parsers::{keypair_of, pubkeys_of},
         input_validators::{is_keypair_or_ask_keyword, is_port, is_pubkey},
     },
+    solana_gossip::contact_info::socket_tag_name,
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     std::{
@@ -153,6 +155,16 @@ fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'
                         .value_name("SECONDS")
                         .takes_value(true)
                         .help("Maximum time to wait in seconds [default: wait forever]"),
+                )
+                .arg(
+                    Arg::with_name("dump")
+                        .long("dump")
+                        .value_name("PATH")
+                        .takes_value(true)
+                        .help(
+                            "Dump every discovered ContactInfo to PATH as JSON lines (- for \
+                             stdout)",
+                        ),
                 ),
         )
 }
@@ -247,6 +259,36 @@ fn process_spy_results(
     }
 }
 
+fn dump_contact_infos(path: &str, nodes: &[ContactInfo]) -> std::io::Result<()> {
+    let mut out = String::new();
+    for node in nodes {
+        let sockets: Map<String, Value> = node
+            .iter_sockets()
+            .map(|(tag, addr)| {
+                let name = socket_tag_name(tag)
+                    .map_or_else(|| format!("unknown_{tag}"), ToString::to_string);
+                (name, Value::from(addr.to_string()))
+            })
+            .collect();
+        let entry = json!({
+            "pubkey": node.pubkey().to_string(),
+            "wallclock": node.wallclock(),
+            "outset": node.outset(),
+            "shred_version": node.shred_version(),
+            "version": node.version().to_string(),
+            "sockets": sockets,
+        });
+        out.push_str(&entry.to_string());
+        out.push('\n');
+    }
+    if path == "-" {
+        print!("{out}");
+        Ok(())
+    } else {
+        std::fs::write(path, out)
+    }
+}
+
 /// Check entrypoints until one returns a valid non-zero shred version
 fn get_entrypoint_shred_version(entrypoint_addrs: &[SocketAddr]) -> Option<u16> {
     entrypoint_addrs.iter().find_map(|entrypoint_addr| {
@@ -291,7 +333,7 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
 
     let discover_timeout = Duration::from_secs(timeout.unwrap_or(u64::MAX));
     #[allow(deprecated)]
-    let (_all_peers, validators) = discover_peers(
+    let (all_peers, validators) = discover_peers(
         identity_keypair,
         &entrypoint_addrs,
         num_nodes,
@@ -302,6 +344,10 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
         shred_version,
         socket_addr_space,
     )?;
+
+    if let Some(path) = matches.value_of("dump") {
+        dump_contact_infos(path, &all_peers)?;
+    }
 
     process_spy_results(
         timeout,

--- a/gossip-cli/src/main.rs
+++ b/gossip-cli/src/main.rs
@@ -1,6 +1,9 @@
 //! A command-line executable for monitoring a cluster's gossip plane.
 #[allow(deprecated)]
-use solana_gossip::{contact_info::ContactInfo, gossip_service::discover_peers};
+use solana_gossip::{
+    contact_info::ContactInfo,
+    gossip_service::{discover_peers, discover_peers_and_inspect},
+};
 use {
     clap::{
         App, AppSettings, Arg, ArgMatches, SubCommand, crate_description, crate_name, value_t,
@@ -17,6 +20,7 @@ use {
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     std::{
+        collections::HashMap,
         error,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         process::exit,
@@ -162,8 +166,8 @@ fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'
                         .value_name("PATH")
                         .takes_value(true)
                         .help(
-                            "Dump every discovered ContactInfo to PATH as JSON lines (- for \
-                             stdout)",
+                            "Dump every discovered ContactInfo, plus the slots each node voted \
+                             on, to PATH as JSON lines (- for stdout)",
                         ),
                 ),
         )
@@ -259,7 +263,14 @@ fn process_spy_results(
     }
 }
 
-fn dump_contact_infos(path: &str, nodes: &[ContactInfo]) -> std::io::Result<()> {
+/// Dumps one JSON object per line: every discovered ContactInfo together with
+/// the slots of the votes that node gossiped, followed by vote-only records for
+/// nodes which have votes in CRDS but no (longer a) contact info.
+fn dump_gossip_state(
+    path: &str,
+    nodes: &[ContactInfo],
+    mut vote_slots: HashMap<Pubkey, Vec<u64>>,
+) -> std::io::Result<()> {
     let mut out = String::new();
     for node in nodes {
         let sockets: Map<String, Value> = node
@@ -277,6 +288,15 @@ fn dump_contact_infos(path: &str, nodes: &[ContactInfo]) -> std::io::Result<()> 
             "shred_version": node.shred_version(),
             "version": node.version().to_string(),
             "sockets": sockets,
+            "vote_slots": vote_slots.remove(node.pubkey()).unwrap_or_default(),
+        });
+        out.push_str(&entry.to_string());
+        out.push('\n');
+    }
+    for (pubkey, slots) in vote_slots {
+        let entry = json!({
+            "pubkey": pubkey.to_string(),
+            "vote_slots": slots,
         });
         out.push_str(&entry.to_string());
         out.push('\n');
@@ -332,8 +352,9 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
     }
 
     let discover_timeout = Duration::from_secs(timeout.unwrap_or(u64::MAX));
+    let dump_path = matches.value_of("dump");
     #[allow(deprecated)]
-    let (all_peers, validators) = discover_peers(
+    let (all_peers, validators, vote_slots) = discover_peers_and_inspect(
         identity_keypair,
         &entrypoint_addrs,
         num_nodes,
@@ -343,10 +364,15 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
         Some(&gossip_addr),
         shred_version,
         socket_addr_space,
+        |cluster_info| {
+            dump_path
+                .map(|_| cluster_info.get_all_vote_slots())
+                .unwrap_or_default()
+        },
     )?;
 
-    if let Some(path) = matches.value_of("dump") {
-        dump_contact_infos(path, &all_peers)?;
+    if let Some(path) = dump_path {
+        dump_gossip_state(path, &all_peers, vote_slots)?;
     }
 
     process_spy_results(

--- a/gossip-cli/src/main.rs
+++ b/gossip-cli/src/main.rs
@@ -16,7 +16,10 @@ use {
         input_parsers::{keypair_of, pubkeys_of},
         input_validators::{is_keypair_or_ask_keyword, is_port, is_pubkey},
     },
-    solana_gossip::contact_info::socket_tag_name,
+    solana_gossip::{
+        contact_info::socket_tag_name,
+        ping_probe::{PingProbeConfig, TargetStats, run_ping_probe},
+    },
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     std::{
@@ -170,6 +173,71 @@ fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'
                              on, to PATH as JSON lines (- for stdout)",
                         ),
                 ),
+        )
+        .subcommand(
+            SubCommand::with_name("ping")
+                .about("Measure gossip ping/pong loss and round-trip time against endpoints")
+                .setting(AppSettings::DisableVersion)
+                .arg(
+                    Arg::with_name("target")
+                        .short("t")
+                        .long("target")
+                        .value_name("HOST:PORT")
+                        .takes_value(true)
+                        .multiple(true)
+                        .required(true)
+                        .validator(solana_net_utils::is_host_port)
+                        .help("Gossip endpoint to ping. May be given more than once"),
+                )
+                .arg(
+                    Arg::with_name("identity")
+                        .short("i")
+                        .long("identity")
+                        .value_name("PATH")
+                        .takes_value(true)
+                        .validator(is_keypair_or_ask_keyword)
+                        .help("Identity keypair to sign pings with [default: ephemeral keypair]"),
+                )
+                .arg(
+                    Arg::with_name("count")
+                        .short("c")
+                        .long("count")
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .default_value("10")
+                        .help("Number of pings to send to each target, or 0 to ping forever"),
+                )
+                .arg(
+                    Arg::with_name("interval")
+                        .long("interval")
+                        .value_name("MILLIS")
+                        .takes_value(true)
+                        .default_value("500")
+                        .help("Delay between successive pings to the same target"),
+                )
+                .arg(
+                    Arg::with_name("timeout")
+                        .long("timeout")
+                        .value_name("MILLIS")
+                        .takes_value(true)
+                        .default_value("500")
+                        .help("A pong arriving later than this counts as lost"),
+                )
+                .arg(
+                    Arg::with_name("report_interval")
+                        .long("report-interval")
+                        .value_name("SECONDS")
+                        .takes_value(true)
+                        .default_value("10")
+                        .help("How often to log an interim summary while running"),
+                )
+                .arg(
+                    Arg::with_name("json")
+                        .long("json")
+                        .takes_value(false)
+                        .help("Print the summary as JSON lines, one object per target"),
+                )
+                .arg(&bind_address_arg),
         )
 }
 
@@ -386,6 +454,109 @@ fn process_spy(matches: &ArgMatches, socket_addr_space: SocketAddrSpace) -> std:
     Ok(())
 }
 
+fn process_ping(matches: &ArgMatches) -> std::io::Result<()> {
+    let targets: Vec<SocketAddr> = values_t!(matches, "target", String)
+        .unwrap_or_default()
+        .iter()
+        .map(|target| {
+            solana_net_utils::parse_host_port(target).unwrap_or_else(|e| {
+                eprintln!("failed to parse target {target}: {e}");
+                exit(1);
+            })
+        })
+        .collect();
+    let count = value_t_or_exit!(matches, "count", u64);
+    let config = PingProbeConfig {
+        bind_ip: matches.value_of("bind_address").map_or(
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            |bind_address| {
+                solana_net_utils::parse_host(bind_address).unwrap_or_else(|e| {
+                    eprintln!("failed to parse bind-address: {e}");
+                    exit(1);
+                })
+            },
+        ),
+        interval: Duration::from_millis(value_t_or_exit!(matches, "interval", u64)),
+        timeout: Duration::from_millis(value_t_or_exit!(matches, "timeout", u64)),
+        count: (count != 0).then_some(count),
+        report_interval: Duration::from_secs(value_t_or_exit!(matches, "report_interval", u64)),
+    };
+    let stats = run_ping_probe(&targets, keypair_of(matches, "identity"), &config)?;
+    if matches.is_present("json") {
+        for stats in &stats {
+            println!("{}", ping_stats_json(stats));
+        }
+    } else {
+        for stats in &stats {
+            print_ping_stats(stats);
+        }
+    }
+    Ok(())
+}
+
+fn ping_stats_json(stats: &TargetStats) -> Value {
+    let rtt_ms = stats.rtt_summary().map(|rtt| {
+        json!({
+            "min": millis(rtt.min),
+            "p50": millis(rtt.p50),
+            "mean": millis(rtt.mean),
+            "p99": millis(rtt.p99),
+            "max": millis(rtt.max),
+            "stddev": millis(rtt.stddev),
+        })
+    });
+    let responders: Map<String, Value> = stats
+        .responders
+        .iter()
+        .map(|(pubkey, count)| (pubkey.to_string(), Value::from(*count)))
+        .collect();
+    json!({
+        "target": stats.addr.to_string(),
+        "sent": stats.sent,
+        "received": stats.received,
+        "loss_percent": stats.loss_percent(),
+        "late": stats.late,
+        "invalid": stats.invalid,
+        "send_errors": stats.send_errors,
+        "rtt_ms": rtt_ms,
+        "responders": responders,
+    })
+}
+
+fn print_ping_stats(stats: &TargetStats) {
+    println!("{}", stats.addr);
+    println!(
+        "  sent {}  received {}  loss {:.2}%  late {}  invalid {}  send-errors {}",
+        stats.sent,
+        stats.received,
+        stats.loss_percent(),
+        stats.late,
+        stats.invalid,
+        stats.send_errors,
+    );
+    match stats.rtt_summary() {
+        Some(rtt) => println!(
+            "  rtt ms  min {:.3}  p50 {:.3}  mean {:.3}  p99 {:.3}  max {:.3}  stddev {:.3}",
+            millis(rtt.min),
+            millis(rtt.p50),
+            millis(rtt.mean),
+            millis(rtt.p99),
+            millis(rtt.max),
+            millis(rtt.stddev),
+        ),
+        None => println!("  rtt ms  no replies in time"),
+    }
+    let mut responders: Vec<_> = stats.responders.iter().collect();
+    responders.sort_unstable_by_key(|(_pubkey, count)| std::cmp::Reverse(**count));
+    for (pubkey, count) in responders {
+        println!("  responder {pubkey}  {count} pong(s)");
+    }
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
 fn parse_entrypoints(matches: &ArgMatches) -> Vec<SocketAddr> {
     values_t!(matches, "entrypoint", String)
         .unwrap_or_default()
@@ -482,6 +653,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
         ("rpc-url", Some(matches)) => {
             process_rpc_url(matches, socket_addr_space)?;
+        }
+        ("ping", Some(matches)) => {
+            process_ping(matches)?;
         }
         _ => unreachable!(),
     }

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1035,6 +1035,30 @@ impl ClusterInfo {
         txs
     }
 
+    /// Returns the slots of all votes currently in CRDS, keyed by the identity
+    /// pubkey of the node which gossiped them. Slots are sorted ascending.
+    /// Only staked nodes' votes are retained in CRDS, so this covers the
+    /// staked set as seen by this node.
+    pub fn get_all_vote_slots(&self) -> HashMap<Pubkey, Vec<Slot>> {
+        let mut cursor = Cursor::default();
+        let mut slots: HashMap<Pubkey, Vec<Slot>> = HashMap::new();
+        for value in self
+            .time_gossip_read_lock("get_votes", &self.stats.get_votes)
+            .get_votes(&mut cursor)
+        {
+            let CrdsData::Vote(_, vote) = value.value.data() else {
+                panic!("the votes index of CRDS must only contain votes");
+            };
+            if let Some(slot) = vote.slot() {
+                slots.entry(value.value.pubkey()).or_default().push(slot);
+            }
+        }
+        for slots in slots.values_mut() {
+            slots.sort_unstable();
+        }
+        slots
+    }
+
     /// Returns votes and the associated labels inserted since the given cursor.
     pub fn get_votes_with_labels(
         &self,

--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -47,6 +47,27 @@ const SOCKET_TAG_ALPENGLOW: u8 = 13;
 const_assert_eq!(SOCKET_CACHE_SIZE, 14);
 const SOCKET_CACHE_SIZE: usize = SOCKET_TAG_ALPENGLOW as usize + 1usize;
 
+/// Human readable name of a socket tag, or None if the tag is unknown.
+pub const fn socket_tag_name(key: u8) -> Option<&'static str> {
+    Some(match key {
+        SOCKET_TAG_GOSSIP => "gossip",
+        SOCKET_TAG_RPC => "rpc",
+        SOCKET_TAG_RPC_PUBSUB => "rpc_pubsub",
+        SOCKET_TAG_SERVE_REPAIR => "serve_repair",
+        SOCKET_TAG_SERVE_REPAIR_QUIC => "serve_repair_quic",
+        SOCKET_TAG_TPU => "tpu",
+        SOCKET_TAG_TPU_FORWARDS => "tpu_forwards",
+        SOCKET_TAG_TPU_FORWARDS_QUIC => "tpu_forwards_quic",
+        SOCKET_TAG_TPU_QUIC => "tpu_quic",
+        SOCKET_TAG_TPU_VOTE => "tpu_vote",
+        SOCKET_TAG_TPU_VOTE_QUIC => "tpu_vote_quic",
+        SOCKET_TAG_TVU => "tvu",
+        SOCKET_TAG_TVU_QUIC => "tvu_quic",
+        SOCKET_TAG_ALPENGLOW => "alpenglow",
+        _ => return None,
+    })
+}
+
 // An alias for a function that reads data from a ContactInfo entry stored in
 // the gossip CRDS table.
 pub trait ContactInfoQuery<R>: Fn(&ContactInfo) -> R {}
@@ -283,6 +304,19 @@ impl ContactInfo {
 
     pub fn set_shred_version(&mut self, shred_version: u16) {
         self.shred_version = shred_version
+    }
+
+    /// Iterator over every advertised socket as (socket tag, address) pairs,
+    /// including tags which have no dedicated accessor.
+    pub fn iter_sockets(&self) -> impl Iterator<Item = (u8, SocketAddr)> + '_ {
+        let mut port = 0u16;
+        self.sockets.iter().filter_map(move |entry| {
+            // Entries are sanitized on deserialization, so the running port
+            // sum cannot overflow and every index is in bounds.
+            port += entry.offset;
+            let addr = self.addrs.get(usize::from(entry.index))?;
+            Some((entry.key, SocketAddr::new(*addr, port)))
+        })
     }
 
     get_socket!(gossip, SOCKET_TAG_GOSSIP);

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -187,6 +187,41 @@ pub fn discover_peers(
     Vec<ContactInfo>, // all gossip peers
     Vec<ContactInfo>, // tvu peers (validators)
 )> {
+    let (all_peers, tvu_peers, ()) = discover_peers_and_inspect(
+        keypair,
+        entrypoints,
+        num_nodes,
+        timeout,
+        find_nodes_by_pubkey,
+        find_nodes_by_gossip_addr,
+        my_gossip_addr,
+        my_shred_version,
+        socket_addr_space,
+        |_| (),
+    )?;
+    Ok((all_peers, tvu_peers))
+}
+
+/// Same as [`discover_peers`], but additionally runs `inspect` against the spy
+/// node's `ClusterInfo` once discovery ends, so that CRDS contents other than
+/// contact infos can be extracted before the node is torn down.
+#[allow(clippy::too_many_arguments)]
+pub fn discover_peers_and_inspect<T>(
+    keypair: Option<Keypair>,
+    entrypoints: &[SocketAddr],
+    num_nodes: Option<usize>, // num_nodes only counts validators, excludes spy nodes
+    timeout: Duration,
+    find_nodes_by_pubkey: Option<&[Pubkey]>,
+    find_nodes_by_gossip_addr: &[SocketAddr],
+    my_gossip_addr: Option<&SocketAddr>,
+    my_shred_version: u16,
+    socket_addr_space: SocketAddrSpace,
+    inspect: impl FnOnce(&ClusterInfo) -> T,
+) -> std::io::Result<(
+    Vec<ContactInfo>, // all gossip peers
+    Vec<ContactInfo>, // tvu peers (validators)
+    T,                // result of inspecting the spy node's CRDS
+)> {
     let keypair = keypair.unwrap_or_else(Keypair::new);
     let exit = Arc::new(AtomicBool::new(false));
     let (gossip_service, ip_echo, spy_ref) = make_node(
@@ -221,6 +256,8 @@ pub fn discover_peers(
         find_nodes_by_gossip_addr,
     );
 
+    let inspected = inspect(&spy_ref);
+
     exit.store(true, Ordering::Relaxed);
     gossip_service.join().unwrap();
 
@@ -230,7 +267,7 @@ pub fn discover_peers(
             elapsed.as_secs(),
             spy_ref.contact_info_trace()
         );
-        return Ok((all_peers, tvu_peers));
+        return Ok((all_peers, tvu_peers, inspected));
     }
 
     if !tvu_peers.is_empty() {
@@ -238,7 +275,7 @@ pub fn discover_peers(
             "discover failed to match criteria by timeout...\n{}",
             spy_ref.contact_info_trace()
         );
-        return Ok((all_peers, tvu_peers));
+        return Ok((all_peers, tvu_peers, inspected));
     }
 
     info!("discover failed...\n{}", spy_ref.contact_info_trace());

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -26,6 +26,7 @@ pub mod node;
 #[macro_use]
 mod tlv;
 pub mod ping_pong;
+pub mod ping_probe;
 mod protocol;
 mod push_active_set;
 mod received_cache;

--- a/gossip/src/ping_pong.rs
+++ b/gossip/src/ping_pong.rs
@@ -131,6 +131,11 @@ impl Pong {
         &self.from
     }
 
+    /// Hash of the token of the ping which this pong answers.
+    pub(crate) fn hash(&self) -> &Hash {
+        &self.hash
+    }
+
     pub(crate) fn signature(&self) -> &Signature {
         &self.signature
     }
@@ -324,7 +329,7 @@ impl<const N: usize> PingCache<N> {
     }
 }
 
-fn hash_ping_token<const N: usize>(token: &[u8; N]) -> Hash {
+pub(crate) fn hash_ping_token<const N: usize>(token: &[u8; N]) -> Hash {
     solana_sha256_hasher::hashv(&[PING_PONG_HASH_PREFIX, token])
 }
 

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -40,7 +40,7 @@ pub(crate) const MAX_PRUNE_DATA_NODES: usize = 32;
 /// Prune data prefix for PruneMessage
 const PRUNE_DATA_PREFIX: &[u8] = b"\xffSOLANA_PRUNE_DATA";
 /// Number of bytes in the randomly generated token sent with ping messages.
-const GOSSIP_PING_TOKEN_SIZE: usize = 32;
+pub(crate) const GOSSIP_PING_TOKEN_SIZE: usize = 32;
 /// Minimum serialized size of a Protocol::PullResponse packet.
 pub(crate) const PULL_RESPONSE_MIN_SERIALIZED_SIZE: usize = 161;
 const MIN_CRDS_VALUE_SERIALIZED_SIZE: usize =


### PR DESCRIPTION
#### Problem

It is inconvenient to work with gossip data that is not published by RPCs

#### Summary of Changes

allow gossip-spy to dump the entirety of ContactInfo table to a JSON file

#### Testing

Manual

