### PR TITLE
snapshots: record the bank's account count in the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Release channels have their own copy of this changelog:
 * [stable - v4.0](https://github.com/anza-xyz/agave/blob/v4.0/CHANGELOG.md)
 
 <a name="edge-channel"></a>
+## 4.4.0-Unreleased
+### Validator
+#### Changes
+* Snapshots now record the bank's account count, which is used to pre-allocate the accounts index
+  at startup. `--accounts-index-initial-accounts-count` still overrides it.
+
 ## 4.3.0-Unreleased
 ### RPC
 #### Breaking

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -449,6 +449,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self.storage.storage.stats
     }
 
+    /// Number of pubkeys tracked by the index, in-mem and on-disk.
+    pub fn num_accounts(&self) -> usize {
+        self.stats().total_count()
+    }
+
     /// get stats related to startup
     pub(crate) fn get_startup_stats(&self) -> &StartupStats {
         &self.storage.storage.startup_stats

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -62,7 +62,10 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .help(
+                "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
+                 account count recorded in the snapshot being loaded.",
+            )
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_index_limit")
             .long("accounts-index-limit")

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -516,6 +516,7 @@ pub enum VATHealthError {
         accounts_lt_hash(pub),
         bank_hash_stats(pub),
         block_id(pub),
+        num_accounts(pub),
     )
 )]
 pub struct BankFieldsToDeserialize {
@@ -549,6 +550,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) accounts_lt_hash: AccountsLtHash,
     pub(crate) bank_hash_stats: BankHashStats,
     pub(crate) block_id: Option<Hash>, // Option wrapper can be removed in version after v4.1
+    pub(crate) num_accounts: Option<u64>,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
@@ -589,6 +591,7 @@ impl Default for BankFieldsToDeserialize {
             accounts_lt_hash: AccountsLtHash(LtHash::identity()),
             bank_hash_stats: BankHashStats::default(),
             block_id: Option::<Hash>::default(),
+            num_accounts: Option::<u64>::default(),
         }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -630,6 +630,7 @@ pub struct BankFieldsToSerialize {
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: AccountsLtHash,
     pub block_id: Hash,
+    pub num_accounts: u64,
 }
 
 // Can't derive PartialEq because RwLock doesn't implement PartialEq
@@ -791,6 +792,7 @@ impl BankFieldsToSerialize {
             versioned_epoch_stakes: HashMap::default(),
             accounts_lt_hash: AccountsLtHash(LtHash([0x7E57; LtHash::NUM_ELEMENTS])),
             block_id: Hash::default(),
+            num_accounts: u64::default(),
         }
     }
 }
@@ -2307,6 +2309,7 @@ impl Bank {
             versioned_epoch_stakes: self.epoch_stakes.clone(),
             accounts_lt_hash: self.accounts_lt_hash.lock().unwrap().clone(),
             block_id: self.block_id().expect("block id must be set"),
+            num_accounts: self.rc.accounts.accounts_db.accounts_index.num_accounts() as u64,
         }
     }
 

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -264,6 +264,15 @@ mod tests {
         )
         .unwrap();
 
+        // The account count lands in the bank fields, where it is used to size the index
+        let (bank_fields, _) =
+            crate::serde_snapshot::fields_from_stream(&mut std::io::BufReader::new(&buf[..]))
+                .unwrap();
+        assert_eq!(
+            bank_fields.num_accounts,
+            Some(bank.rc.accounts.accounts_db.accounts_index.num_accounts() as u64),
+        );
+
         // Deserialize
         let rdr = Cursor::new(&buf[..]);
         let mut reader = std::io::BufReader::new(&buf[rdr.position() as usize..]);

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -128,6 +128,7 @@ mod tests {
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
             let block_id = Some(bank_fields.block_id);
+            let num_accounts = Some(bank_fields.num_accounts);
             serde_snapshot::serialize_bank_snapshot_into(
                 &mut writer,
                 bank_fields,
@@ -140,6 +141,7 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash,
                     block_id,
+                    num_accounts,
                 },
             )
             .unwrap();
