### PR TITLE
CI - syscall address parameters

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1398,7 +1398,10 @@ mod tests {
         solana_account::{Account, AccountSharedData, ReadableAccount},
         solana_account_info::AccountInfo,
         solana_sbpf::{
-            ebpf::MM_INPUT_START, memory_region::MemoryRegion, program::SBPFVersion, vm::Config,
+            ebpf::{MM_INPUT_START, MM_STACK_START},
+            memory_region::MemoryRegion,
+            program::SBPFVersion,
+            vm::Config,
         },
         solana_sdk_ids::{bpf_loader, system_program},
         solana_svm_feature_set::SVMFeatureSet,
@@ -1937,7 +1940,7 @@ mod tests {
         let key = transaction_accounts[1].0;
         let original_data_len = account.data().len();
 
-        let vm_addr = MM_INPUT_START;
+        let vm_addr = MM_STACK_START;
         let (_mem, region, account_metadata) =
             MockAccountInfo::new(key, &account).into_region(vm_addr);
 
@@ -2043,7 +2046,7 @@ mod tests {
         );
 
         let key = Pubkey::new_unique();
-        let vm_addr = MM_INPUT_START;
+        let vm_addr = MM_STACK_START;
         let (_mem, region, account_metadata) =
             MockAccountInfo::new(key, &account).into_region(vm_addr);
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4875,10 +4875,10 @@ mod tests {
         let clock_id = Clock::id().to_bytes();
 
         let mut got_clock_buf_rw = vec![0; solana_clock::SIZE];
-        let got_clock_buf_rw_va = 0x400000000;
+        let got_clock_buf_rw_va = 0x300000100;
 
         let got_clock_buf_ro = [0; solana_clock::SIZE];
-        let got_clock_buf_ro_va = 0x500000000;
+        let got_clock_buf_ro_va = 0x300000200;
 
         let access_violation_err =
             std::mem::discriminant(&EbpfError::AccessViolation(AccessType::Load, 0, 0, ""));


### PR DESCRIPTION
#### Problem

Some tests still pass pointers to the input region to CPI or sysvar syscalls, which is now forbidden.

#### Summary of Changes

Uses the stack and heap instead of the input region.

#### Testing

- Adjusts `test_syscall_get_sysvar_errors()`.
- Adjusts `test_translate_accounts_rust()` and `test_caller_account_from_account_info()`.