### PR TITLE
clear only the mapped heap prefix on pool return

### DIFF
--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -177,6 +177,27 @@ mod test {
     }
 
     #[test]
+    fn test_heap_shrink_then_grow_stays_zeroed() {
+        let mut pool = VmMemoryPool::new();
+        let big = MAX_HEAP_FRAME_BYTES;
+        let small = MIN_HEAP_FRAME_BYTES;
+
+        let mut heap = pool.get_heap(big);
+        heap.as_slice_mut().fill(0xaa);
+        assert!(pool.put_heap(heap, big as usize));
+
+        let mut heap = pool.get_heap(small);
+        heap.as_slice_mut()
+            .get_mut(..small as usize)
+            .unwrap()
+            .fill(0xbb);
+        assert!(pool.put_heap(heap, small as usize));
+
+        let heap = pool.get_heap(big);
+        assert!(heap.as_slice().iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
     fn test_pool() {
         let mut pool = Pool::<Item, 2>::new([Item(0, 1), Item(1, 1)]);
         assert_eq!(pool.get(), Some(Item(1, 1)));

--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -11,7 +11,7 @@ use {
 };
 
 trait Reset {
-    fn reset(&mut self);
+    fn reset(&mut self, len: usize);
 }
 
 struct Pool<T: Reset, const SIZE: usize> {
@@ -41,11 +41,11 @@ impl<T: Reset, const SIZE: usize> Pool<T, SIZE> {
             .and_then(|item| item.take())
     }
 
-    fn put(&mut self, mut value: T) -> bool {
+    fn put(&mut self, mut value: T, len: usize) -> bool {
         self.items
             .get_mut(self.next_empty)
             .map(|item| {
-                value.reset();
+                value.reset(len);
                 item.replace(value);
                 self.next_empty = self.next_empty.saturating_add(1);
                 true
@@ -55,8 +55,12 @@ impl<T: Reset, const SIZE: usize> Pool<T, SIZE> {
 }
 
 impl Reset for AlignedMemory<{ HOST_ALIGN }> {
-    fn reset(&mut self) {
-        self.as_slice_mut().fill(0)
+    fn reset(&mut self, len: usize) {
+        let slice = self.as_slice_mut();
+        let len = len.min(slice.len());
+        if let Some(head) = slice.get_mut(..len) {
+            head.fill(0);
+        }
     }
 }
 
@@ -74,7 +78,7 @@ impl Default for CallFrameBuffer {
 }
 
 impl Reset for CallFrameBuffer {
-    fn reset(&mut self) {
+    fn reset(&mut self, _len: usize) {
         self.fill(CallFrame::default())
     }
 }
@@ -130,7 +134,8 @@ impl VmMemoryPool {
     }
 
     pub fn put_stack(&mut self, stack: AlignedMemory<{ HOST_ALIGN }>) -> bool {
-        self.stack.put(stack)
+        let len = stack.len();
+        self.stack.put(stack, len)
     }
 
     pub fn get_heap(&mut self, heap_size: u32) -> AlignedMemory<{ HOST_ALIGN }> {
@@ -140,13 +145,14 @@ impl VmMemoryPool {
             .unwrap_or_else(|| AlignedMemory::zero_filled(MAX_HEAP_FRAME_BYTES as usize))
     }
 
-    pub fn put_heap(&mut self, heap: AlignedMemory<{ HOST_ALIGN }>) -> bool {
+    pub fn put_heap(&mut self, heap: AlignedMemory<{ HOST_ALIGN }>, mapped_len: usize) -> bool {
         let heap_size = heap.len();
         debug_assert!(
             heap_size >= MIN_HEAP_FRAME_BYTES as usize
                 && heap_size <= MAX_HEAP_FRAME_BYTES as usize
         );
-        self.heap.put(heap)
+        debug_assert!(mapped_len <= heap_size);
+        self.heap.put(heap, mapped_len.min(heap_size))
     }
 
     pub fn get_call_frames(&mut self) -> CallFrameBuffer {
@@ -154,7 +160,7 @@ impl VmMemoryPool {
     }
 
     pub fn put_call_frames(&mut self, call_frame: CallFrameBuffer) -> bool {
-        self.call_frame.put(call_frame)
+        self.call_frame.put(call_frame, 0)
     }
 }
 
@@ -165,7 +171,7 @@ mod test {
     #[derive(Debug, Eq, PartialEq)]
     struct Item(u8, u8);
     impl Reset for Item {
-        fn reset(&mut self) {
+        fn reset(&mut self, _len: usize) {
             self.1 = 0;
         }
     }
@@ -176,11 +182,11 @@ mod test {
         assert_eq!(pool.get(), Some(Item(1, 1)));
         assert_eq!(pool.get(), Some(Item(0, 1)));
         assert_eq!(pool.get(), None);
-        pool.put(Item(1, 1));
+        pool.put(Item(1, 1), 0);
         assert_eq!(pool.get(), Some(Item(1, 0)));
-        pool.put(Item(2, 2));
-        pool.put(Item(3, 3));
-        assert!(!pool.put(Item(4, 4)));
+        pool.put(Item(2, 2), 0);
+        pool.put(Item(3, 3), 0);
+        assert!(!pool.put(Item(4, 4), 0));
         assert_eq!(pool.get(), Some(Item(3, 0)));
         assert_eq!(pool.get(), Some(Item(2, 0)));
         assert_eq!(pool.get(), None);

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -286,6 +286,7 @@ pub fn execute<'a, 'b: 'a>(
         }
 
         let compute_meter_prev = invoke_context.get_remaining();
+        let mapped_heap_len = invoke_context.get_compute_budget().heap_size as usize;
         let (mut vm, stack, heap) = unsafe {
             // SAFETY: The `stack`, `heap` and `executable` live past the lifetime of
             // `invoke_context`.
@@ -318,7 +319,7 @@ pub fn execute<'a, 'b: 'a>(
         let register_trace = std::mem::take(&mut vm.register_trace);
         MEMORY_POOL.with_borrow_mut(|memory_pool| {
             memory_pool.put_stack(stack);
-            memory_pool.put_heap(heap);
+            memory_pool.put_heap(heap, mapped_heap_len);
             memory_pool.put_call_frames(call_frames);
             debug_assert!(memory_pool.stack_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);
             debug_assert!(memory_pool.heap_len() <= MAX_INSTRUCTION_STACK_DEPTH_SIMD_0268);


### PR DESCRIPTION
#### Problem

`put_heap` clears the whole pooled buffer, which is always `MAX_HEAP_FRAME_BYTES` (256 KiB). but `create_vm!` slices that buffer to `..heap_size` before handing it to `MemoryRegion::new`, so the guest can only address the first `heap_size` bytes, 32 KiB by default. the tail is unreachable and already zero, so clearing it is dead work on every instruction.

#### Summary of Changes

- `put_heap` takes the mapped length and clears only that prefix
- `Reset::reset` takes a size hint, so the pool is still the only thing that clears and callers can't forget to
- stack is untouched. the whole stack region is mapped, so the guest can dirty all of it regardless of call depth

measured on an EPYC 9B45 with the guest dirtying subtracted out: 2.24us today vs 1.34us clearing only what is mapped, so ~0.9us per instruction at the default heap size, 40% of the reset. the saving goes to zero when a program requests the full 256 KiB, as expected.

#### Testing

`test_stack_heap_zeroed` passes. also forced the clear to zero bytes to confirm the test actually covers this, and it fails there with `heap not zeroed`.