@@ -153,6 +155,7 @@ mod tests {
             let versioned_epoch_stakes = mem::take(&mut bank_fields.versioned_epoch_stakes);
             let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
             let block_id = Some(bank_fields.block_id);
+            let num_accounts = Some(bank_fields.num_accounts);
             serde_snapshot::serialize_bank_snapshot_into_wincode(
                 &mut buf_wincode,
                 bank_fields,
@@ -165,6 +168,7 @@ mod tests {
                     versioned_epoch_stakes,
                     accounts_lt_hash,
                     block_id,
+                    num_accounts,
                 },
             )
             .unwrap();

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13207,6 +13207,7 @@ fn test_new_for_txn_tests_system_transfer() {
         accounts_lt_hash: AccountsLtHash(LtHash::identity()),
         bank_hash_stats: BankHashStats::default(),
         block_id: None,
+        num_accounts: None,
     };
 
     let bank = Bank::new_for_txn_tests(bank_rc, fields, FeatureSet::all_enabled(), epoch_stakes);
@@ -13384,6 +13385,7 @@ fn test_new_for_block_tests_with_vote_account() {
         accounts_lt_hash: AccountsLtHash(LtHash::identity()),
         bank_hash_stats: BankHashStats::default(),
         block_id: None,
+        num_accounts: None,
     };
 
     let bank = Bank::new_for_block_tests(

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -452,6 +452,9 @@ struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     #[wincode(with = "DefaultOnEmptyRead<Option<Hash>>")]
     block_id: Option<Hash>,
+    #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<u64>>")]
+    num_accounts: Option<u64>,
 }
 
 /// Extra fields that are serialized at the end of snapshots.
@@ -466,7 +469,7 @@ struct ExtraFieldsToDeserialize {
     // Write-only type (its deserialize counterpart is `ExtraFieldsToDeserialize`), so the abi digest
     // only verifies the serialized wire format; there is no roundtrip.
     frozen_abi(
-        abi_digest = "A1hmQvmrkwy33dXMpHXTweArYefPfWtsmwXK6EbNV4K6",
+        abi_digest = "CwLyerwxcFq1fHJm9SbrLZzJQJsbaiQTEz2Vv7PeAAFj",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "no"
     )
@@ -480,6 +483,7 @@ pub struct ExtraFieldsToSerialize {
     pub versioned_epoch_stakes: HashMap<u64, VersionedEpochStakes>,
     pub accounts_lt_hash: Option<SerdeAccountsLtHash>,
     pub block_id: Option<Hash>,
+    pub num_accounts: Option<u64>,
 }
 
 /// Deserializable counterpart of [`SerializableBankSnapshot`], read as one struct (wincode reads
@@ -491,7 +495,7 @@ pub struct ExtraFieldsToSerialize {
     feature = "frozen-abi",
     derive(Deserialize, Serialize, SchemaWrite, StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
+        abi_digest = "A7bEzKHTmpgkwPQd3pb7PJ3fJ5ivaqdgmkgg7bbwFG3b",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "wire_only"
     )
@@ -524,6 +528,7 @@ impl DeserializableBankSnapshot {
             versioned_epoch_stakes,
             accounts_lt_hash,
             block_id,
+            num_accounts: _,
         } = extra_fields;
 
         bank_fields.fee_rate_governor = bank_fields
@@ -635,6 +640,7 @@ where
     let versioned_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
     let accounts_lt_hash = Some(bank_fields.accounts_lt_hash.clone().into());
     let block_id = Some(bank_fields.block_id);
+    let num_accounts = Some(bank_fields.num_accounts);
     serialize_bank_snapshot_into_wincode(
         stream,
         bank_fields,
@@ -647,6 +653,7 @@ where
             versioned_epoch_stakes,
             accounts_lt_hash,
             block_id,
+            num_accounts,
         },
     )
 }
@@ -689,7 +696,7 @@ struct SerializableBankSnapshot<E> {
 // roundtrip.
 #[cfg(all(test, feature = "frozen-abi"))]
 #[frozen_abi(
-    abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
+    abi_digest = "A7bEzKHTmpgkwPQd3pb7PJ3fJ5ivaqdgmkgg7bbwFG3b",
     abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -239,7 +239,8 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             versioned_epoch_stakes: vec![], // populated from ExtraFieldsToDeserialize
             accounts_lt_hash: AccountsLtHash(LT_HASH_CANARY), // populated from ExtraFieldsToDeserialize
             bank_hash_stats: BankHashStats::default(),        // populated from AccountsDbFields
-            block_id: None, // populated from ExtraFieldsToDeserialize
+            block_id: None,     // populated from ExtraFieldsToDeserialize
+            num_accounts: None, // populated from ExtraFieldsToDeserialize
         }
     }
 }
