### PR TITLE
cli: reserve pending delegator rewards when withdrawing ALL from a vote account

### DIFF
--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -134,19 +134,12 @@ where
             } else {
                 0
             };
-        if (amount == SpendAmount::RentExempt || amount == SpendAmount::Available)
-            && account.owner == solana_sdk_ids::vote::id()
-        {
+        if amount == SpendAmount::RentExempt && account.owner == solana_sdk_ids::vote::id() {
             // On top of the rent-exempt minimum, the vote program also reserves the rewards that
             // are pending distribution to the account's stake delegators.
             let pending_delegator_rewards =
                 vote::get_pending_delegator_rewards(&account, from_pubkey)?;
             from_balance = from_balance.saturating_sub(pending_delegator_rewards);
-            if amount == SpendAmount::Available {
-                // `RentExempt` has the rent-exempt minimum deducted when the spend amount is
-                // resolved, but `Available` does not, so reserve it here.
-                from_balance = from_balance.saturating_sub(from_rent_exempt_minimum);
-            }
         }
         if amount == SpendAmount::Available && account.owner == solana_sdk_ids::stake::id() {
             let state = stake::get_account_stake_state(
@@ -359,13 +352,9 @@ mod tests {
         }
     }
 
-    /// Resolves the amount that `withdraw-from-vote-account` withdraws from
-    /// `vote_account` for `amount`, with the fee paid by another account.
-    async fn resolve_vote_withdrawal(
-        vote_account: Account,
-        rent_exempt_minimum: u64,
-        amount: SpendAmount,
-    ) -> u64 {
+    /// Resolves the amount that `withdraw-from-vote-account ALL` withdraws from
+    /// `vote_account`, with the fee paid by another account.
+    async fn resolve_rent_exempt_spend(vote_account: Account, rent_exempt_minimum: u64) -> u64 {
         let vote_account_pubkey = Pubkey::new_unique();
         let account_response = json!(Response {
             context: RpcResponseContext {
@@ -394,7 +383,7 @@ mod tests {
         let (_message, spend) = resolve_spend_tx_and_check_account_balances(
             &rpc_client,
             false,
-            amount,
+            SpendAmount::RentExempt,
             &Hash::default(),
             &vote_account_pubkey,
             &fee_payer,
@@ -417,10 +406,8 @@ mod tests {
         spend
     }
 
-    /// `withdraw-from-vote-account` resolves both `ALL` and `AVAILABLE` to the
-    /// balance in excess of what the vote program requires the account to retain.
     #[tokio::test]
-    async fn test_vote_withdrawal_reserves_pending_delegator_rewards() {
+    async fn test_rent_exempt_spend_reserves_pending_delegator_rewards() {
         const RENT_EXEMPT_MINIMUM: u64 = 27_000_000;
         const PENDING_DELEGATOR_REWARDS: u64 = 5_000_000;
         const WITHDRAWABLE: u64 = 1_000_000;
@@ -428,41 +415,36 @@ mod tests {
         const BALANCE: u64 = RESERVED_BALANCE + WITHDRAWABLE;
         const BALANCE_WITHOUT_PENDING_REWARDS: u64 = RENT_EXEMPT_MINIMUM + WITHDRAWABLE;
 
-        for amount in [SpendAmount::RentExempt, SpendAmount::Available] {
-            // Without pending rewards, everything in excess of the rent-exempt
-            // minimum is withdrawable.
-            assert_eq!(
-                resolve_vote_withdrawal(
-                    vote_account(BALANCE_WITHOUT_PENDING_REWARDS, 0),
-                    RENT_EXEMPT_MINIMUM,
-                    amount,
-                )
-                .await,
-                WITHDRAWABLE
-            );
+        // Without pending rewards, everything in excess of the rent-exempt
+        // minimum is withdrawable.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(BALANCE_WITHOUT_PENDING_REWARDS, 0),
+                RENT_EXEMPT_MINIMUM,
+            )
+            .await,
+            WITHDRAWABLE
+        );
 
-            // Pending delegator rewards are reserved as well, matching the balance
-            // the vote program requires the account to retain.
-            assert_eq!(
-                resolve_vote_withdrawal(
-                    vote_account(BALANCE, PENDING_DELEGATOR_REWARDS),
-                    RENT_EXEMPT_MINIMUM,
-                    amount,
-                )
-                .await,
-                WITHDRAWABLE
-            );
+        // Pending delegator rewards are reserved as well, matching the balance
+        // the vote program requires the account to retain.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(BALANCE, PENDING_DELEGATOR_REWARDS),
+                RENT_EXEMPT_MINIMUM,
+            )
+            .await,
+            WITHDRAWABLE
+        );
 
-            // Nothing is withdrawable when the balance only covers the reserves.
-            assert_eq!(
-                resolve_vote_withdrawal(
-                    vote_account(RESERVED_BALANCE, PENDING_DELEGATOR_REWARDS),
-                    RENT_EXEMPT_MINIMUM,
-                    amount,
-                )
-                .await,
-                0
-            );
-        }
+        // Nothing is withdrawable when the balance only covers the reserves.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(RESERVED_BALANCE, PENDING_DELEGATOR_REWARDS),
+                RENT_EXEMPT_MINIMUM,
+            )
+            .await,
+            0
+        );
     }
 }

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -408,43 +408,40 @@ mod tests {
 
     #[tokio::test]
     async fn test_rent_exempt_spend_reserves_pending_delegator_rewards() {
-        let rent_exempt_minimum = 26_858_640;
-        let pending_delegator_rewards = 5_000_000;
-        let withdrawable = 1_000_000;
+        const RENT_EXEMPT_MINIMUM: u64 = 27_000_000;
+        const PENDING_DELEGATOR_REWARDS: u64 = 5_000_000;
+        const WITHDRAWABLE: u64 = 1_000_000;
+        const RESERVED_BALANCE: u64 = RENT_EXEMPT_MINIMUM + PENDING_DELEGATOR_REWARDS;
+        const BALANCE: u64 = RESERVED_BALANCE + WITHDRAWABLE;
+        const BALANCE_WITHOUT_PENDING_REWARDS: u64 = RENT_EXEMPT_MINIMUM + WITHDRAWABLE;
 
         // Without pending rewards, everything in excess of the rent-exempt
         // minimum is withdrawable.
         assert_eq!(
             resolve_rent_exempt_spend(
-                vote_account(rent_exempt_minimum + withdrawable, 0),
-                rent_exempt_minimum,
+                vote_account(BALANCE_WITHOUT_PENDING_REWARDS, 0),
+                RENT_EXEMPT_MINIMUM,
             )
             .await,
-            withdrawable
+            WITHDRAWABLE
         );
 
         // Pending delegator rewards are reserved as well, matching the balance
         // the vote program requires the account to retain.
         assert_eq!(
             resolve_rent_exempt_spend(
-                vote_account(
-                    rent_exempt_minimum + pending_delegator_rewards + withdrawable,
-                    pending_delegator_rewards,
-                ),
-                rent_exempt_minimum,
+                vote_account(BALANCE, PENDING_DELEGATOR_REWARDS),
+                RENT_EXEMPT_MINIMUM,
             )
             .await,
-            withdrawable
+            WITHDRAWABLE
         );
 
         // Nothing is withdrawable when the balance only covers the reserves.
         assert_eq!(
             resolve_rent_exempt_spend(
-                vote_account(
-                    rent_exempt_minimum + pending_delegator_rewards,
-                    pending_delegator_rewards,
-                ),
-                rent_exempt_minimum,
+                vote_account(RESERVED_BALANCE, PENDING_DELEGATOR_REWARDS),
+                RENT_EXEMPT_MINIMUM,
             )
             .await,
             0

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -3,7 +3,7 @@ use {
         checks::{check_account_for_balance_with_commitment, get_fee_for_messages},
         cli::CliError,
         compute_budget::{UpdateComputeUnitLimitResult, simulate_and_update_compute_unit_limit},
-        stake,
+        stake, vote,
     },
     clap::ArgMatches,
     solana_clap_utils::{
@@ -134,6 +134,13 @@ where
             } else {
                 0
             };
+        if amount == SpendAmount::RentExempt && account.owner == solana_sdk_ids::vote::id() {
+            // On top of the rent-exempt minimum, the vote program also reserves the rewards that
+            // are pending distribution to the account's stake delegators.
+            let pending_delegator_rewards =
+                vote::get_pending_delegator_rewards(&account, from_pubkey)?;
+            from_balance = from_balance.saturating_sub(pending_delegator_rewards);
+        }
         if amount == SpendAmount::Available && account.owner == solana_sdk_ids::stake::id() {
             let state = stake::get_account_stake_state(
                 rpc_client,
@@ -310,4 +317,137 @@ where
         message.instructions[ix_index].data = ix_data;
     }
     Ok((message, spend_and_fee))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        serde_json::json,
+        solana_account::Account,
+        solana_account_decoder::{UiAccountEncoding, encode_ui_account},
+        solana_rpc_client_api::{
+            request::RpcRequest,
+            response::{Response, RpcResponseContext},
+        },
+        solana_vote_program::{
+            vote_instruction::withdraw,
+            vote_state::{VoteStateV4, VoteStateVersions},
+        },
+        std::collections::HashMap,
+    };
+
+    fn vote_account(lamports: u64, pending_delegator_rewards: u64) -> Account {
+        let vote_state = VoteStateV4 {
+            pending_delegator_rewards,
+            ..VoteStateV4::default()
+        };
+        let mut data = vec![0; VoteStateV4::size_of()];
+        VoteStateV4::serialize(&VoteStateVersions::new_v4(vote_state), &mut data).unwrap();
+        Account {
+            lamports,
+            data,
+            owner: solana_sdk_ids::vote::id(),
+            ..Account::default()
+        }
+    }
+
+    /// Resolves the amount that `withdraw-from-vote-account ALL` withdraws from
+    /// `vote_account`, with the fee paid by another account.
+    async fn resolve_rent_exempt_spend(vote_account: Account, rent_exempt_minimum: u64) -> u64 {
+        let vote_account_pubkey = Pubkey::new_unique();
+        let account_response = json!(Response {
+            context: RpcResponseContext {
+                slot: 1,
+                api_version: None
+            },
+            value: json!(encode_ui_account(
+                &vote_account_pubkey,
+                &vote_account,
+                UiAccountEncoding::Base64,
+                None,
+                None,
+            )),
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_response);
+        mocks.insert(
+            RpcRequest::GetMinimumBalanceForRentExemption,
+            json!(rent_exempt_minimum),
+        );
+        let rpc_client = RpcClient::new_mock_with_mocks("".to_string(), mocks);
+
+        let withdraw_authority = Pubkey::new_unique();
+        let destination_pubkey = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+        let (_message, spend) = resolve_spend_tx_and_check_account_balances(
+            &rpc_client,
+            false,
+            SpendAmount::RentExempt,
+            &Hash::default(),
+            &vote_account_pubkey,
+            &fee_payer,
+            ComputeUnitLimit::Default,
+            |lamports| {
+                Message::new(
+                    &[withdraw(
+                        &vote_account_pubkey,
+                        &withdraw_authority,
+                        lamports,
+                        &destination_pubkey,
+                    )],
+                    Some(&fee_payer),
+                )
+            },
+            CommitmentConfig::processed(),
+        )
+        .await
+        .unwrap();
+        spend
+    }
+
+    #[tokio::test]
+    async fn test_rent_exempt_spend_reserves_pending_delegator_rewards() {
+        let rent_exempt_minimum = 26_858_640;
+        let pending_delegator_rewards = 5_000_000;
+        let withdrawable = 1_000_000;
+
+        // Without pending rewards, everything in excess of the rent-exempt
+        // minimum is withdrawable.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(rent_exempt_minimum + withdrawable, 0),
+                rent_exempt_minimum,
+            )
+            .await,
+            withdrawable
+        );
+
+        // Pending delegator rewards are reserved as well, matching the balance
+        // the vote program requires the account to retain.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(
+                    rent_exempt_minimum + pending_delegator_rewards + withdrawable,
+                    pending_delegator_rewards,
+                ),
+                rent_exempt_minimum,
+            )
+            .await,
+            withdrawable
+        );
+
+        // Nothing is withdrawable when the balance only covers the reserves.
+        assert_eq!(
+            resolve_rent_exempt_spend(
+                vote_account(
+                    rent_exempt_minimum + pending_delegator_rewards,
+                    pending_delegator_rewards,
+                ),
+                rent_exempt_minimum,
+            )
+            .await,
+            0
+        );
+    }
 }

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -134,12 +134,19 @@ where
             } else {
                 0
             };
-        if amount == SpendAmount::RentExempt && account.owner == solana_sdk_ids::vote::id() {
+        if (amount == SpendAmount::RentExempt || amount == SpendAmount::Available)
+            && account.owner == solana_sdk_ids::vote::id()
+        {
             // On top of the rent-exempt minimum, the vote program also reserves the rewards that
             // are pending distribution to the account's stake delegators.
             let pending_delegator_rewards =
                 vote::get_pending_delegator_rewards(&account, from_pubkey)?;
             from_balance = from_balance.saturating_sub(pending_delegator_rewards);
+            if amount == SpendAmount::Available {
+                // `RentExempt` has the rent-exempt minimum deducted when the spend amount is
+                // resolved, but `Available` does not, so reserve it here.
+                from_balance = from_balance.saturating_sub(from_rent_exempt_minimum);
+            }
         }
         if amount == SpendAmount::Available && account.owner == solana_sdk_ids::stake::id() {
             let state = stake::get_account_stake_state(
@@ -352,9 +359,13 @@ mod tests {
         }
     }
 
-    /// Resolves the amount that `withdraw-from-vote-account ALL` withdraws from
-    /// `vote_account`, with the fee paid by another account.
-    async fn resolve_rent_exempt_spend(vote_account: Account, rent_exempt_minimum: u64) -> u64 {
+    /// Resolves the amount that `withdraw-from-vote-account` withdraws from
+    /// `vote_account` for `amount`, with the fee paid by another account.
+    async fn resolve_vote_withdrawal(
+        vote_account: Account,
+        rent_exempt_minimum: u64,
+        amount: SpendAmount,
+    ) -> u64 {
         let vote_account_pubkey = Pubkey::new_unique();
         let account_response = json!(Response {
             context: RpcResponseContext {
@@ -383,7 +394,7 @@ mod tests {
         let (_message, spend) = resolve_spend_tx_and_check_account_balances(
             &rpc_client,
             false,
-            SpendAmount::RentExempt,
+            amount,
             &Hash::default(),
             &vote_account_pubkey,
             &fee_payer,
@@ -406,8 +417,10 @@ mod tests {
         spend
     }
 
+    /// `withdraw-from-vote-account` resolves both `ALL` and `AVAILABLE` to the
+    /// balance in excess of what the vote program requires the account to retain.
     #[tokio::test]
-    async fn test_rent_exempt_spend_reserves_pending_delegator_rewards() {
+    async fn test_vote_withdrawal_reserves_pending_delegator_rewards() {
         const RENT_EXEMPT_MINIMUM: u64 = 27_000_000;
         const PENDING_DELEGATOR_REWARDS: u64 = 5_000_000;
         const WITHDRAWABLE: u64 = 1_000_000;
@@ -415,36 +428,41 @@ mod tests {
         const BALANCE: u64 = RESERVED_BALANCE + WITHDRAWABLE;
         const BALANCE_WITHOUT_PENDING_REWARDS: u64 = RENT_EXEMPT_MINIMUM + WITHDRAWABLE;
 
-        // Without pending rewards, everything in excess of the rent-exempt
-        // minimum is withdrawable.
-        assert_eq!(
-            resolve_rent_exempt_spend(
-                vote_account(BALANCE_WITHOUT_PENDING_REWARDS, 0),
-                RENT_EXEMPT_MINIMUM,
-            )
-            .await,
-            WITHDRAWABLE
-        );
+        for amount in [SpendAmount::RentExempt, SpendAmount::Available] {
+            // Without pending rewards, everything in excess of the rent-exempt
+            // minimum is withdrawable.
+            assert_eq!(
+                resolve_vote_withdrawal(
+                    vote_account(BALANCE_WITHOUT_PENDING_REWARDS, 0),
+                    RENT_EXEMPT_MINIMUM,
+                    amount,
+                )
+                .await,
+                WITHDRAWABLE
+            );
 
-        // Pending delegator rewards are reserved as well, matching the balance
-        // the vote program requires the account to retain.
-        assert_eq!(
-            resolve_rent_exempt_spend(
-                vote_account(BALANCE, PENDING_DELEGATOR_REWARDS),
-                RENT_EXEMPT_MINIMUM,
-            )
-            .await,
-            WITHDRAWABLE
-        );
+            // Pending delegator rewards are reserved as well, matching the balance
+            // the vote program requires the account to retain.
+            assert_eq!(
+                resolve_vote_withdrawal(
+                    vote_account(BALANCE, PENDING_DELEGATOR_REWARDS),
+                    RENT_EXEMPT_MINIMUM,
+                    amount,
+                )
+                .await,
+                WITHDRAWABLE
+            );
 
-        // Nothing is withdrawable when the balance only covers the reserves.
-        assert_eq!(
-            resolve_rent_exempt_spend(
-                vote_account(RESERVED_BALANCE, PENDING_DELEGATOR_REWARDS),
-                RENT_EXEMPT_MINIMUM,
-            )
-            .await,
-            0
-        );
+            // Nothing is withdrawable when the balance only covers the reserves.
+            assert_eq!(
+                resolve_vote_withdrawal(
+                    vote_account(RESERVED_BALANCE, PENDING_DELEGATOR_REWARDS),
+                    RENT_EXEMPT_MINIMUM,
+                    amount,
+                )
+                .await,
+                0
+            );
+        }
     }
 }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -472,13 +472,10 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("AMOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_amount_or_all_or_available)
+                        .validator(is_amount_or_all)
                         .help(
-                            "The amount to withdraw, in SOL; accepts keywords ALL and AVAILABLE, \
-                             which for this command both mean the account balance minus the \
-                             amount the vote program requires the account to retain: the \
-                             rent-exempt minimum, plus any rewards pending distribution to \
-                             delegators",
+                            "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
+                             command means account balance minus rent-exempt minimum",
                         ),
                 )
                 .arg(
@@ -831,8 +828,8 @@ pub fn parse_withdraw_from_vote_account(
         pubkey_of_signer(matches, "destination_account_pubkey", wallet_manager)?.unwrap();
     let mut withdraw_amount = SpendAmount::new_from_matches(matches, "amount")?;
     // As a safeguard for vote accounts for running validators, `ALL` withdraws only the amount in
-    // excess of the rent-exempt minimum, the same as `AVAILABLE`. In order to close the account
-    // with this subcommand, a validator must specify the withdrawal amount precisely.
+    // excess of the rent-exempt minimum. In order to close the account with this subcommand, a
+    // validator must specify the withdrawal amount precisely.
     if withdraw_amount == SpendAmount::All {
         withdraw_amount = SpendAmount::RentExempt;
     }
@@ -2814,35 +2811,6 @@ mod tests {
                     destination_account_pubkey: pubkey,
                     withdraw_authority: 0,
                     withdraw_amount: SpendAmount::RentExempt,
-                    sign_only: false,
-                    dump_transaction_message: false,
-                    blockhash_query: BlockhashQuery::Rpc(Source::Cluster),
-                    nonce_account: None,
-                    nonce_authority: 0,
-                    memo: None,
-                    fee_payer: 0,
-                    compute_unit_price: None,
-                },
-                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
-            }
-        );
-
-        // Test WithdrawFromVoteAccount subcommand w/ AVAILABLE amount
-        let test_withdraw_from_vote_account = test_commands.clone().get_matches_from(vec![
-            "test",
-            "withdraw-from-vote-account",
-            &keypair_file,
-            &pubkey_string,
-            "AVAILABLE",
-        ]);
-        assert_eq!(
-            parse_command(&test_withdraw_from_vote_account, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::WithdrawFromVoteAccount {
-                    vote_account_pubkey: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    destination_account_pubkey: pubkey,
-                    withdraw_authority: 0,
-                    withdraw_amount: SpendAmount::Available,
                     sign_only: false,
                     dump_transaction_message: false,
                     blockhash_query: BlockhashQuery::Rpc(Source::Cluster),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -475,7 +475,8 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_amount_or_all)
                         .help(
                             "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
-                             command means account balance minus rent-exempt minimum",
+                             command means account balance minus rent-exempt minimum and any \
+                             rewards pending distribution to delegators",
                         ),
                 )
                 .arg(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -472,10 +472,13 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("AMOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_amount_or_all)
+                        .validator(is_amount_or_all_or_available)
                         .help(
-                            "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
-                             command means account balance minus rent-exempt minimum",
+                            "The amount to withdraw, in SOL; accepts keywords ALL and AVAILABLE, \
+                             which for this command both mean the account balance minus the \
+                             amount the vote program requires the account to retain: the \
+                             rent-exempt minimum, plus any rewards pending distribution to \
+                             delegators",
                         ),
                 )
                 .arg(
@@ -828,8 +831,8 @@ pub fn parse_withdraw_from_vote_account(
         pubkey_of_signer(matches, "destination_account_pubkey", wallet_manager)?.unwrap();
     let mut withdraw_amount = SpendAmount::new_from_matches(matches, "amount")?;
     // As a safeguard for vote accounts for running validators, `ALL` withdraws only the amount in
-    // excess of the rent-exempt minimum. In order to close the account with this subcommand, a
-    // validator must specify the withdrawal amount precisely.
+    // excess of the rent-exempt minimum, the same as `AVAILABLE`. In order to close the account
+    // with this subcommand, a validator must specify the withdrawal amount precisely.
     if withdraw_amount == SpendAmount::All {
         withdraw_amount = SpendAmount::RentExempt;
     }
@@ -2811,6 +2814,35 @@ mod tests {
                     destination_account_pubkey: pubkey,
                     withdraw_authority: 0,
                     withdraw_amount: SpendAmount::RentExempt,
+                    sign_only: false,
+                    dump_transaction_message: false,
+                    blockhash_query: BlockhashQuery::Rpc(Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    memo: None,
+                    fee_payer: 0,
+                    compute_unit_price: None,
+                },
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
+            }
+        );
+
+        // Test WithdrawFromVoteAccount subcommand w/ AVAILABLE amount
+        let test_withdraw_from_vote_account = test_commands.clone().get_matches_from(vec![
+            "test",
+            "withdraw-from-vote-account",
+            &keypair_file,
+            &pubkey_string,
+            "AVAILABLE",
+        ]);
+        assert_eq!(
+            parse_command(&test_withdraw_from_vote_account, &default_signer, &mut None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::WithdrawFromVoteAccount {
+                    vote_account_pubkey: read_keypair_file(&keypair_file).unwrap().pubkey(),
+                    destination_account_pubkey: pubkey,
+                    withdraw_authority: 0,
+                    withdraw_amount: SpendAmount::Available,
                     sign_only: false,
                     dump_transaction_message: false,
                     blockhash_query: BlockhashQuery::Rpc(Source::Cluster),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1590,7 +1590,9 @@ fn deserialize_vote_state(
     vote_account_pubkey: &Pubkey,
 ) -> Result<VoteStateV4, CliError> {
     VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey).map_err(|_| {
-        CliError::RpcRequestError("Account data could not be deserialized to vote state".to_string())
+        CliError::RpcRequestError(
+            "Account data could not be deserialized to vote state".to_string(),
+        )
     })
 }
 
@@ -1807,9 +1809,7 @@ pub async fn process_withdraw_from_vote_account(
     )
     .await?;
 
-    if !sign_only
-        && let SpendAmount::Some(withdraw_amount) = withdraw_amount
-    {
+    if !sign_only && let SpendAmount::Some(withdraw_amount) = withdraw_amount {
         let (vote_account, vote_state) =
             get_vote_account(rpc_client, vote_account_pubkey, config.commitment).await?;
         let rent_exempt_minimum = rpc_client
@@ -3027,44 +3027,41 @@ mod tests {
 
     #[test]
     fn test_check_remaining_balance() {
-        let rent_exempt_minimum = 26_858_640;
-        let pending_delegator_rewards = 5_000_000;
-        let balance = rent_exempt_minimum + pending_delegator_rewards + 1_000_000;
+        const RENT_EXEMPT_MINIMUM: u64 = 27_000_000;
+        const PENDING_DELEGATOR_REWARDS: u64 = 5_000_000;
+        const BALANCE: u64 = 33_000_000;
+        // Largest withdrawal leaving the rent-exempt minimum behind, and the
+        // largest also leaving the pending delegator rewards behind.
+        const MAX_WITHDRAWAL: u64 = BALANCE - RENT_EXEMPT_MINIMUM;
+        const MAX_WITHDRAWAL_WITH_PENDING_REWARDS: u64 = MAX_WITHDRAWAL - PENDING_DELEGATOR_REWARDS;
 
         // Without pending rewards, only the rent-exempt minimum must remain.
-        check_remaining_balance(balance, balance - rent_exempt_minimum, rent_exempt_minimum, 0)
-            .unwrap();
-        check_remaining_balance(
-            balance,
-            balance - rent_exempt_minimum + 1,
-            rent_exempt_minimum,
-            0,
-        )
-        .unwrap_err();
+        check_remaining_balance(BALANCE, MAX_WITHDRAWAL, RENT_EXEMPT_MINIMUM, 0).unwrap();
+        check_remaining_balance(BALANCE, MAX_WITHDRAWAL + 1, RENT_EXEMPT_MINIMUM, 0).unwrap_err();
 
         // Pending rewards must remain in the account too.
         check_remaining_balance(
-            balance,
-            balance - rent_exempt_minimum - pending_delegator_rewards,
-            rent_exempt_minimum,
-            pending_delegator_rewards,
+            BALANCE,
+            MAX_WITHDRAWAL_WITH_PENDING_REWARDS,
+            RENT_EXEMPT_MINIMUM,
+            PENDING_DELEGATOR_REWARDS,
         )
         .unwrap();
         check_remaining_balance(
-            balance,
-            balance - rent_exempt_minimum - pending_delegator_rewards + 1,
-            rent_exempt_minimum,
-            pending_delegator_rewards,
+            BALANCE,
+            MAX_WITHDRAWAL_WITH_PENDING_REWARDS + 1,
+            RENT_EXEMPT_MINIMUM,
+            PENDING_DELEGATOR_REWARDS,
         )
         .unwrap_err();
 
         // The account may only be closed once no rewards are pending.
-        check_remaining_balance(balance, balance, rent_exempt_minimum, 0).unwrap();
+        check_remaining_balance(BALANCE, BALANCE, RENT_EXEMPT_MINIMUM, 0).unwrap();
         check_remaining_balance(
-            balance,
-            balance,
-            rent_exempt_minimum,
-            pending_delegator_rewards,
+            BALANCE,
+            BALANCE,
+            RENT_EXEMPT_MINIMUM,
+            PENDING_DELEGATOR_REWARDS,
         )
         .unwrap_err();
     }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1580,14 +1580,29 @@ pub(crate) async fn get_vote_account(
         ))
         .into());
     }
-    let vote_state =
-        VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey).map_err(|_| {
-            CliError::RpcRequestError(
-                "Account data could not be deserialized to vote state".to_string(),
-            )
-        })?;
+    let vote_state = deserialize_vote_state(&vote_account, vote_account_pubkey)?;
 
     Ok((vote_account, vote_state))
+}
+
+fn deserialize_vote_state(
+    vote_account: &Account,
+    vote_account_pubkey: &Pubkey,
+) -> Result<VoteStateV4, CliError> {
+    VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey).map_err(|_| {
+        CliError::RpcRequestError("Account data could not be deserialized to vote state".to_string())
+    })
+}
+
+/// Rewards held by the vote account for distribution to its stake delegators.
+///
+/// The vote program reserves these lamports on top of the rent-exempt minimum,
+/// so they are not withdrawable.
+pub(crate) fn get_pending_delegator_rewards(
+    vote_account: &Account,
+    vote_account_pubkey: &Pubkey,
+) -> Result<u64, CliError> {
+    Ok(deserialize_vote_state(vote_account, vote_account_pubkey)?.pending_delegator_rewards)
 }
 
 pub async fn process_show_vote_account(
@@ -1680,6 +1695,51 @@ pub async fn process_show_vote_account(
     Ok(config.output_format.formatted_string(&vote_account_data))
 }
 
+/// Mirrors the balance constraints enforced by the vote program's `Withdraw`
+/// instruction: the balance left in the vote account must either be zero with no
+/// rewards pending distribution to delegators, or cover both the rent-exempt
+/// minimum and those pending rewards.
+fn check_remaining_balance(
+    current_balance: u64,
+    withdraw_amount: u64,
+    rent_exempt_minimum: u64,
+    pending_delegator_rewards: u64,
+) -> Result<(), CliError> {
+    let balance_remaining = current_balance.saturating_sub(withdraw_amount);
+    if balance_remaining == 0 {
+        if pending_delegator_rewards > 0 {
+            return Err(CliError::BadParameter(format!(
+                "Withdraw amount too large. The vote account cannot be closed while {} SOL of \
+                 rewards are pending distribution to delegators",
+                build_balance_message(pending_delegator_rewards, false, false)
+            )));
+        }
+        return Ok(());
+    }
+
+    let minimum_balance = rent_exempt_minimum.saturating_add(pending_delegator_rewards);
+    if balance_remaining < minimum_balance {
+        let requirement = if pending_delegator_rewards > 0 {
+            format!(
+                "{} SOL to remain rent exempt, plus {} SOL of rewards pending distribution to \
+                 delegators",
+                build_balance_message(rent_exempt_minimum, false, false),
+                build_balance_message(pending_delegator_rewards, false, false)
+            )
+        } else {
+            format!(
+                "{} SOL to remain rent exempt",
+                build_balance_message(rent_exempt_minimum, false, false)
+            )
+        };
+        return Err(CliError::BadParameter(format!(
+            "Withdraw amount too large. The vote account balance must be at least {requirement}"
+        )));
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn process_withdraw_from_vote_account(
     rpc_client: &RpcClient,
@@ -1747,22 +1807,20 @@ pub async fn process_withdraw_from_vote_account(
     )
     .await?;
 
-    if !sign_only {
-        let current_balance = rpc_client.get_balance(vote_account_pubkey).await?;
-        let minimum_balance = rpc_client
-            .get_minimum_balance_for_rent_exemption(VoteStateV4::size_of())
+    if !sign_only
+        && let SpendAmount::Some(withdraw_amount) = withdraw_amount
+    {
+        let (vote_account, vote_state) =
+            get_vote_account(rpc_client, vote_account_pubkey, config.commitment).await?;
+        let rent_exempt_minimum = rpc_client
+            .get_minimum_balance_for_rent_exemption(vote_account.data.len())
             .await?;
-        if let SpendAmount::Some(withdraw_amount) = withdraw_amount {
-            let balance_remaining = current_balance.saturating_sub(withdraw_amount);
-            if balance_remaining < minimum_balance && balance_remaining != 0 {
-                return Err(CliError::BadParameter(format!(
-                    "Withdraw amount too large. The vote account balance must be at least {} SOL \
-                     to remain rent exempt",
-                    build_balance_message(minimum_balance, false, false)
-                ))
-                .into());
-            }
-        }
+        check_remaining_balance(
+            vote_account.lamports,
+            withdraw_amount,
+            rent_exempt_minimum,
+            vote_state.pending_delegator_rewards,
+        )?;
     }
 
     let mut tx = Transaction::new_unsigned(message);
@@ -2965,5 +3023,49 @@ mod tests {
                 ],
             }
         );
+    }
+
+    #[test]
+    fn test_check_remaining_balance() {
+        let rent_exempt_minimum = 26_858_640;
+        let pending_delegator_rewards = 5_000_000;
+        let balance = rent_exempt_minimum + pending_delegator_rewards + 1_000_000;
+
+        // Without pending rewards, only the rent-exempt minimum must remain.
+        check_remaining_balance(balance, balance - rent_exempt_minimum, rent_exempt_minimum, 0)
+            .unwrap();
+        check_remaining_balance(
+            balance,
+            balance - rent_exempt_minimum + 1,
+            rent_exempt_minimum,
+            0,
+        )
+        .unwrap_err();
+
+        // Pending rewards must remain in the account too.
+        check_remaining_balance(
+            balance,
+            balance - rent_exempt_minimum - pending_delegator_rewards,
+            rent_exempt_minimum,
+            pending_delegator_rewards,
+        )
+        .unwrap();
+        check_remaining_balance(
+            balance,
+            balance - rent_exempt_minimum - pending_delegator_rewards + 1,
+            rent_exempt_minimum,
+            pending_delegator_rewards,
+        )
+        .unwrap_err();
+
+        // The account may only be closed once no rewards are pending.
+        check_remaining_balance(balance, balance, rent_exempt_minimum, 0).unwrap();
+        check_remaining_balance(
+            balance,
+            balance,
+            rent_exempt_minimum,
+            pending_delegator_rewards,
+        )
+        .unwrap_err();
     }
 }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1585,17 +1585,6 @@ pub(crate) async fn get_vote_account(
     Ok((vote_account, vote_state))
 }
 
-fn deserialize_vote_state(
-    vote_account: &Account,
-    vote_account_pubkey: &Pubkey,
-) -> Result<VoteStateV4, CliError> {
-    VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey).map_err(|_| {
-        CliError::RpcRequestError(
-            "Account data could not be deserialized to vote state".to_string(),
-        )
-    })
-}
-
 /// Rewards held by the vote account for distribution to its stake delegators.
 ///
 /// The vote program reserves these lamports on top of the rent-exempt minimum,
@@ -1695,51 +1684,6 @@ pub async fn process_show_vote_account(
     };
 
     Ok(config.output_format.formatted_string(&vote_account_data))
-}
-
-/// Mirrors the balance constraints enforced by the vote program's `Withdraw`
-/// instruction: the balance left in the vote account must either be zero with no
-/// rewards pending distribution to delegators, or cover both the rent-exempt
-/// minimum and those pending rewards.
-fn check_remaining_balance(
-    current_balance: u64,
-    withdraw_amount: u64,
-    rent_exempt_minimum: u64,
-    pending_delegator_rewards: u64,
-) -> Result<(), CliError> {
-    let balance_remaining = current_balance.saturating_sub(withdraw_amount);
-    if balance_remaining == 0 {
-        if pending_delegator_rewards > 0 {
-            return Err(CliError::BadParameter(format!(
-                "Withdraw amount too large. The vote account cannot be closed while {} SOL of \
-                 rewards are pending distribution to delegators",
-                build_balance_message(pending_delegator_rewards, false, false)
-            )));
-        }
-        return Ok(());
-    }
-
-    let minimum_balance = rent_exempt_minimum.saturating_add(pending_delegator_rewards);
-    if balance_remaining < minimum_balance {
-        let requirement = if pending_delegator_rewards > 0 {
-            format!(
-                "{} SOL to remain rent exempt, plus {} SOL of rewards pending distribution to \
-                 delegators",
-                build_balance_message(rent_exempt_minimum, false, false),
-                build_balance_message(pending_delegator_rewards, false, false)
-            )
-        } else {
-            format!(
-                "{} SOL to remain rent exempt",
-                build_balance_message(rent_exempt_minimum, false, false)
-            )
-        };
-        return Err(CliError::BadParameter(format!(
-            "Withdraw amount too large. The vote account balance must be at least {requirement}"
-        )));
-    }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1932,6 +1876,62 @@ pub async fn process_close_vote_account(
         )
         .await;
     log_instruction_custom_error::<VoteError>(result, config)
+}
+
+fn deserialize_vote_state(
+    vote_account: &Account,
+    vote_account_pubkey: &Pubkey,
+) -> Result<VoteStateV4, CliError> {
+    VoteStateV4::deserialize(&vote_account.data, vote_account_pubkey).map_err(|_| {
+        CliError::RpcRequestError(
+            "Account data could not be deserialized to vote state".to_string(),
+        )
+    })
+}
+
+/// Mirrors the balance constraints enforced by the vote program's `Withdraw`
+/// instruction: the balance left in the vote account must either be zero with no
+/// rewards pending distribution to delegators, or cover both the rent-exempt
+/// minimum and those pending rewards.
+fn check_remaining_balance(
+    current_balance: u64,
+    withdraw_amount: u64,
+    rent_exempt_minimum: u64,
+    pending_delegator_rewards: u64,
+) -> Result<(), CliError> {
+    let balance_remaining = current_balance.saturating_sub(withdraw_amount);
+    if balance_remaining == 0 {
+        if pending_delegator_rewards > 0 {
+            return Err(CliError::BadParameter(format!(
+                "Withdraw amount too large. The vote account cannot be closed while {} SOL of \
+                 rewards are pending distribution to delegators",
+                build_balance_message(pending_delegator_rewards, false, false)
+            )));
+        }
+        return Ok(());
+    }
+
+    let minimum_balance = rent_exempt_minimum.saturating_add(pending_delegator_rewards);
+    if balance_remaining < minimum_balance {
+        let requirement = if pending_delegator_rewards > 0 {
+            format!(
+                "{} SOL to remain rent exempt, plus {} SOL of rewards pending distribution to \
+                 delegators",
+                build_balance_message(rent_exempt_minimum, false, false),
+                build_balance_message(pending_delegator_rewards, false, false)
+            )
+        } else {
+            format!(
+                "{} SOL to remain rent exempt",
+                build_balance_message(rent_exempt_minimum, false, false)
+            )
+        };
+        return Err(CliError::BadParameter(format!(
+            "Withdraw amount too large. The vote account balance must be at least {requirement}"
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #14931.

`withdraw-from-vote-account ... ALL` maps to `SpendAmount::RentExempt`, which only reserved the rent-exempt minimum. The vote program also requires the account to retain `pending_delegator_rewards`, so the withdrawal failed with `InsufficientFunds` whenever rewards were pending distribution.

This PR reserves those rewards too, reading them from the vote-account snapshot that `resolve_spend_tx_and_check_account_balances` already fetches for the balance and rent-exempt minimum. The explicit-amount remaining-balance check now matches the program: zero remaining is only allowed when no rewards are pending; otherwise the remainder must cover rent plus pending rewards.

`RentExempt` is only used by vote-account withdrawal, so no other command changes behavior.

## Test plan
- `cargo test -p solana-cli --lib` (covers `test_rent_exempt_spend_reserves_pending_delegator_rewards` and `test_check_remaining_balance`)
- `cargo clippy -p solana-cli --all-targets -- --deny=warnings`
- `withdraw-from-vote-account ... ALL` with a separate fee payer should succeed when pending delegator rewards are positive, leaving `rent + pending_delegator_rewards`