### PR TITLE
chore: Add solana-hash feature directly

### DIFF
--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -50,6 +50,7 @@ protobuf-src = { workspace = true }
 
 [dev-dependencies]
 enum-iterator = { workspace = true }
+solana-hash = { workspace = true, features = ["atomic"] }
 test-case = { workspace = true }
 
 [lints]


### PR DESCRIPTION
#### Problem
4be7622e recently started using code behind the "atomic" feature of solana-hash crate. The symbol was available due to feature unification and a different dependency of solana-storage-proto enabling that feature.

#### Summary of Changes
Transitive feature enablement is confusing so state the dep directly

#### Testing
CI