@@ -528,7 +529,7 @@ impl DeserializableBankSnapshot {
             versioned_epoch_stakes,
             accounts_lt_hash,
             block_id,
-            num_accounts: _,
+            num_accounts,
         } = extra_fields;
 
         bank_fields.fee_rate_governor = bank_fields
@@ -539,6 +540,7 @@ impl DeserializableBankSnapshot {
             .expect("snapshot must have accounts_lt_hash")
             .into();
         bank_fields.block_id = block_id;
+        bank_fields.num_accounts = num_accounts;
 
         Ok((bank_fields, accounts_db))
     }
@@ -892,11 +894,19 @@ pub(crate) fn reconstruct_bank_from_fields(
     leader_for_tests: Option<SlotLeader>,
     limit_load_slot_count_from_snapshot: Option<usize>,
     verify_index: bool,
-    accounts_db_config: AccountsDbConfig,
+    mut accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
 ) -> Result<(Bank, ReconstructedBankInfo), SnapshotError> {
     let mut bank_fields = bank_fields.collapse_into();
+    // Size the index up front from the snapshot's account count, unless it was configured explicitly
+    if let Some(num_accounts) = bank_fields.num_accounts {
+        let index_config = accounts_db_config.index.get_or_insert_default();
+        if index_config.num_initial_accounts.is_none() {
+            info!("Sizing accounts index for {num_accounts} accounts, per the snapshot");
+            index_config.num_initial_accounts = Some(num_accounts as usize);
+        }
+    }
     // Epoch stakes take several seconds to reconstruct, do it in parallel with loading accountsdb
     let deserializable_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
     let epoch_stakes_handle = thread::Builder::new()

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -528,6 +528,7 @@ pub fn serialize_snapshot(
                 versioned_epoch_stakes,
                 accounts_lt_hash: Some(bank_fields.accounts_lt_hash.clone().into()),
                 block_id: Some(bank_fields.block_id),
+                num_accounts: Some(bank_fields.num_accounts),
             };
             serde_snapshot::serialize_bank_snapshot_into_wincode(
                 stream,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1096,7 +1096,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .help(
+                "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
+                 account count recorded in the snapshot being loaded.",
+            )
             .hidden(hidden_unless_forced()),
     )
     .arg(


### PR DESCRIPTION
#### Problem
The accounts index is grown from empty during startup index generation, so every bin rehashes its way up to the final size. The only way to avoid that is `--accounts-index-initial-accounts-count`, which operators must guess and keep up to date by hand.

#### Summary of Changes
- add `num_accounts` to the snapshot manifest's extra fields
- take the value from the accounts index entry count at serialization time
- size the index from it on load, unless the cli flag was given

#### Testing
* validator at PR starts from master's fastboot
* validator started with PR and then restarted preallocates the index (checked based no logs and profile)
* validator from master restarts back from fastboot generated with PR
* ledger-tool verify from PR reads master, from master reads incremental generated by PR