### PR TITLE
runtime: Account for pending delegator rewards during VAT filter for SIMD-0123

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2878,11 +2878,13 @@ impl Bank {
         }
 
         let my_balance = vote_account.lamports();
-        let minimum_vote_account_balance_for_vat = self.minimum_vote_account_balance_for_vat();
-        if vote_account.lamports() < minimum_vote_account_balance_for_vat {
+        let minimum_required_balance = self
+            .minimum_vote_account_balance_for_vat()
+            .saturating_add(vote_account.vote_state_view().pending_delegator_rewards());
+        if vote_account.lamports() < minimum_required_balance {
             return Err(VATHealthError::InsufficientFundsInVoteAccount(
                 my_balance,
-                minimum_vote_account_balance_for_vat,
+                minimum_required_balance,
             ));
         }
 

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -17,8 +17,8 @@ use {
 /// Creates a vote account
 /// `set_bls_pubkey`: controls whether the bls pubkey is None or Some
 #[cfg(feature = "dev-context-only-utils")]
-pub fn new_rand_vote_account<R: Rng, F>(
-    rng: &mut R,
+pub fn new_rand_vote_account<F>(
+    lamports: u64,
     node_pubkey: Option<Pubkey>,
     set_bls_pubkey: bool,
     pending_delegator_rewards_from_account_lamports: F,
@@ -27,7 +27,7 @@ where
     F: Fn(u64) -> u64,
 {
     let owner = solana_sdk_ids::vote::id();
-    let mut account = AccountSharedData::new(rng.random(), VoteStateV4::size_of(), &owner);
+    let mut account = AccountSharedData::new(lamports, VoteStateV4::size_of(), &owner);
 
     let bls_pubkey_compressed = set_bls_pubkey.then(|| {
         let bls_pubkey: BLSPubkeyCompressed = (*BLSKeypair::new().public).into();
@@ -62,7 +62,7 @@ pub fn new_rand_vote_accounts<R: Rng>(
     let nodes: Vec<_> = repeat_with(Pubkey::new_unique).take(num_nodes).collect();
     repeat_with(move || {
         let node = nodes[rng.random_range(0..nodes.len())];
-        let account = new_rand_vote_account(rng, Some(node), true, |_| 0);
+        let account = new_rand_vote_account(rng.random(), Some(node), true, |_| 0);
         let stake = rng.random_range(0..max_stake_for_staked_account);
         let vote_account = VoteAccount::try_from(account).unwrap();
         (Pubkey::new_unique(), (stake, vote_account))
@@ -99,13 +99,12 @@ where
         let set_bls_pubkey = index < num_nodes_with_bls_pubkeys;
         let pending_delegator_rewards_fn =
             pending_delegator_rewards_from_account_lamports_generator(index);
-        let mut account = new_rand_vote_account(
-            rng,
+        let account = new_rand_vote_account(
+            lamports_per_node(index),
             Some(node_pubkey),
             set_bls_pubkey,
             pending_delegator_rewards_fn,
         );
-        account.set_lamports(lamports_per_node(index));
         vote_accounts.insert(pubkey, VoteAccount::try_from(account).unwrap(), || stake);
     }
     vote_accounts

--- a/runtime/src/test_utils.rs
+++ b/runtime/src/test_utils.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use {
     rand::Rng,
-    solana_account::{AccountSharedData, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_bls_signatures::{
         keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
     },
@@ -17,11 +17,15 @@ use {
 /// Creates a vote account
 /// `set_bls_pubkey`: controls whether the bls pubkey is None or Some
 #[cfg(feature = "dev-context-only-utils")]
-pub fn new_rand_vote_account<R: Rng>(
+pub fn new_rand_vote_account<R: Rng, F>(
     rng: &mut R,
     node_pubkey: Option<Pubkey>,
     set_bls_pubkey: bool,
-) -> AccountSharedData {
+    pending_delegator_rewards_from_account_lamports: F,
+) -> AccountSharedData
+where
+    F: Fn(u64) -> u64,
+{
     let owner = solana_sdk_ids::vote::id();
     let mut account = AccountSharedData::new(rng.random(), VoteStateV4::size_of(), &owner);
 
@@ -35,6 +39,9 @@ pub fn new_rand_vote_account<R: Rng>(
         authorized_voters: AuthorizedVoters::new(0, Pubkey::new_unique()),
         authorized_withdrawer: Pubkey::new_unique(),
         bls_pubkey_compressed,
+        pending_delegator_rewards: pending_delegator_rewards_from_account_lamports(
+            account.lamports(),
+        ),
         ..VoteStateV4::default()
     };
 
@@ -55,7 +62,7 @@ pub fn new_rand_vote_accounts<R: Rng>(
     let nodes: Vec<_> = repeat_with(Pubkey::new_unique).take(num_nodes).collect();
     repeat_with(move || {
         let node = nodes[rng.random_range(0..nodes.len())];
-        let account = new_rand_vote_account(rng, Some(node), true);
+        let account = new_rand_vote_account(rng, Some(node), true, |_| 0);
         let stake = rng.random_range(0..max_stake_for_staked_account);
         let vote_account = VoteAccount::try_from(account).unwrap();
         (Pubkey::new_unique(), (stake, vote_account))
@@ -67,7 +74,7 @@ pub fn new_rand_vote_accounts<R: Rng>(
 /// If `stake_per_node` is specified, then each node will have that stake, otherwise a random amount
 /// between `min_stake_for_staked_account` and `max_stake_for_staked_account` is chosen.
 #[cfg(feature = "dev-context-only-utils")]
-pub fn new_staked_vote_accounts<R: Rng, F>(
+pub fn new_staked_vote_accounts<R: Rng, F, G, H>(
     rng: &mut R,
     num_nodes: usize,
     num_nodes_with_bls_pubkeys: usize,
@@ -75,9 +82,12 @@ pub fn new_staked_vote_accounts<R: Rng, F>(
     min_stake_for_staked_account: u64,
     max_stake_for_staked_account: u64,
     lamports_per_node: F,
+    pending_delegator_rewards_from_account_lamports_generator: G,
 ) -> VoteAccounts
 where
     F: Fn(usize) -> u64,
+    G: Fn(usize) -> H, // generator to create a function based on index
+    H: Fn(u64) -> u64, // function returned by generator to set pending rewards
 {
     let mut vote_accounts = VoteAccounts::default();
     for index in 0..num_nodes {
@@ -87,7 +97,14 @@ where
         });
         let node_pubkey = Pubkey::new_unique();
         let set_bls_pubkey = index < num_nodes_with_bls_pubkeys;
-        let mut account = new_rand_vote_account(rng, Some(node_pubkey), set_bls_pubkey);
+        let pending_delegator_rewards_fn =
+            pending_delegator_rewards_from_account_lamports_generator(index);
+        let mut account = new_rand_vote_account(
+            rng,
+            Some(node_pubkey),
+            set_bls_pubkey,
+            pending_delegator_rewards_fn,
+        );
         account.set_lamports(lamports_per_node(index));
         vote_accounts.insert(pubkey, VoteAccount::try_from(account).unwrap(), || stake);
     }

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -27,7 +27,7 @@ const MAX_STAKE_FOR_STAKED_ACCOUNT: u64 = 997;
 #[test]
 fn test_vote_account_try_from() {
     let mut rng = rand::rng();
-    let account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+    let account = new_rand_vote_account(rng.random(), None, true, |_| 0);
     let lamports = account.lamports();
     let vote_account = VoteAccount::try_from(account.clone()).unwrap();
     assert_eq!(lamports, vote_account.lamports());
@@ -38,7 +38,7 @@ fn test_vote_account_try_from() {
 #[should_panic(expected = "InvalidOwner")]
 fn test_vote_account_try_from_invalid_owner() {
     let mut rng = rand::rng();
-    let mut account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+    let mut account = new_rand_vote_account(rng.random(), None, true, |_| 0);
     account.set_owner(Pubkey::new_unique());
     VoteAccount::try_from(account).unwrap();
 }
@@ -46,7 +46,7 @@ fn test_vote_account_try_from_invalid_owner() {
 #[test]
 fn test_vote_account_serialize() {
     let mut rng = rand::rng();
-    let account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+    let account = new_rand_vote_account(rng.random(), None, true, |_| 0);
     let vote_account = VoteAccount::try_from(account.clone()).unwrap();
     // Assert that VoteAccount has the same wire format as Account.
     assert_eq!(
@@ -101,7 +101,7 @@ fn test_vote_accounts_deserialize_invalid_account() {
     // being silently dropped (bad data)
     let mut vote_accounts_hash_map = HashMap::<Pubkey, (u64, AccountSharedData)>::new();
 
-    let valid_account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+    let valid_account = new_rand_vote_account(rng.random(), None, true, |_| 0);
     vote_accounts_hash_map.insert(Pubkey::new_unique(), (0xAA, valid_account.clone()));
 
     let invalid_account_data =
@@ -181,7 +181,7 @@ fn test_staked_nodes_update() {
     let mut rng = rand::rng();
     let pubkey = Pubkey::new_unique();
     let node_pubkey = Pubkey::new_unique();
-    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
+    let account1 = new_rand_vote_account(rng.random(), Some(node_pubkey), true, |_| 0);
     let vote_account1 = VoteAccount::try_from(account1).unwrap();
 
     // first insert
@@ -201,7 +201,7 @@ fn test_staked_nodes_update() {
     assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), Some(&42));
 
     // update with changed state, same node pubkey
-    let account2 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
+    let account2 = new_rand_vote_account(rng.random(), Some(node_pubkey), true, |_| 0);
     let vote_account2 = VoteAccount::try_from(account2).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account2.clone(), || {
         panic!("should not be called")
@@ -214,7 +214,7 @@ fn test_staked_nodes_update() {
 
     // update with new node pubkey, stake must be moved
     let new_node_pubkey = Pubkey::new_unique();
-    let account3 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true, |_| 0);
+    let account3 = new_rand_vote_account(rng.random(), Some(new_node_pubkey), true, |_| 0);
     let vote_account3 = VoteAccount::try_from(account3).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account3, || panic!("should not be called"));
     assert_eq!(ret, Some(vote_account2));
@@ -232,7 +232,7 @@ fn test_staked_nodes_zero_stake() {
     let mut rng = rand::rng();
     let pubkey = Pubkey::new_unique();
     let node_pubkey = Pubkey::new_unique();
-    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
+    let account1 = new_rand_vote_account(rng.random(), Some(node_pubkey), true, |_| 0);
     let vote_account1 = VoteAccount::try_from(account1).unwrap();
 
     // we call this here to initialize VoteAccounts::staked_nodes which is a OnceLock
@@ -245,7 +245,7 @@ fn test_staked_nodes_zero_stake() {
 
     // update with new node pubkey, stake is 0 and should remain 0
     let new_node_pubkey = Pubkey::new_unique();
-    let account2 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true, |_| 0);
+    let account2 = new_rand_vote_account(rng.random(), Some(new_node_pubkey), true, |_| 0);
     let vote_account2 = VoteAccount::try_from(account2).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account2, || panic!("should not be called"));
     assert_eq!(ret, Some(vote_account1));
@@ -410,7 +410,7 @@ fn test_clone_and_filter_for_vat_same_stake_at_border() {
     // Create exactly 2 accounts more than maximum to test border truncation
     let num_accounts = MAX_ALPENGLOW_VOTE_ACCOUNTS + 2;
     let accounts = (0..num_accounts).map(|index| {
-        let mut account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+        let mut account = new_rand_vote_account(rng.random(), None, true, |_| 0);
         account.set_lamports(10_000_000_000);
         let vote_account = VoteAccount::try_from(account).unwrap();
         let stake = if index < MAX_ALPENGLOW_VOTE_ACCOUNTS - 10 {
@@ -454,7 +454,7 @@ fn test_clone_and_filter_for_vat_not_enough_lamports() {
         |_| {
             |lamports| {
                 let mut rng = rand::rng();
-                rng.random_range(0..lamports.saturating_sub(DEFAULT_VAT_TO_BURN_PER_EPOCH))
+                rng.random_range(0..=lamports.saturating_sub(DEFAULT_VAT_TO_BURN_PER_EPOCH))
             }
         },
     );
@@ -523,7 +523,7 @@ fn test_vote_account_trailing_bytes_ignored() {
     // Trailing bytes (zero and garbage) must not affect VoteAccount
     // accessor results.
     let mut rng = rand::rng();
-    let base_account = new_rand_vote_account(&mut rng, None, true, |_| 0);
+    let base_account = new_rand_vote_account(rng.random(), None, true, |_| 0);
     let base_data = base_account.data().to_vec();
 
     // With trailing zeros.

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -27,7 +27,7 @@ const MAX_STAKE_FOR_STAKED_ACCOUNT: u64 = 997;
 #[test]
 fn test_vote_account_try_from() {
     let mut rng = rand::rng();
-    let account = new_rand_vote_account(&mut rng, None, true);
+    let account = new_rand_vote_account(&mut rng, None, true, |_| 0);
     let lamports = account.lamports();
     let vote_account = VoteAccount::try_from(account.clone()).unwrap();
     assert_eq!(lamports, vote_account.lamports());
@@ -38,7 +38,7 @@ fn test_vote_account_try_from() {
 #[should_panic(expected = "InvalidOwner")]
 fn test_vote_account_try_from_invalid_owner() {
     let mut rng = rand::rng();
-    let mut account = new_rand_vote_account(&mut rng, None, true);
+    let mut account = new_rand_vote_account(&mut rng, None, true, |_| 0);
     account.set_owner(Pubkey::new_unique());
     VoteAccount::try_from(account).unwrap();
 }
@@ -46,7 +46,7 @@ fn test_vote_account_try_from_invalid_owner() {
 #[test]
 fn test_vote_account_serialize() {
     let mut rng = rand::rng();
-    let account = new_rand_vote_account(&mut rng, None, true);
+    let account = new_rand_vote_account(&mut rng, None, true, |_| 0);
     let vote_account = VoteAccount::try_from(account.clone()).unwrap();
     // Assert that VoteAccount has the same wire format as Account.
     assert_eq!(
@@ -101,7 +101,7 @@ fn test_vote_accounts_deserialize_invalid_account() {
     // being silently dropped (bad data)
     let mut vote_accounts_hash_map = HashMap::<Pubkey, (u64, AccountSharedData)>::new();
 
-    let valid_account = new_rand_vote_account(&mut rng, None, true);
+    let valid_account = new_rand_vote_account(&mut rng, None, true, |_| 0);
     vote_accounts_hash_map.insert(Pubkey::new_unique(), (0xAA, valid_account.clone()));
 
     let invalid_account_data =
@@ -181,7 +181,7 @@ fn test_staked_nodes_update() {
     let mut rng = rand::rng();
     let pubkey = Pubkey::new_unique();
     let node_pubkey = Pubkey::new_unique();
-    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true);
+    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
     let vote_account1 = VoteAccount::try_from(account1).unwrap();
 
     // first insert
@@ -201,7 +201,7 @@ fn test_staked_nodes_update() {
     assert_eq!(vote_accounts.staked_nodes().get(&node_pubkey), Some(&42));
 
     // update with changed state, same node pubkey
-    let account2 = new_rand_vote_account(&mut rng, Some(node_pubkey), true);
+    let account2 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
     let vote_account2 = VoteAccount::try_from(account2).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account2.clone(), || {
         panic!("should not be called")
@@ -214,7 +214,7 @@ fn test_staked_nodes_update() {
 
     // update with new node pubkey, stake must be moved
     let new_node_pubkey = Pubkey::new_unique();
-    let account3 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true);
+    let account3 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true, |_| 0);
     let vote_account3 = VoteAccount::try_from(account3).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account3, || panic!("should not be called"));
     assert_eq!(ret, Some(vote_account2));
@@ -232,7 +232,7 @@ fn test_staked_nodes_zero_stake() {
     let mut rng = rand::rng();
     let pubkey = Pubkey::new_unique();
     let node_pubkey = Pubkey::new_unique();
-    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true);
+    let account1 = new_rand_vote_account(&mut rng, Some(node_pubkey), true, |_| 0);
     let vote_account1 = VoteAccount::try_from(account1).unwrap();
 
     // we call this here to initialize VoteAccounts::staked_nodes which is a OnceLock
@@ -245,7 +245,7 @@ fn test_staked_nodes_zero_stake() {
 
     // update with new node pubkey, stake is 0 and should remain 0
     let new_node_pubkey = Pubkey::new_unique();
-    let account2 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true);
+    let account2 = new_rand_vote_account(&mut rng, Some(new_node_pubkey), true, |_| 0);
     let vote_account2 = VoteAccount::try_from(account2).unwrap();
     let ret = vote_accounts.insert(pubkey, vote_account2, || panic!("should not be called"));
     assert_eq!(ret, Some(vote_account1));
@@ -332,6 +332,7 @@ fn test_clone_and_filter_for_vat_truncates() {
         MIN_STAKE_FOR_STAKED_ACCOUNT,
         MAX_STAKE_FOR_STAKED_ACCOUNT,
         |_| 10_000_000_000,
+        |_| |_| 0,
     );
     // All vote accounts should be returned if the limit is high enough.
     let filtered =
@@ -375,6 +376,7 @@ fn test_clone_and_filter_for_vat_filters_non_alpenglow() {
         MIN_STAKE_FOR_STAKED_ACCOUNT,
         MAX_STAKE_FOR_STAKED_ACCOUNT,
         |_| 10_000_000_000,
+        |_| |_| 0,
     );
     let new_limit = MAX_ALPENGLOW_VOTE_ACCOUNTS + 500;
     let filtered = vote_accounts.clone_and_filter_for_vat(new_limit, MIN_STAKE_FOR_STAKED_ACCOUNT);
@@ -408,7 +410,7 @@ fn test_clone_and_filter_for_vat_same_stake_at_border() {
     // Create exactly 2 accounts more than maximum to test border truncation
     let num_accounts = MAX_ALPENGLOW_VOTE_ACCOUNTS + 2;
     let accounts = (0..num_accounts).map(|index| {
-        let mut account = new_rand_vote_account(&mut rng, None, true);
+        let mut account = new_rand_vote_account(&mut rng, None, true, |_| 0);
         account.set_lamports(10_000_000_000);
         let vote_account = VoteAccount::try_from(account).unwrap();
         let stake = if index < MAX_ALPENGLOW_VOTE_ACCOUNTS - 10 {
@@ -449,6 +451,46 @@ fn test_clone_and_filter_for_vat_not_enough_lamports() {
                 10_000_000_000
             }
         },
+        |_| {
+            |lamports| {
+                let mut rng = rand::rng();
+                rng.random_range(0..lamports.saturating_sub(DEFAULT_VAT_TO_BURN_PER_EPOCH))
+            }
+        },
+    );
+    let filtered = vote_accounts
+        .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, DEFAULT_VAT_TO_BURN_PER_EPOCH);
+    assert!(filtered.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS - entries_to_modify);
+}
+
+#[test]
+fn test_clone_and_filter_for_vat_not_enough_lamports_with_pending_delegator_rewards() {
+    let mut rng = rand::rng();
+    // For 10% of vote accounts, set the balance below the minimum.
+    let entries_to_modify = MAX_ALPENGLOW_VOTE_ACCOUNTS / 10;
+    let vote_accounts = new_staked_vote_accounts(
+        &mut rng,
+        MAX_ALPENGLOW_VOTE_ACCOUNTS,
+        MAX_ALPENGLOW_VOTE_ACCOUNTS,
+        None,
+        MIN_STAKE_FOR_STAKED_ACCOUNT,
+        MAX_STAKE_FOR_STAKED_ACCOUNT,
+        |_| 10_000_000_000,
+        |index| {
+            if index < entries_to_modify {
+                |lamports: u64| {
+                    let mut rng = rand::rng();
+                    rng.random_range(0..=lamports.saturating_sub(DEFAULT_VAT_TO_BURN_PER_EPOCH))
+                }
+            } else {
+                |lamports: u64| {
+                    let mut rng = rand::rng();
+                    rng.random_range(
+                        lamports.saturating_sub(DEFAULT_VAT_TO_BURN_PER_EPOCH) + 1..lamports,
+                    )
+                }
+            }
+        },
     );
     let filtered = vote_accounts
         .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, DEFAULT_VAT_TO_BURN_PER_EPOCH);
@@ -467,6 +509,7 @@ fn test_clone_and_filter_for_vat_empty_accounts() {
         MIN_STAKE_FOR_STAKED_ACCOUNT,
         MAX_STAKE_FOR_STAKED_ACCOUNT,
         |_| 10_000_000_000,
+        |_| |_| 0,
     );
     // Since everyone has the same stake and the limit is 500 less than number of accounts,
     // all border stake peers are removed and we end up with no valid accounts.
@@ -480,7 +523,7 @@ fn test_vote_account_trailing_bytes_ignored() {
     // Trailing bytes (zero and garbage) must not affect VoteAccount
     // accessor results.
     let mut rng = rand::rng();
-    let base_account = new_rand_vote_account(&mut rng, None, true);
+    let base_account = new_rand_vote_account(&mut rng, None, true, |_| 0);
     let base_data = base_account.data().to_vec();
 
     // With trailing zeros.

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -218,12 +218,13 @@ impl VoteAccounts {
         let capacity = max_vote_accounts.min(self.vote_accounts.len());
         let mut entries_to_sort: Vec<(&Pubkey, &VoteAccount, u64)> = Vec::with_capacity(capacity);
         for (pubkey, (stake, vote_account)) in self.vote_accounts.iter() {
-            let has_bls = vote_account
-                .vote_state_view()
-                .bls_pubkey_compressed()
-                .is_some();
+            let vote_state_view = vote_account.vote_state_view();
+            let has_bls = vote_state_view.bls_pubkey_compressed().is_some();
             let has_stake = *stake != 0u64;
-            let has_balance = vote_account.lamports() >= minimum_vote_account_balance;
+            let has_balance = vote_account
+                .lamports()
+                .saturating_sub(vote_state_view.pending_delegator_rewards())
+                >= minimum_vote_account_balance;
 
             if !has_bls || !has_stake || !has_balance {
                 continue;

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -221,6 +221,8 @@ impl VoteAccounts {
             let vote_state_view = vote_account.vote_state_view();
             let has_bls = vote_state_view.bls_pubkey_compressed().is_some();
             let has_stake = *stake != 0u64;
+            // Pending delegator rewards are deducted at the start of the epoch,
+            // so this operation reflects the actual expected balance
             let has_balance = vote_account
                 .lamports()
                 .saturating_sub(vote_state_view.pending_delegator_rewards())


### PR DESCRIPTION
#### Problem

As described at #13228, the VAT filtering in Alpenglow does not take into account pending delegator rewards. This can cause big issues during rewards payout, as VAT burning happens before block reward distribution.

#### Summary of changes

Account for pending delegator rewards during VAT filtering.

Note that this PR doesn't check for SIMD-0123 being enabled, since pending delegator rewards can't be incremented before it's enabled.

#### Testing

New unit test

Fixes #13228