### PR TITLE
Various perf improvements to bls-sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9008,6 +9008,7 @@ dependencies = [
  "serial_test",
  "solana-account 4.6.0",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-client-traits",
  "solana-clock",
  "solana-cluster-type",

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -548,7 +548,9 @@ mod tests {
         bitvec::prelude::{BitVec, Lsb0},
         bytes::Bytes,
         crossbeam_channel::{Receiver, TryRecvError, bounded},
-        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature},
+        solana_bls_signatures::{
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature, signature::SignatureAffine,
+        },
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
@@ -719,7 +721,7 @@ mod tests {
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
         let payload = get_vote_payload_to_sign(vote, shred_version);
-        let signature: Signature = bls_keypair.sign(&payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
         VoteMessage {
             vote,
             signature,
@@ -958,10 +960,13 @@ mod tests {
         expect_no_receive(&ctx.pool_receiver);
 
         // Send a packet with invalid rank
+        let vote = Vote::new_finalization_vote(5);
+        let payload = get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
+        let signature = SignatureAffine::from(ctx.validator_keypairs[0].bls_keypair.sign(&payload));
         let messages_invalid_rank = [(
             ConsensusMessage::Vote(VoteMessage {
                 vote: Vote::new_finalization_vote(5),
-                signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                signature,
                 rank: 1000, // Invalid rank
                 stake: NonZero::new(123).unwrap(),
             }),
@@ -1109,7 +1114,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature: Signature = bls_keypair.sign(&vote_payload).into();
+            let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1253,9 +1258,9 @@ mod tests {
             };
 
             let signature = if rank == invalid_rank {
-                bls_keypair.sign(&invalid_payload).into() // Invalid signature
+                SignatureAffine::from(bls_keypair.sign(&invalid_payload)) // Invalid signature
             } else {
-                bls_keypair.sign(payload).into()
+                SignatureAffine::from(bls_keypair.sign(payload))
             };
 
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
@@ -1316,9 +1321,9 @@ mod tests {
             let bls_keypair = &validator_keypair.bls_keypair;
 
             let signature = if rank == invalid_rank {
-                bls_keypair.sign(&invalid_vote_payload).into() // Invalid signature
+                SignatureAffine::from(bls_keypair.sign(&invalid_vote_payload)) // Invalid signature
             } else {
-                bls_keypair.sign(&valid_vote_payload).into() // Valid signature
+                SignatureAffine::from(bls_keypair.sign(&valid_vote_payload)) // Valid signature
             };
 
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
@@ -1521,7 +1526,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature = bls_keypair.sign(&vote_payload).into();
+            let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1591,7 +1596,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
-        let signature: Signature = bls_keypair.sign(&vote_payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
 
         let consensus_message = ConsensusMessage::Vote(VoteMessage {
             vote,
@@ -1671,7 +1676,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, sig_verifier.cluster_info.my_shred_version());
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
-        let signature: Signature = bls_keypair.sign(&vote_payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
             vote,
             signature,
@@ -1915,9 +1920,9 @@ mod tests {
             .take(5)
             .map(|(i, keypair)| {
                 let signature = if invalid_indexes.contains(&i) {
-                    keypair.bls_keypair.sign(&invalid_payload).into()
+                    SignatureAffine::from(keypair.bls_keypair.sign(&invalid_payload))
                 } else {
-                    keypair.bls_keypair.sign(&valid_payload).into()
+                    SignatureAffine::from(keypair.bls_keypair.sign(&valid_payload))
                 };
                 let message = ConsensusMessage::Vote(VoteMessage {
                     vote,

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -30,6 +30,7 @@ use {
     solana_bls_signatures::{
         BlsError, PreparedHashedMessage, PubkeyProjective, SignatureProjective,
         pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature},
+        signature::SignatureAffine,
     },
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
@@ -99,11 +100,12 @@ impl UnverifiedVotePayload {
         max_validators: usize,
         prepared_hashed_message: &PreparedHashedMessage,
     ) -> Result<VerifiedVotePayload, BlsError> {
+        let signature = SignatureAffine::try_from(self.vote_message.signature)?;
         self.sender_bls_pubkey
-            .verify_signature_prepared(&self.vote_message.signature, prepared_hashed_message)?;
+            .verify_signature_prepared(&signature, prepared_hashed_message)?;
         let vote_msg = VoteMessage {
             vote: self.vote_message.vote,
-            signature: self.vote_message.signature,
+            signature,
             rank: self.rank,
             stake: self.stake,
         };
@@ -337,6 +339,31 @@ fn verify_votes(
     thread_pool: &ThreadPool,
 ) -> (Vec<VerifiedVotePayload>, VoteVerificationStats) {
     let mut stats = VoteVerificationStats::default();
+
+    // no need to do optimistic verification when batch size == 1.
+    if let [unverified_vote] = unverified_votes.as_slice() {
+        let ((verification_result, sender_identity_pubkey), time_us) = measure_us!({
+            let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
+            let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
+            let sender_identity_pubkey = unverified_vote.sender_identity_pubkey;
+            (
+                unverified_vote.verify(max_validators, &prepared_hash_msg),
+                sender_identity_pubkey,
+            )
+        });
+        stats.fn_verify_individual_votes_stats.add_sample(time_us);
+        return match verification_result {
+            Ok(verified_vote) => {
+                stats.num_individual_verified += 1;
+                (vec![verified_vote], stats)
+            }
+            Err(error) => {
+                ban_invalid_vote_sender(ban_sender, &mut stats, sender_identity_pubkey, error);
+                (Vec::new(), stats)
+            }
+        };
+    }
+
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
     let res = verify_votes_optimistic(
         vote_payload_to_sign,
@@ -381,17 +408,26 @@ fn verify_votes(
                 ));
             stats.num_individual_verified += verified_votes.len() as u64;
             for (sender_identity_pubkey, error) in invalid_remote_pubkeys {
-                stats.banning_validator += 1;
-                ban_sender.ban(sender_identity_pubkey, BAN_TIMEOUT);
-                info!(
-                    "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed \
-                     verification {error:?}"
-                );
+                ban_invalid_vote_sender(ban_sender, &mut stats, sender_identity_pubkey, error);
             }
             stats.fn_verify_individual_votes_stats.add_sample(time_us);
             (verified_votes, stats)
         }
     }
+}
+
+fn ban_invalid_vote_sender(
+    ban_sender: &BanSender,
+    stats: &mut VoteVerificationStats,
+    sender_identity_pubkey: Pubkey,
+    error: BlsError,
+) {
+    stats.banning_validator += 1;
+    ban_sender.ban(sender_identity_pubkey, BAN_TIMEOUT);
+    info!(
+        "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed verification \
+         {error:?}"
+    );
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -40,6 +40,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 solana-account = { workspace = true, features = ["wincode"] }
 solana-accounts-db = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -17,6 +17,7 @@ use {
     crossbeam_channel::{Receiver, bounded},
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
+    solana_bls_signatures::signature::SignatureAffine,
     solana_clock::{self as clock, Slot},
     solana_commitment_config::CommitmentConfig,
     solana_core::consensus::tower_storage::{
@@ -686,9 +687,10 @@ fn convert_datagram_to_vote_message(
     let bank = bank_forks.read().unwrap().root_bank();
     let rank_map = bank.get_rank_map(vote_msg.vote.slot())?;
     let (rank, sender_entry) = rank_map.get_ranked_entry_for_node(&sender)?;
+    let signature = SignatureAffine::try_from(vote_msg.signature).ok()?;
     Some(VoteMessage {
         vote: vote_msg.vote,
-        signature: vote_msg.signature,
+        signature,
         rank,
         stake: sender_entry.stake,
     })

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -422,6 +422,6 @@ impl ThreadArg for TvuBlsShredSigverifyThreadsArg {
                                 verification of received Alpenglow consensus messages";
 
     fn default() -> usize {
-        get_thread_count()
+        num_cpus::get() * 3 / 4
     }
 }

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -5,7 +5,7 @@ use {
         vote::Vote,
     },
     serde::{Deserialize, Serialize},
-    solana_bls_signatures::Signature as BLSSignature,
+    solana_bls_signatures::{Signature as BLSSignature, signature::SignatureAffine},
     solana_clock::Slot,
     solana_hash::Hash,
     std::num::NonZero,
@@ -65,12 +65,12 @@ impl Block {
 }
 
 /// A consensus vote.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
     /// The signature.
-    pub signature: BLSSignature,
+    pub signature: SignatureAffine,
     /// The rank of the validator.
     pub rank: u16,
     /// The stake of the validator
@@ -78,7 +78,7 @@ pub struct VoteMessage {
 }
 
 /// A consensus message sent between validators.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
     /// A vote from a single party.
@@ -89,7 +89,12 @@ pub enum ConsensusMessage {
 
 impl ConsensusMessage {
     /// Create a new vote message
-    pub fn new_vote(vote: Vote, signature: BLSSignature, rank: u16, stake: NonZero<u64>) -> Self {
+    pub fn new_vote(
+        vote: Vote,
+        signature: SignatureAffine,
+        rank: u16,
+        stake: NonZero<u64>,
+    ) -> Self {
         Self::Vote(VoteMessage {
             vote,
             signature,

--- a/votor-messages/src/sig_verified_messages.rs
+++ b/votor-messages/src/sig_verified_messages.rs
@@ -6,7 +6,7 @@ use {
         wire::VotePayloadToSign,
     },
     bitvec::vec::BitVec,
-    solana_bls_signatures::{Signature as BLSSignature, SignatureProjective},
+    solana_bls_signatures::{SignatureProjective, signature::SignatureAffine},
     std::num::NonZero,
 };
 
@@ -42,12 +42,12 @@ impl SigVerifiedBatch {
 ///
 /// NOTE: the fields should not be exposed outside of the crate so that users use approved paths to
 /// build it to ensure signature verification takes place.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VoteAggregate {
     /// The type of vote in the batch.
     vote: Vote,
     /// The aggregate signature of the votes in the batch.
-    signature: BLSSignature,
+    signature: SignatureAffine,
     /// The total stake in the batch.
     stake: NonZero<u64>,
     /// Ranks of the various validators whose votes are in the batch.
@@ -114,7 +114,7 @@ impl VoteAggregate {
     }
 
     /// Accessor for the signature.
-    pub fn signature(&self) -> &BLSSignature {
+    pub fn signature(&self) -> &SignatureAffine {
         &self.signature
     }
 

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -85,9 +85,8 @@ pub(crate) struct WireVoteSignature {
 
 impl From<VoteMessage> for WireVoteSignature {
     fn from(msg: VoteMessage) -> Self {
-        Self {
-            signature: msg.signature,
-        }
+        let signature = BLSSignature::from(msg.signature);
+        Self { signature }
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -584,7 +584,7 @@ mod tests {
         bitvec::vec::BitVec,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature, VerifiableSignature,
-            keypair::Keypair as BLSKeypair,
+            keypair::Keypair as BLSKeypair, signature::SignatureAffine,
         },
         solana_clock::Slot,
         solana_hash::Hash,
@@ -746,7 +746,7 @@ mod tests {
                 .unwrap()
                 .stake;
             let payload = get_vote_payload_to_sign(vote, self.pool.cluster_info.my_shred_version());
-            let signature: BLSSignature = bls_keypair.sign(&payload).into();
+            let signature = SignatureAffine::from(bls_keypair.sign(&payload));
             VoteMessage {
                 vote,
                 signature,
@@ -804,7 +804,7 @@ mod tests {
             .unwrap()
             .stake;
         let payload = get_vote_payload_to_sign(*vote, shred_version);
-        let signature: BLSSignature = bls_keypair.sign(&payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
         let msg = VoteMessage {
             vote: *vote,
             signature,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1055,9 +1055,7 @@ mod tests {
         },
         crossbeam_channel::{Receiver, Sender, TryRecvError, bounded},
         parking_lot::RwLock as PlRwLock,
-        solana_bls_signatures::{
-            keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
-        },
+        solana_bls_signatures::{keypair::Keypair as BLSKeypair, signature::SignatureAffine},
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_ledger::{
@@ -1511,7 +1509,7 @@ mod tests {
         fn expected_vote_message(&self, expected_vote: &Vote) -> VoteMessage {
             let payload =
                 get_vote_payload_to_sign(*expected_vote, self.cluster_info.my_shred_version());
-            let signature: BLSSignature = self.my_bls_keypair.sign(&payload).into();
+            let signature = SignatureAffine::from(self.my_bls_keypair.sign(&payload));
             let root_bank = self.bank_forks.read().unwrap().root_bank();
             let rank_map = root_bank.get_rank_map(expected_vote.slot()).unwrap();
             let stake = rank_map.get_pubkey_stake_entry(0).unwrap().stake;

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -368,6 +368,7 @@ mod tests {
             consensus_message::{ConsensusMessage, VoteMessage},
             migration::MigrationStatus,
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
         agave_votor_transport::{
             PeerList, PeerListReceiver, PeerListSender,
@@ -377,7 +378,10 @@ mod tests {
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded, unbounded},
         rand::Rng,
-        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_bls_signatures::{
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BlsKeypair, Signature as BLSSignature,
+            signature::SignatureAffine,
+        },
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
@@ -411,14 +415,21 @@ mod tests {
         shred_verion: u16,
     ) -> VersionedWireConsensusMessage {
         VersionedWireConsensusMessage::new_from_vote(
-            VoteMessage {
-                vote,
-                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-                rank,
-                stake: NonZero::new(123).unwrap(),
-            },
+            test_vote(vote, rank, shred_verion),
             shred_verion,
         )
+    }
+
+    fn test_vote(vote: Vote, rank: u16, shred_version: u16) -> VoteMessage {
+        let bls_keypair = BlsKeypair::new();
+        let payload = get_vote_payload_to_sign(vote, shred_version);
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
+        VoteMessage {
+            vote,
+            signature,
+            rank,
+            stake: NonZero::new(123).unwrap(),
+        }
     }
 
     fn test_certificate_message(
@@ -623,45 +634,29 @@ mod tests {
         )
     }
 
-    #[test_case(BLSOp::PushVote {
-        vote: Arc::new(VoteMessage {
-            vote: Vote::new_skip_vote(5),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            rank: 1,
-            stake:NonZero::new(123).unwrap()
-        }),
-    }, ConsensusMessage::Vote(VoteMessage {
-        vote: Vote::new_skip_vote(5),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-    }))]
+    #[test_case(BLSOp::PushVote { vote: Arc::new(test_vote(Vote::new_skip_vote(5), 1, 0)) }, None)]
     #[test_case(BLSOp::PushCertificates {
         certificates: vec![Arc::new(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
         })],
-    }, ConsensusMessage::Certificate(Certificate {
+    }, Some(ConsensusMessage::Certificate(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
-    }))]
+    })))]
     #[test_case(BLSOp::RefreshVotes {
-        votes: vec![Arc::new(VoteMessage {
-        vote: Vote::new_skip_vote(6),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-        })],
-    }, ConsensusMessage::Vote(VoteMessage {
-        vote: Vote::new_skip_vote(6),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-    }))]
-    fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {
+        votes: vec![Arc::new(test_vote(Vote::new_skip_vote(6), 1, 0))],
+    }, None)]
+    fn test_send_message(bls_op: BLSOp, expected_message: Option<ConsensusMessage>) {
         agave_logger::setup();
+
+        let expected_message = expected_message.unwrap_or_else(|| match &bls_op {
+            BLSOp::PushVote { vote } => ConsensusMessage::Vote((**vote).clone()),
+            BLSOp::RefreshVotes { votes } => ConsensusMessage::Vote((*votes[0]).clone()),
+            _ => panic!("expected message is required for certificate operations"),
+        });
 
         let listener_kp = Keypair::new();
         let listener_pubkey = listener_kp.pubkey();


### PR DESCRIPTION
#### Problem

We recently built a votes attack where we simulate 1990 validators sending 5 votes per slot each.  At 200ms slot times, this is roughly 50K votes per second.

When profiling the bls-sigvery under this load, we came up with some performance bottlenecks that this PR addresses.


#### Summary of Changes

- Initially, we were storing `BLSSignature` in `VoteAggregate` and `VoteMessage`.  The consensus pool was spending a lot of time converting this to a `SignatureAffine`.  bls-sigverify already computed the `SignatureAffine` so we changed `VoteAggregate` and `VoteMessage` to store `SignatureAffine` instead.
- We are seeing that a thread pool of 32 threads is essentially 100% busy doing bls-sigverify.  So we increased the thread pool size to 48.  They are still effectively 100% busy but this improved the performance significantly.
- Finally, under this load, we get a lot of vote batches of size 1 to sig-verify.  Trying to do optimistic verification on such batches is unnecessary and incurs additional rayon overhead.  So we special cased these batches to do individual verification instead.


### Testing
Did extensive performance testing on the invalidator cluster.  

## Before this change

<img width="454" height="488" alt="image" src="https://github.com/user-attachments/assets/7fe0e0cf-3adb-4186-9ac5-9666a765781c" />

We are dropping about 27k datagrams / s and sigverifying 20k votes per second. Noticeably downstream is struggling and causing backpressure to the sigverifier, causing slowdown as the verification threads are blocking sends.

Analysis of the downstream thread (consensus pool) sees that it's struggling with crypto operations pinned at 100%

<img width="635" height="658" alt="Screenshot from 2026-08-28 17-50-46" src="https://github.com/user-attachments/assets/0317e858-d7e0-4057-834a-134add89199c" />

These operations are for converting the `BLSSignature` into its affine representation `SignatureAffine` 

Additionally we see that the BLS sigverification threads have frequent dips in utlization due to the overhead of parallel verification of vote batches of size 1. Almost 99% of vote batches are of size 1
<img width="1311" height="214" alt="image" src="https://github.com/user-attachments/assets/ed877a8a-d5c7-45d8-b690-95ac7ea6e389" />

## After this change

<img width="407" height="571" alt="image" src="https://github.com/user-attachments/assets/ed960bee-0849-4a27-a024-8b3113baca37" />

We are able to verify ~40k votes per second and dropping only 10k votes per second at ingress

<img width="712" height="489" alt="image" src="https://github.com/user-attachments/assets/513edafb-7a6b-4b7d-b763-8e9c531c7d8d" />

`SignatureAffine` is already computed during signature verification, so we pass this to the consensus pool, the downstream thread now is at 6% CPU and the backpressure is eliminated.

Additionally with the singleton fast path, we see that the batch sizes queued to rayon are increased to an average of ~470 (previously the avg size was ~1). This shows almost perfect utilization of the sigverification threads, all 48 threads are near 100% doing BLS work

<img width="910" height="1233" alt="image" src="https://github.com/user-attachments/assets/9bb3f5ef-6258-41dc-8824-dd785cfe2e68" />


## Follow up work & Backport justification
The invalidator attack simulates a worst case scenario:
- 2000 validators
- Leader equivocates 4 versions in each slot
- Perfect distribution to make each version votable split amongst the stake
- Resulting in 5 votes per slot (4 blocks to vote on + 1 skip fallback vote)

Resulting in 50000 votes per second. Without equivocation we expect roughly 2 votes per slot (Notarize + Finalize or Skip) which corresponds to 20000 votes per second.

Backporting this change allows us to be comfortably within this range, and future master work will get us to 50k or higher. 