### PR TITLE
Changes format of repair msg to reduce processing

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -845,13 +845,11 @@ mod tests {
         assert_eq!(ctx.pool_receiver.try_iter().count(), 2);
         assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
         assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 1);
-        let received_verified_votes1 = ctx.repair_receiver.try_recv().unwrap();
+        let mut received_verified_votes1 = ctx.repair_receiver.try_recv().unwrap();
+        assert_eq!(received_verified_votes1.len(), 1);
         assert_eq!(
-            received_verified_votes1,
-            (
-                ctx.validator_keypairs[vote_rank1].vote_keypair.pubkey(),
-                vec![5]
-            )
+            received_verified_votes1.remove(&5).unwrap(),
+            vec![ctx.validator_keypairs[vote_rank1].vote_keypair.pubkey()]
         );
 
         let vote_rank2 = 3;
@@ -877,13 +875,11 @@ mod tests {
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
         assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
         assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
-        let received_verified_votes2 = ctx.repair_receiver.try_recv().unwrap();
+        let mut received_verified_votes2 = ctx.repair_receiver.try_recv().unwrap();
+        assert_eq!(received_verified_votes2.len(), 1);
         assert_eq!(
-            received_verified_votes2,
-            (
-                ctx.validator_keypairs[vote_rank2].vote_keypair.pubkey(),
-                vec![6]
-            )
+            received_verified_votes2.remove(&6).unwrap(),
+            vec![ctx.validator_keypairs[vote_rank2].vote_keypair.pubkey()]
         );
 
         let vote_rank3 = 9;
@@ -908,13 +904,11 @@ mod tests {
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
         assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
         assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
-        let received_verified_votes3 = ctx.repair_receiver.try_recv().unwrap();
+        let mut received_verified_votes3 = ctx.repair_receiver.try_recv().unwrap();
+        assert_eq!(received_verified_votes3.len(), 1);
         assert_eq!(
-            received_verified_votes3,
-            (
-                ctx.validator_keypairs[vote_rank3].vote_keypair.pubkey(),
-                vec![7]
-            )
+            received_verified_votes3.remove(&7).unwrap(),
+            vec![ctx.validator_keypairs[vote_rank3].vote_keypair.pubkey()]
         );
     }
 
@@ -2097,14 +2091,15 @@ mod tests {
         assert_eq!(ctx.verifier.stats.cert_too_far_in_future.0, 0);
         assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 1);
         assert_eq!(ctx.pool_receiver.try_iter().count(), 2);
+        let mut map = ctx.repair_receiver.try_recv().unwrap();
+        assert_eq!(map.len(), 1);
         assert_eq!(
-            ctx.repair_receiver.try_recv().unwrap(),
-            (
+            map.remove(&max_vote_slot).unwrap(),
+            vec![
                 ctx.validator_keypairs[accepted_vote_rank]
                     .vote_keypair
                     .pubkey(),
-                vec![max_vote_slot],
-            )
+            ]
         );
         expect_no_receive(&ctx.repair_receiver);
     }

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -47,7 +47,7 @@ use {
 #[derive(Default)]
 struct ProcessedVotes {
     reward_msg: Vec<VoteAggregate>,
-    repair_msg: HashMap<Pubkey, Vec<Slot>>,
+    repair_msg: HashMap<Slot, Vec<Pubkey>>,
     vote_aggregates_for_pool: Vec<VoteAggregate>,
     metrics_msg: Vec<ConsensusMetricsEvent>,
 }
@@ -233,14 +233,15 @@ pub(super) fn verify_and_send_votes(
 /// be sent to repair.
 fn inspect_for_repair(
     vote: &VerifiedVotePayload,
-    msgs_for_repair: &mut HashMap<Pubkey, Vec<Slot>>,
+    msgs_for_repair: &mut HashMap<Slot, Vec<Pubkey>>,
 ) {
     let vote_slot = vote.vote_aggregate.vote().slot();
     match vote.vote_aggregate.vote() {
         Vote::Notarize(_) | Vote::Finalize(_) | Vote::NotarizeFallback(_) => {
-            for pubkey in &vote.sender_vote_account_pubkeys {
-                msgs_for_repair.entry(*pubkey).or_default().push(vote_slot);
-            }
+            msgs_for_repair
+                .entry(vote_slot)
+                .or_default()
+                .extend(&vote.sender_vote_account_pubkeys);
         }
         Vote::Skip(_) | Vote::SkipFallback(_) | Vote::Genesis(_) => (),
     }

--- a/bls-sigverify/src/utils.rs
+++ b/bls-sigverify/src/utils.rs
@@ -101,21 +101,21 @@ pub(super) fn send_sig_verified_batch_to_pool(
 
 pub(super) fn send_votes_to_repair(
     my_pubkey: &Pubkey,
-    votes: HashMap<Pubkey, Vec<Slot>>,
+    votes: HashMap<Slot, Vec<Pubkey>>,
     channel: &VerifiedVoterSlotsSender,
     stats: &mut VoteSenderStats,
 ) {
-    for (pubkey, slots) in votes {
-        match channel.try_send((pubkey, slots)) {
-            Ok(()) => stats.repair_sender.sent += 1,
-            Err(TrySendError::Full(_)) => {
-                warn!("{my_pubkey}: channel \"{REPAIR_CHANNEL}\" is full, dropping msg");
-                stats.repair_sender.channel_full += 1
-            }
-            Err(TrySendError::Disconnected(_)) => {
-                warn!("{my_pubkey}: channel \"{REPAIR_CHANNEL}\" disconnected");
-                return;
-            }
+    if votes.is_empty() {
+        return;
+    }
+    match channel.try_send(votes) {
+        Ok(()) => stats.repair_sender.sent += 1,
+        Err(TrySendError::Full(_)) => {
+            warn!("{my_pubkey}: channel \"{REPAIR_CHANNEL}\" is full, dropping msg");
+            stats.repair_sender.channel_full += 1
+        }
+        Err(TrySendError::Disconnected(_)) => {
+            warn!("{my_pubkey}: channel \"{REPAIR_CHANNEL}\" disconnected");
         }
     }
 }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -916,14 +916,17 @@ impl ClusterInfoVoteListener {
             return;
         }
 
+        let mut verified_voter_slots = HashMap::new();
+
         // Track all vote slots for propagated check (iterates from most recent to oldest)
         for slot in vote_slots
-            .iter()
-            .filter(|slot| **slot > root && **slot >= *latest_vote_slot)
+            .into_iter()
+            .inspect(|&slot| {
+                verified_voter_slots.insert(slot, vec![*vote_pubkey]);
+            })
+            .filter(|&slot| slot > root && slot >= *latest_vote_slot)
             .rev()
         {
-            let slot = *slot;
-
             // If we don't have stake information, ignore it
             let epoch = root_bank.epoch_schedule().get_epoch(slot);
             if root_bank.epoch_stakes(epoch).is_none() {
@@ -947,7 +950,7 @@ impl ClusterInfoVoteListener {
             }
             let _ = notifiers
                 .verified_voter_slots_sender
-                .send((*vote_pubkey, vote_slots));
+                .send(verified_voter_slots);
         }
     }
 
@@ -1452,10 +1455,11 @@ mod tests {
             .chain(replay_vote_slots.clone())
             .collect();
         let mut pubkey_to_slots: HashMap<Pubkey, BTreeSet<Slot>> = HashMap::new();
-        for (received_pubkey, new_slots) in verified_voter_slots_receiver.try_iter() {
-            let already_received_slots = pubkey_to_slots.entry(received_pubkey).or_default();
-            for new_slot in new_slots {
-                // `new_slot` should only be received once
+        for map in verified_voter_slots_receiver.try_iter() {
+            for (new_slot, received_pubkeys) in map {
+                assert_eq!(received_pubkeys.len(), 1);
+                let already_received_slots =
+                    pubkey_to_slots.entry(received_pubkeys[0]).or_default();
                 assert!(already_received_slots.insert(new_slot));
             }
         }
@@ -1635,7 +1639,10 @@ mod tests {
                 .map(|keypairs| {
                     let node_keypair = &keypairs.node_keypair;
                     let vote_keypair = &keypairs.vote_keypair;
-                    expected_voter_slots.push((vote_keypair.pubkey(), vec![i as Slot + 1]));
+                    expected_voter_slots.push(HashMap::from([(
+                        i as Slot + 1,
+                        vec![vote_keypair.pubkey()],
+                    )]));
                     let tower_sync =
                         TowerSync::new_from_slots(vec![(i as u64 + 1)], bank_hash, None);
                     vote_transaction::new_tower_sync_transaction(

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -704,17 +704,19 @@ impl RepairService {
 
         // Add new votes to the weighting heuristic
         let mut get_votes_us = Measure::start("get_votes_us");
-        let mut slot_to_vote_pubkeys: HashMap<Slot, Vec<Pubkey>> = HashMap::new();
-        verified_voter_slots_receiver
-            .try_iter()
-            .for_each(|(vote_pubkey, vote_slots)| {
-                for slot in vote_slots {
-                    slot_to_vote_pubkeys
-                        .entry(slot)
-                        .or_default()
-                        .push(vote_pubkey);
+        let mut slot_to_vote_pubkeys = HashMap::new();
+        verified_voter_slots_receiver.try_iter().for_each(|map| {
+            for (slot, mut pubkeys) in map {
+                match slot_to_vote_pubkeys.entry(slot) {
+                    Entry::Vacant(e) => {
+                        e.insert(pubkeys);
+                    }
+                    Entry::Occupied(e) => {
+                        e.into_mut().append(&mut pubkeys);
+                    }
                 }
-            });
+            }
+        });
         get_votes_us.stop();
 
         let mut add_voters_us = Measure::start("add_voters_us");

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -7,6 +7,7 @@ use {
     crossbeam_channel::{Receiver, Sender},
     solana_clock::Slot,
     solana_pubkey::Pubkey,
+    std::collections::HashMap,
 };
 
 pub mod certificate;
@@ -25,8 +26,11 @@ pub mod wire;
 #[cfg(feature = "frozen-abi")]
 extern crate solana_frozen_abi_macro;
 
+/// Message type for the verified voter channel.
+/// A message is a HashMap mapping slots to the list of validators from whom a valid vote in that
+/// slot was received.
+type VerifiedVotorSlotsMessage = HashMap<Slot, Vec<Pubkey>>;
 /// Send side of verified voter channel.
-/// Each message contains the Pubkey of the voter and the slots in last verified vote.
-pub type VerifiedVoterSlotsSender = Sender<(Pubkey, Vec<Slot>)>;
+pub type VerifiedVoterSlotsSender = Sender<VerifiedVotorSlotsMessage>;
 /// Receive side of verified voter channel.
-pub type VerifiedVoterSlotsReceiver = Receiver<(Pubkey, Vec<Slot>)>;
+pub type VerifiedVoterSlotsReceiver = Receiver<VerifiedVotorSlotsMessage>;


### PR DESCRIPTION
#### Problem

Currently, bls-sigverify builds a HashMap of msgs to send to repair.  It sends each entry in a single msg.  And then repair builds a differently HashMap from the received msgs.  If bls-sigverify builds the HashMap in the expected format already, we can save processing and number of sends on the channel.


#### Summary of Changes

- Instead of sending `(Pubkey, Vec<Slot>)`, bls-sigverify sends `HashMap<Slot, Vec<Pubkey>>` to repair.
- repair does not need to construct a new hash map of the received msgs and can process the received msg as is.
- updates related code in cluster_info
- updates some related metrics in repair



#### Testing

Existing tests updates but no new tests added.