### PR TITLE
ledger-tool: add create-snapshot --rollback-alpenglow

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-syscalls",
  "solana-system-interface 3.3.0",
+ "solana-sysvar",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-status",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -141,6 +141,7 @@ solana-svm-transaction = "5.0.0"
 solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-system-interface = "3.2"
 solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-sysvar = { version = "4.3.0", features = ["wincode"] }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.4.0-alpha.2" }
 solana-time-utils = "3.0.0"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -83,6 +83,7 @@ solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true }
+solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-status = { workspace = true }

--- a/ledger-tool/src/alpenglow_rollback.rs
+++ b/ledger-tool/src/alpenglow_rollback.rs
@@ -1,0 +1,425 @@
+use {
+    solana_account::{AccountSharedData, ReadableAccount as _, state_traits::StateMutWincode as _},
+    solana_clock::Epoch,
+    solana_pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+    solana_stake_interface::{self as stake, state::StakeStateV2},
+    solana_sysvar::epoch_rewards::{self, EpochRewards},
+    solana_vote_program::{self, vote_state::VoteStateVersions},
+    thiserror::Error,
+};
+
+/// Counts and identifies every reward-state change made by an Alpenglow rollback.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AlpenglowRollbackReport {
+    pub vote_accounts_reset: usize,
+    pub stake_accounts_reset: usize,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum AlpenglowRollbackError {
+    #[error(
+        "partitioned epoch rewards are active: {distributed_rewards} of {total_rewards} lamports \
+         have been distributed"
+    )]
+    ActiveEpochRewards {
+        distributed_rewards: u64,
+        total_rewards: u64,
+    },
+
+    #[error("the EpochRewards sysvar account is malformed")]
+    InvalidEpochRewardsSysvar,
+
+    #[error("failed to scan vote accounts: {0}")]
+    VoteAccountScan(String),
+
+    #[error("failed to scan stake accounts: {0}")]
+    StakeAccountScan(String),
+
+    #[error(
+        "vote account {address} still has {pending_delegator_rewards} lamports of pending \
+         delegator rewards"
+    )]
+    PendingDelegatorRewards {
+        address: Pubkey,
+        pending_delegator_rewards: u64,
+    },
+}
+
+pub(crate) struct PreparedAlpenglowRollback {
+    accounts: Vec<(Pubkey, AccountSharedData)>,
+    report: AlpenglowRollbackReport,
+}
+
+impl PreparedAlpenglowRollback {
+    pub(crate) fn apply(self, bank: &Bank) -> AlpenglowRollbackReport {
+        if !self.accounts.is_empty() {
+            bank.store_accounts((bank.slot(), self.accounts.as_slice()), None);
+        }
+        self.report
+    }
+}
+
+/// Prepare Tower reward cursors without changing materialized balances.
+pub(crate) fn preflight_alpenglow_rollback(
+    bank: &Bank,
+) -> Result<PreparedAlpenglowRollback, AlpenglowRollbackError> {
+    require_inactive_epoch_rewards(bank)?;
+
+    let rollback_epoch = bank.epoch_schedule().get_epoch(bank.slot() + 1);
+    let mut report = AlpenglowRollbackReport::default();
+
+    let mut vote_accounts = bank
+        .get_program_accounts(&solana_vote_program::id())
+        .map_err(|err| AlpenglowRollbackError::VoteAccountScan(err.to_string()))?;
+    vote_accounts.sort_unstable_by_key(|(address, _account)| *address);
+
+    let mut prepared_accounts = Vec::new();
+    for (address, account) in vote_accounts {
+        if let Some(replacement) = prepare_vote_account(address, &account, rollback_epoch)? {
+            report.vote_accounts_reset += 1;
+            prepared_accounts.push((address, replacement));
+        }
+    }
+
+    let mut stake_accounts = bank
+        .get_program_accounts(&stake::program::id())
+        .map_err(|err| AlpenglowRollbackError::StakeAccountScan(err.to_string()))?;
+    stake_accounts.sort_unstable_by_key(|(address, _account)| *address);
+
+    for (address, account) in stake_accounts {
+        if let Some(replacement) = prepare_stake_account(&account) {
+            report.stake_accounts_reset += 1;
+            prepared_accounts.push((address, replacement));
+        }
+    }
+
+    Ok(PreparedAlpenglowRollback {
+        accounts: prepared_accounts,
+        report,
+    })
+}
+
+fn require_inactive_epoch_rewards(bank: &Bank) -> Result<(), AlpenglowRollbackError> {
+    let Some(account) = bank.get_account(&epoch_rewards::id()) else {
+        // This sysvar did not exist on older ledgers. Absence is equivalent to the runtime's
+        // default, inactive EpochRewards value.
+        return Ok(());
+    };
+    let epoch_rewards: EpochRewards = account
+        .state()
+        .map_err(|_| AlpenglowRollbackError::InvalidEpochRewardsSysvar)?;
+    if epoch_rewards.active {
+        return Err(AlpenglowRollbackError::ActiveEpochRewards {
+            distributed_rewards: epoch_rewards.distributed_rewards,
+            total_rewards: epoch_rewards.total_rewards,
+        });
+    }
+    Ok(())
+}
+
+fn prepare_vote_account(
+    address: Pubkey,
+    account: &AccountSharedData,
+    rollback_epoch: Epoch,
+) -> Result<Option<AccountSharedData>, AlpenglowRollbackError> {
+    let Ok(mut vote_state): Result<VoteStateVersions, _> = account.state() else {
+        return Ok(None);
+    };
+
+    if vote_state.is_uninitialized() {
+        return Ok(None);
+    }
+
+    // Match StakesCache::check_and_store(): merely being owned by the vote program and
+    // deserializing as VoteStateVersions is not enough to participate in rewards.  Invalid-size
+    // and otherwise non-cacheable accounts are inert protocol state, so an unrelated account
+    // assigned to the vote program must not be able to prevent an emergency rollback.
+    if !VoteStateVersions::is_correct_size_and_initialized(account.data())
+        || solana_vote::vote_account::VoteAccount::try_from(account.clone()).is_err()
+    {
+        return Ok(None);
+    }
+
+    if let VoteStateVersions::V4(vote_state_v4) = &vote_state
+        && vote_state_v4.pending_delegator_rewards != 0
+    {
+        return Err(AlpenglowRollbackError::PendingDelegatorRewards {
+            address,
+            pending_delegator_rewards: vote_state_v4.pending_delegator_rewards,
+        });
+    }
+    let epoch_credits = match &mut vote_state {
+        VoteStateVersions::Uninitialized => unreachable!("checked is_uninitialized above"),
+        VoteStateVersions::V1_14_11(vote_state) => &mut vote_state.epoch_credits,
+        VoteStateVersions::V3(vote_state) => &mut vote_state.epoch_credits,
+        VoteStateVersions::V4(vote_state) => &mut vote_state.epoch_credits,
+    };
+    *epoch_credits = vec![(rollback_epoch, 0, 0)];
+
+    let mut replacement = account.clone();
+    replacement
+        .set_state(&vote_state)
+        .expect("shortened vote state must fit");
+    Ok(Some(replacement))
+}
+
+fn prepare_stake_account(account: &AccountSharedData) -> Option<AccountSharedData> {
+    let stake_state: StakeStateV2 = account.state().ok()?;
+    let StakeStateV2::Stake(meta, mut stake, stake_flags) = stake_state else {
+        return None;
+    };
+    stake.credits_observed = 0;
+
+    let mut replacement = account.clone();
+    replacement
+        .set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
+        .expect("unchanged-size stake state must fit");
+    Some(replacement)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_account::WritableAccount as _,
+        solana_clock::Clock,
+        solana_runtime::{bank::Bank, genesis_utils::create_genesis_config},
+        solana_stake_interface::{
+            stake_flags::StakeFlags,
+            state::{Delegation, Meta, Stake},
+        },
+        solana_vote_program::vote_state::{VoteInit, VoteStateV3, VoteStateV4},
+    };
+
+    fn new_vote_account(vote_state: VoteStateVersions, lamports: u64) -> AccountSharedData {
+        AccountSharedData::new_data_with_space(
+            lamports,
+            &vote_state,
+            VoteStateV4::size_of(),
+            &solana_vote_program::id(),
+        )
+        .unwrap()
+    }
+
+    fn deserialize_vote_state(account: &AccountSharedData) -> VoteStateVersions {
+        account.state().unwrap()
+    }
+
+    fn initialized_v3(epoch_credits: Vec<(Epoch, u64, u64)>) -> VoteStateVersions {
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: 17,
+        };
+        let mut vote_state = VoteStateV3::new(&vote_init, &Clock::default());
+        vote_state.root_slot = Some(41);
+        vote_state.epoch_credits = epoch_credits;
+        VoteStateVersions::new_v3(vote_state)
+    }
+
+    fn new_stake_account(stake_state: &StakeStateV2, lamports: u64) -> AccountSharedData {
+        AccountSharedData::new_data_with_space(
+            lamports,
+            stake_state,
+            StakeStateV2::size_of(),
+            &stake::program::id(),
+        )
+        .unwrap()
+    }
+
+    fn deserialize_stake_state(account: &AccountSharedData) -> StakeStateV2 {
+        account.state().unwrap()
+    }
+
+    #[test]
+    fn multi_epoch_vote_history_and_migration_marker_are_reset() {
+        let address = Pubkey::new_unique();
+        let migration_marker = (Epoch::MAX, u64::MAX, u64::MAX);
+        let original_state =
+            initialized_v3(vec![(3, 11, 7), migration_marker, (4, 19, 0), (5, 31, 19)]);
+        let mut account = new_vote_account(original_state, 123_456);
+        account.set_executable(true);
+        account.set_rent_epoch(55);
+
+        let replacement = prepare_vote_account(address, &account, 9).unwrap().unwrap();
+        let VoteStateVersions::V3(vote_state) = deserialize_vote_state(&replacement) else {
+            unreachable!();
+        };
+        assert_eq!(vote_state.epoch_credits, vec![(9, 0, 0)]);
+        assert_eq!(replacement.lamports(), account.lamports());
+        assert_eq!(replacement.executable(), account.executable());
+        assert_eq!(replacement.rent_epoch(), account.rent_epoch());
+    }
+
+    #[test]
+    fn v4_pending_delegator_rewards_abort_preparation() {
+        let address = Pubkey::new_unique();
+        let vote_state = VoteStateV4 {
+            pending_delegator_rewards: 42,
+            epoch_credits: vec![(7, 99, 80)],
+            ..VoteStateV4::default()
+        };
+        let account = new_vote_account(VoteStateVersions::new_v4(vote_state), 500);
+
+        assert_eq!(
+            prepare_vote_account(address, &account, 8),
+            Err(AlpenglowRollbackError::PendingDelegatorRewards {
+                address,
+                pending_delegator_rewards: 42,
+            })
+        );
+    }
+
+    #[test]
+    fn parseable_but_noncacheable_vote_account_is_malformed() {
+        let address = Pubkey::new_unique();
+        let account = AccountSharedData::new_data(
+            1,
+            &initialized_v3(vec![(1, 10, 0)]),
+            &solana_vote_program::id(),
+        )
+        .unwrap();
+        assert!(
+            prepare_vote_account(address, &account, 2)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            prepare_vote_account(
+                address,
+                &new_vote_account(VoteStateVersions::Uninitialized, 1),
+                2
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn stake_cursor_is_reset_without_changing_delegation_or_account_fields() {
+        let original_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey: Pubkey::new_unique(),
+                stake: 99_000,
+                activation_epoch: 3,
+                deactivation_epoch: 20,
+                ..Delegation::default()
+            },
+            credits_observed: 1_234,
+        };
+        let original_state =
+            StakeStateV2::Stake(Meta::default(), original_stake, StakeFlags::empty());
+        let mut account = new_stake_account(&original_state, 456_789);
+        account.set_rent_epoch(77);
+
+        let replacement = prepare_stake_account(&account).unwrap();
+        let StakeStateV2::Stake(_, normalized_stake, _) = deserialize_stake_state(&replacement)
+        else {
+            unreachable!();
+        };
+
+        assert_eq!(normalized_stake.credits_observed, 0);
+        assert_eq!(normalized_stake.delegation, original_stake.delegation);
+        assert_eq!(replacement.lamports(), account.lamports());
+        assert_eq!(replacement.rent_epoch(), account.rent_epoch());
+        assert_eq!(
+            deserialize_stake_state(&account)
+                .stake()
+                .unwrap()
+                .credits_observed,
+            1_234
+        );
+        assert!(
+            prepare_stake_account(&new_stake_account(
+                &StakeStateV2::Initialized(Meta::default()),
+                1
+            ))
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn active_epoch_rewards_abort_before_account_preparation() {
+        let bank = Bank::new_for_tests(&create_genesis_config(1_000_000).genesis_config);
+        let epoch_rewards = EpochRewards {
+            total_rewards: 100,
+            distributed_rewards: 40,
+            active: true,
+            ..EpochRewards::default()
+        };
+        let account =
+            AccountSharedData::new_data(1, &epoch_rewards, &solana_sdk_ids::sysvar::id()).unwrap();
+        bank.store_account(&epoch_rewards::id(), &account);
+
+        assert!(matches!(
+            preflight_alpenglow_rollback(&bank),
+            Err(AlpenglowRollbackError::ActiveEpochRewards {
+                distributed_rewards: 40,
+                total_rewards: 100,
+            })
+        ));
+    }
+
+    #[test]
+    fn apply_stores_all_replacements_and_updates_vote_cache() {
+        let source = Bank::new_for_tests(&create_genesis_config(1_000_000).genesis_config);
+        let vote_address = Pubkey::new_unique();
+        let stake_address = Pubkey::new_unique();
+        let vote_account = new_vote_account(initialized_v3(vec![(0, 15, 0), (1, 30, 15)]), 10_000);
+        let stake_account = new_stake_account(
+            &StakeStateV2::Stake(
+                Meta::default(),
+                Stake {
+                    delegation: Delegation {
+                        voter_pubkey: vote_address,
+                        stake: 5_000,
+                        ..Delegation::default()
+                    },
+                    credits_observed: 30,
+                },
+                StakeFlags::empty(),
+            ),
+            20_000,
+        );
+        source.store_accounts(
+            (
+                source.slot(),
+                &[
+                    (vote_address, vote_account.clone()),
+                    (stake_address, stake_account.clone()),
+                ][..],
+            ),
+            None,
+        );
+
+        let prepared = preflight_alpenglow_rollback(&source).unwrap();
+        let report = prepared.apply(&source);
+        assert!(report.vote_accounts_reset >= 1);
+        assert!(report.stake_accounts_reset >= 1);
+
+        let VoteStateVersions::V3(vote_state) =
+            deserialize_vote_state(&source.get_account(&vote_address).unwrap())
+        else {
+            unreachable!();
+        };
+        assert_eq!(
+            vote_state.epoch_credits,
+            vec![(source.epoch_schedule().get_epoch(source.slot() + 1), 0, 0)]
+        );
+        let StakeStateV2::Stake(_, stake, _) =
+            deserialize_stake_state(&source.get_account(&stake_address).unwrap())
+        else {
+            unreachable!();
+        };
+        assert_eq!(stake.credits_observed, 0);
+        let cached_vote_accounts = source.vote_accounts();
+        let cached_vote_account = cached_vote_accounts.get(&vote_address).unwrap().1.account();
+        let VoteStateVersions::V3(cached_vote_state) = deserialize_vote_state(cached_vote_account)
+        else {
+            unreachable!();
+        };
+        assert_eq!(cached_vote_state.epoch_credits, vote_state.epoch_credits);
+    }
+}

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{
+        alpenglow_rollback::*,
         args::*,
         bigtable::*,
         blockstore::*,
@@ -55,6 +56,7 @@ use {
         blockstore::{Blockstore, PurgeType, banking_trace_path, create_new_ledger},
         blockstore_options::{AccessType, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, LedgerColumnOptions},
         blockstore_processor::ProcessSlotCallback,
+        leader_schedule_cache::LeaderScheduleCache,
         shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_measure::{measure::Measure, measure_time},
@@ -105,6 +107,7 @@ use {
     },
 };
 
+mod alpenglow_rollback;
 mod args;
 mod bigtable;
 mod blockstore;
@@ -113,6 +116,71 @@ mod ledger_path;
 mod ledger_utils;
 mod output;
 mod program;
+
+fn install_synthetic_shreds(
+    blockstore: &Arc<Blockstore>,
+    ledger_path: &Path,
+    arg_matches: &ArgMatches<'_>,
+    start_slot: Slot,
+    end_slot: Slot,
+    shreds: Vec<Shred>,
+    backup_shred_version: Option<u16>,
+) -> Arc<Blockstore> {
+    if let Some(shred_version) = backup_shred_version {
+        let backup_path = ledger_path.join(format!(
+            "{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL}_backup_{shred_version}_{start_slot}"
+        ));
+        let backup = open_blockstore(&backup_path, arg_matches, AccessType::PrimaryForMaintenance);
+        let mut old_shreds = Vec::new();
+        for (slot, _) in blockstore
+            .slot_meta_iterator(start_slot)
+            .expect("Blockstore operation must succeed")
+            .take_while(|(slot, _)| *slot <= end_slot)
+        {
+            old_shreds.extend(
+                blockstore
+                    .get_data_shreds_for_slot(slot, 0)
+                    .expect("Blockstore operation must succeed"),
+            );
+        }
+        let mut pinnable_slice = backup.new_pinnable_slice();
+        let mut write_batch = backup.get_write_batch();
+        backup
+            .insert_cow_shreds(
+                old_shreds.into_iter().map(Cow::Owned),
+                true,
+                &mut pinnable_slice,
+                &mut write_batch,
+            )
+            .expect("Blockstore operation must succeed");
+    }
+
+    let blockstore = if blockstore.is_primary_access() {
+        Arc::clone(blockstore)
+    } else {
+        Arc::new(open_blockstore(
+            ledger_path,
+            arg_matches,
+            AccessType::PrimaryForMaintenance,
+        ))
+    };
+    if backup_shred_version.is_some() {
+        blockstore
+            .purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)
+            .expect("Blockstore operation must succeed");
+    }
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
+    blockstore
+        .insert_cow_shreds(
+            shreds.into_iter().map(Cow::Owned),
+            true,
+            &mut pinnable_slice,
+            &mut write_batch,
+        )
+        .expect("Blockstore operation must succeed");
+    Arc::clone(&blockstore)
+}
 
 fn render_dot(dot: String, output_file: &str, output_format: &str) -> io::Result<()> {
     let mut child = Command::new("dot")
@@ -1533,6 +1601,38 @@ fn main() {
                         .long("enable-capitalization-change")
                         .takes_value(false)
                         .help("If snapshot creation should succeed with a capitalization delta."),
+                )
+                .arg(
+                    Arg::with_name("rollback_alpenglow")
+                        .long("rollback-alpenglow")
+                        .takes_value(false)
+                        .requires("enable_capitalization_change")
+                        .conflicts_with_all(&[
+                            "hard_forks",
+                            "incremental",
+                            "minimized",
+                            "ending_slot",
+                            "recalculate_accounts_lt_hash",
+                            "warp_slot",
+                            "faucet_lamports",
+                            "faucet_pubkey",
+                            "bootstrap_validator",
+                            "bootstrap_stake_authorized_pubkey",
+                            "rent_burn_percentage",
+                            "hashes_per_tick",
+                            "accounts_to_remove",
+                            "feature_gates_to_deactivate",
+                            "vote_accounts_to_destake",
+                            "remove_stake_accounts",
+                            "account_paths",
+                            "force_update_to_open",
+                        ])
+                        .help(
+                            "Roll the latest finalized Alpenglow root back to a same-epoch Tower \
+                             hard fork. Closes Alpenglow protocol accounts, resets reward \
+                             cursors, and backs up and replaces the discarded branch in-place. \
+                             Partitioned and pending delegator rewards must be inactive.",
+                        ),
                 ),
         )
         .subcommand(
@@ -2009,6 +2109,7 @@ fn main() {
 
                     let is_incremental = arg_matches.is_present("incremental");
                     let is_minimized = arg_matches.is_present("minimized");
+                    let rollback_alpenglow = arg_matches.is_present("rollback_alpenglow");
                     let output_directory = value_t!(arg_matches, "output_directory", PathBuf)
                         .unwrap_or_else(|_| {
                             let snapshot_archive_path = value_t!(arg_matches, "snapshots", String)
@@ -2125,6 +2226,16 @@ fn main() {
                         );
                         exit(1);
                     }
+                    if rollback_alpenglow
+                        && (!blockstore.is_root(snapshot_slot)
+                            || blockstore.max_root() != snapshot_slot)
+                    {
+                        eprintln!(
+                            "Error: --rollback-alpenglow requires the latest finalized source \
+                             slot."
+                        );
+                        exit(1);
+                    }
                     process_options.halt_at_slot = Some(snapshot_slot);
 
                     let ending_slot = if is_minimized {
@@ -2198,6 +2309,62 @@ fn main() {
                     // possibility.
                     accounts_background_service.join().unwrap();
 
+                    let mut prepared_alpenglow_rollback = None;
+                    let mut alpenglow_rollback_report = None;
+                    let mut source_shred_version = None;
+                    if rollback_alpenglow {
+                        if !bank.feature_set.is_active(&feature_set::alpenglow::id())
+                            || !bank.is_alpenglow()
+                            || bank.get_alpenglow_genesis_certificate().is_none()
+                        {
+                            eprintln!(
+                                "Error: slot {snapshot_slot} is not a completed Alpenglow bank. \
+                                 The feature and genesis certificate must both be active."
+                            );
+                            exit(1);
+                        }
+
+                        let rollback_slot = snapshot_slot.checked_add(1).unwrap_or_else(|| {
+                            eprintln!("Error: source slot {snapshot_slot} has no child slot");
+                            exit(1);
+                        });
+                        let source_epoch = bank.epoch();
+                        let rollback_epoch = bank.epoch_schedule().get_epoch(rollback_slot);
+                        if source_epoch != rollback_epoch {
+                            eprintln!(
+                                "Error: rollback child slot {rollback_slot} crosses an epoch \
+                                 boundary ({source_epoch} -> {rollback_epoch}). Choose an earlier \
+                                 finalized source slot in the same epoch."
+                            );
+                            exit(1);
+                        }
+                        if bank
+                            .hard_forks()
+                            .iter()
+                            .any(|(slot, _count)| *slot == rollback_slot)
+                        {
+                            eprintln!(
+                                "Error: rollback child slot {rollback_slot} is already registered \
+                                 as a hard fork."
+                            );
+                            exit(1);
+                        }
+
+                        // Capture this before constructing the child: Bank hard-fork state is
+                        // shared between parent and child, and registering H changes what the
+                        // in-memory source bank reports even though source replay used this old
+                        // version.
+                        source_shred_version = Some(compute_shred_version(
+                            &genesis_config.hash(),
+                            Some(&bank.hard_forks()),
+                        ));
+                        prepared_alpenglow_rollback =
+                            Some(preflight_alpenglow_rollback(&bank).unwrap_or_else(|err| {
+                                eprintln!("Error: unable to prepare Alpenglow rollback: {err}");
+                                exit(1);
+                            }));
+                    }
+
                     let child_bank_required = rent_burn_percentage.is_ok()
                         || hashes_per_tick.is_some()
                         || remove_stake_accounts
@@ -2205,11 +2372,41 @@ fn main() {
                         || !feature_gates_to_deactivate.is_empty()
                         || !vote_accounts_to_destake.is_empty()
                         || faucet_pubkey.is_some()
-                        || bootstrap_validator_pubkeys.is_some();
+                        || bootstrap_validator_pubkeys.is_some()
+                        || rollback_alpenglow;
 
                     if child_bank_required {
-                        let mut child_bank =
-                            Bank::new_from_parent(bank.clone(), *bank.leader(), bank.slot() + 1);
+                        let child_slot = bank.slot().checked_add(1).unwrap_or_else(|| {
+                            eprintln!("Error: source slot {} has no child slot", bank.slot());
+                            exit(1);
+                        });
+                        let mut child_bank = if rollback_alpenglow {
+                            let leader = LeaderScheduleCache::new_from_bank(&bank)
+                                .slot_leader_at(child_slot, Some(&bank))
+                                .unwrap_or_else(|| {
+                                    eprintln!(
+                                        "Error: unable to determine the leader for rollback slot \
+                                         {child_slot}"
+                                    );
+                                    exit(1);
+                                });
+                            Bank::new_from_parent_for_alpenglow_rollback(
+                                bank.clone(),
+                                leader,
+                                child_slot,
+                            )
+                        } else {
+                            Bank::new_from_parent(bank.clone(), *bank.leader(), child_slot)
+                        };
+
+                        if rollback_alpenglow {
+                            alpenglow_rollback_report = Some(
+                                prepared_alpenglow_rollback
+                                    .take()
+                                    .unwrap()
+                                    .apply(&child_bank),
+                            );
+                        }
 
                         if let Ok(rent_burn_percentage) = rent_burn_percentage {
                             child_bank.set_rent_burn_percentage(rent_burn_percentage);
@@ -2397,8 +2594,35 @@ fn main() {
                         }
                     }
 
-                    let new_shred_verison =
+                    let new_shred_version =
                         compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()));
+                    if rollback_alpenglow {
+                        let old_shred_version = source_shred_version
+                            .expect("rollback source shred version is captured");
+                        if old_shred_version == new_shred_version {
+                            eprintln!(
+                                "Error: rollback hard fork produced the same 16-bit shred version \
+                                 ({new_shred_version}) as the Alpenglow source. Refusing an \
+                                 ambiguous branch."
+                            );
+                            exit(1);
+                        }
+                        let report = alpenglow_rollback_report
+                            .as_ref()
+                            .expect("rollback reward rewrite report is available");
+                        println!(
+                            "Alpenglow rollback prepared: source slot {}, Tower hard-fork slot \
+                             {}, epoch {}, shred version {} -> {}, reset {} vote and {} stake \
+                             accounts",
+                            snapshot_slot,
+                            bank.slot(),
+                            bank.epoch(),
+                            old_shred_version,
+                            new_shred_version,
+                            report.vote_accounts_reset,
+                            report.stake_accounts_reset,
+                        );
+                    }
                     if child_bank_required {
                         let num_ticks_per_slot = bank.ticks_per_slot();
                         let num_hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
@@ -2411,96 +2635,77 @@ fn main() {
                             bank.register_tick(&tick_entry.hash, &scheduler);
                         });
 
-                        // Calculate and set the block ID so we can read it to
-                        // properly chain shreds for the child bank
-                        Bank::calculate_and_set_block_id_for_dcou(&bank);
-
-                        // Next steps will need write access to the Blockstore
-                        // so ensure we have R/W access
-                        let rw_blockstore = if blockstore.is_primary_access() {
-                            blockstore.clone()
+                        if rollback_alpenglow {
+                            assert!(bank.block_id().is_none());
+                            bank.freeze();
                         } else {
-                            Arc::new(open_blockstore(
-                                &ledger_path,
-                                arg_matches,
-                                AccessType::PrimaryForMaintenance,
-                            ))
-                        };
-
-                        // If slot exists, back it up in another Blockstore
-                        // just in case and purge from the Blockstore
-                        let slot = bank.slot();
-                        if blockstore.has_existing_shreds_for_slot(slot) {
-                            let shreds = blockstore
-                                .get_data_shreds_for_slot(slot, 0)
-                                .expect("Blockstore operation must succeed");
-
-                            let old_shred_version =
-                                shreds.first().expect("Slot must have a shred").version();
-                            let backup_directory = format!(
-                                "{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL}_backup_{old_shred_version}_{slot}"
-                            );
-                            let backup_ledger_path = ledger_path.join(backup_directory);
-                            info!("Backing up {slot} at {}", backup_ledger_path.display(),);
-                            let backup_blockstore = Arc::new(open_blockstore(
-                                &backup_ledger_path,
-                                arg_matches,
-                                AccessType::PrimaryForMaintenance,
-                            ));
-                            let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
-                            let mut write_batch = backup_blockstore.get_write_batch();
-                            let _ = backup_blockstore
-                                .insert_cow_shreds(
-                                    shreds.into_iter().map(Cow::Owned),
-                                    true,
-                                    &mut pinnable_slice,
-                                    &mut write_batch,
-                                )
-                                .expect("Blockstore operation must succeed");
-
-                            // Purge modifies state so use rw_blockstore
-                            info!("Purging slot {slot} from Blockstore");
-                            rw_blockstore
-                                .purge_slots_cleanup_chaining(slot, slot, PurgeType::Exact)
-                                .expect("Blockstore operation must succeed");
+                            Bank::calculate_and_set_block_id_for_dcou(&bank);
                         }
 
-                        // Use a "dummy" but deterministic keyapir to sign
+                        let slot = bank.slot();
                         let keypair = keypair_from_seed(&[0; Keypair::SECRET_KEY_LENGTH])
                             .expect("Keypair creation must succeed");
-                        let chained_merkle_root = bank
-                            .parent()
-                            .expect("Child bank must have parent bank available")
-                            .block_id()
-                            .expect("Parent bank must have block ID set");
-
-                        let shredder = Shredder::new(
-                            slot,
-                            bank.parent_slot(),
-                            /*reference_tick:*/ 0,
-                            new_shred_verison,
-                        )
-                        .expect("Shredder creation must succeed");
-                        let shreds: Vec<_> = shredder
+                        let shredder =
+                            Shredder::new(slot, bank.parent_slot(), 0, new_shred_version)
+                                .expect("Shredder creation must succeed");
+                        let synthetic_shreds: Vec<_> = shredder
                             .make_merkle_shreds_from_entries(
                                 &keypair,
                                 &tick_entries,
-                                /*is_last_in_slot:*/ true,
-                                chained_merkle_root,
-                                /*next_shred_index:*/ 0,
-                                /*next_code_index:*/ 0,
+                                true,
+                                bank.parent_block_id().expect("Parent block ID must be set"),
+                                0,
+                                0,
                                 &ReedSolomonCache::default(),
                                 &mut ProcessShredsStats::default(),
                             )
                             .into_iter()
                             .filter(Shred::is_data)
-                            .map(Cow::Owned)
                             .collect();
-                        let mut pinnable_slice = rw_blockstore.new_pinnable_slice();
-                        let mut write_batch = rw_blockstore.get_write_batch();
-                        rw_blockstore
-                            .insert_cow_shreds(shreds, true, &mut pinnable_slice, &mut write_batch)
-                            .expect("Blockstore operation must succeed");
+                        if rollback_alpenglow {
+                            bank.set_block_id(Some(
+                                synthetic_shreds
+                                    .last()
+                                    .expect("Synthetic slot must contain a data shred")
+                                    .merkle_root()
+                                    .expect("Synthetic data shred must have a Merkle root"),
+                            ));
+                        }
+                        let highest_slot = rollback_alpenglow
+                            .then(|| {
+                                blockstore
+                                    .highest_slot()
+                                    .expect("Blockstore operation must succeed")
+                            })
+                            .flatten();
+                        let end_slot = highest_slot.unwrap_or(slot).max(slot);
+                        let backup_shred_version = if rollback_alpenglow {
+                            highest_slot
+                                .is_some_and(|highest_slot| highest_slot >= slot)
+                                .then_some(source_shred_version.unwrap())
+                        } else {
+                            blockstore.has_existing_shreds_for_slot(slot).then(|| {
+                                blockstore
+                                    .get_data_shreds_for_slot(slot, 0)
+                                    .expect("Blockstore operation must succeed")[0]
+                                    .version()
+                            })
+                        };
+                        let rw_blockstore = install_synthetic_shreds(
+                            &blockstore,
+                            &ledger_path,
+                            arg_matches,
+                            slot,
+                            end_slot,
+                            synthetic_shreds,
+                            backup_shred_version,
+                        );
+                        if rollback_alpenglow {
+                            assert_eq!(
+                                rw_blockstore.get_last_shred_merkle_root(slot).unwrap(),
+                                bank.block_id()
+                            );
+                        }
                     }
 
                     let pre_capitalization = bank.capitalization();
@@ -2659,7 +2864,7 @@ fn main() {
                     if let Some(msg) = capitalization_message {
                         println!("{msg}");
                     }
-                    println!("Shred version: {new_shred_verison}",);
+                    println!("Shred version: {new_shred_version}",);
 
                     if let Some(system_monitor_service) = system_monitor_service {
                         exit_signal.store(true, Ordering::Relaxed);

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,8 +1,13 @@
 use {
+    agave_snapshots::snapshot_config::SnapshotConfig,
     solana_ledger::{
         blockstore, blockstore::Blockstore, create_new_tmp_ledger_auto_delete,
         genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
     },
+    solana_runtime::{
+        bank::Bank, genesis_utils::activate_all_features_alpenglow, snapshot_bank_utils,
+    },
+    solana_shred_version::compute_shred_version,
     std::{
         path::Path,
         process::{Command, Output},
@@ -42,6 +47,140 @@ fn nominal_default() {
     let genesis_config = create_genesis_config(100).genesis_config;
     let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
     nominal_test_helper(ledger_path.path().to_str().unwrap());
+}
+
+#[test]
+fn rollback_alpenglow_replaces_existing_child_slot() {
+    const SOURCE_SLOT: u64 = 0;
+    const ROLLBACK_SLOT: u64 = SOURCE_SLOT + 1;
+    const DESCENDANT_SLOT: u64 = ROLLBACK_SLOT + 1;
+
+    // A hard fork changes only a 16-bit version, so avoid the small chance that this test's
+    // randomly generated genesis collides with the source version.
+    let genesis_config = loop {
+        let mut genesis_config = create_genesis_config(100).genesis_config;
+        activate_all_features_alpenglow(&mut genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
+        bank.register_hard_fork(ROLLBACK_SLOT);
+        if compute_shred_version(&genesis_config.hash(), None)
+            != compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()))
+        {
+            break genesis_config;
+        }
+    };
+    let source_shred_version = compute_shred_version(&genesis_config.hash(), None);
+    let (ledger_path, _blockhash) = create_new_tmp_ledger_auto_delete!(&genesis_config);
+
+    let (_, old_entries) = blockstore::make_slot_entries(ROLLBACK_SLOT, SOURCE_SLOT, 10);
+    let old_shreds = blockstore::entries_to_test_shreds(
+        &old_entries,
+        ROLLBACK_SLOT,
+        SOURCE_SLOT,
+        true,
+        source_shred_version,
+    );
+    let (_, descendant_entries) = blockstore::make_slot_entries(DESCENDANT_SLOT, ROLLBACK_SLOT, 10);
+    let descendant_shreds = blockstore::entries_to_test_shreds(
+        &descendant_entries,
+        DESCENDANT_SLOT,
+        ROLLBACK_SLOT,
+        true,
+        source_shred_version,
+    );
+    {
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        blockstore
+            .insert_shreds(
+                old_shreds
+                    .iter()
+                    .chain(&descendant_shreds)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                false,
+            )
+            .unwrap();
+    }
+
+    let output_directory = tempfile::tempdir().unwrap();
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path.path().to_str().unwrap(),
+        "create-snapshot",
+        &SOURCE_SLOT.to_string(),
+        output_directory.path().to_str().unwrap(),
+        "--rollback-alpenglow",
+        "--enable-capitalization-change",
+        "--snapshot-archive-format",
+        "lz4",
+    ]);
+    assert!(
+        output.status.success(),
+        "ledger-tool failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let snapshot_config = SnapshotConfig {
+        full_snapshot_archives_dir: output_directory.path().to_path_buf(),
+        incremental_snapshot_archives_dir: output_directory.path().to_path_buf(),
+        use_direct_io: false,
+        use_registered_io_uring_buffers: false,
+        ..SnapshotConfig::default()
+    };
+    let snapshot_fields =
+        snapshot_bank_utils::bank_fields_from_snapshot_archives(&snapshot_config).unwrap();
+    let hard_fork_shred_version =
+        compute_shred_version(&genesis_config.hash(), Some(&snapshot_fields.hard_forks));
+
+    let verify_output = run_ledger_tool(&[
+        "-l",
+        ledger_path.path().to_str().unwrap(),
+        "verify",
+        "--full-snapshot-archive-path",
+        output_directory.path().to_str().unwrap(),
+        "--halt-at-slot",
+        &ROLLBACK_SLOT.to_string(),
+    ]);
+    assert!(
+        verify_output.status.success(),
+        "in-place ledger verification failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&verify_output.stdout),
+        String::from_utf8_lossy(&verify_output.stderr),
+    );
+
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    assert_eq!(blockstore.highest_slot().unwrap(), Some(ROLLBACK_SLOT));
+    let rewritten_shreds = blockstore
+        .get_data_shreds_for_slot(ROLLBACK_SLOT, 0)
+        .unwrap();
+    assert!(
+        rewritten_shreds
+            .iter()
+            .all(|shred| shred.version() == hard_fork_shred_version)
+    );
+    assert_eq!(
+        blockstore
+            .get_last_shred_merkle_root(ROLLBACK_SLOT)
+            .unwrap(),
+        snapshot_fields.block_id,
+    );
+
+    let backup_path = ledger_path.path().join(format!(
+        "rocksdb_backup_{source_shred_version}_{ROLLBACK_SLOT}"
+    ));
+    let backup_blockstore = Blockstore::open(&backup_path).unwrap();
+    assert_eq!(
+        backup_blockstore
+            .get_data_shreds_for_slot(ROLLBACK_SLOT, 0)
+            .unwrap(),
+        old_shreds,
+    );
+    assert_eq!(
+        backup_blockstore
+            .get_data_shreds_for_slot(DESCENDANT_SLOT, 0)
+            .unwrap(),
+        descendant_shreds,
+    );
 }
 
 fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1429,6 +1429,7 @@ impl Bank {
             slot,
             null_tracer(),
             NewBankOptions::default(),
+            None,
         )
     }
 
@@ -1438,7 +1439,24 @@ impl Bank {
         slot: Slot,
         new_bank_options: NewBankOptions,
     ) -> Self {
-        Self::_new_from_parent(parent, leader, slot, null_tracer(), new_bank_options)
+        Self::_new_from_parent(parent, leader, slot, null_tracer(), new_bank_options, None)
+    }
+
+    /// Creates the immediate, same-epoch Tower hard-fork child used by offline rollback tooling.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_from_parent_for_alpenglow_rollback(
+        parent: Arc<Bank>,
+        leader: SlotLeader,
+        slot: Slot,
+    ) -> Self {
+        Self::_new_from_parent(
+            parent,
+            leader,
+            slot,
+            null_tracer(),
+            NewBankOptions::default(),
+            Some(Self::prepare_alpenglow_rollback),
+        )
     }
 
     pub fn new_from_parent_with_tracer(
@@ -1453,6 +1471,7 @@ impl Bank {
             slot,
             Some(reward_calc_tracer),
             NewBankOptions::default(),
+            None,
         )
     }
 
@@ -1466,6 +1485,7 @@ impl Bank {
         slot: Slot,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         new_bank_options: NewBankOptions,
+        prepare_bank: Option<fn(&mut Bank, &Bank)>,
     ) -> Self {
         let mut time = Measure::start("bank::new_from_parent");
         let NewBankOptions { vote_only_bank } = new_bank_options;
@@ -1614,6 +1634,10 @@ impl Bank {
             ancestors.extend(new.parents_iter().map(|parent| parent.slot()));
             new.ancestors = Ancestors::from(ancestors);
         });
+
+        if let Some(prepare_bank) = prepare_bank {
+            prepare_bank(&mut new, &parent);
+        }
 
         let prepare_timings = new.prepare_for_block_execution(
             parent.epoch(),
@@ -3528,6 +3552,69 @@ impl Bank {
 
     fn set_is_alpenglow(&self) {
         self.is_alpenglow.store(true, Relaxed);
+    }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    fn prepare_alpenglow_rollback(&mut self, parent: &Bank) {
+        assert_eq!(
+            self.slot(),
+            parent.slot().saturating_add(1),
+            "Alpenglow rollback requires the immediate child of the source bank"
+        );
+        assert_eq!(
+            self.epoch(),
+            parent.epoch(),
+            "Alpenglow rollback must not cross an epoch boundary"
+        );
+        assert!(
+            parent.is_alpenglow()
+                && self.is_alpenglow()
+                && self.feature_set.is_active(&feature_set::alpenglow::id())
+                && self.get_alpenglow_genesis_certificate().is_some(),
+            "Alpenglow rollback requires an Alpenglow parent and child"
+        );
+
+        assert!(
+            !parent
+                .get_account(&sysvar::epoch_rewards::id())
+                .and_then(|account| from_account::<sysvar::epoch_rewards::EpochRewards>(&account))
+                .is_some_and(|rewards| rewards.active),
+            "Alpenglow rollback requires inactive partitioned epoch rewards"
+        );
+        assert!(
+            !self
+                .hard_forks()
+                .iter()
+                .any(|(hard_fork_slot, _count)| *hard_fork_slot == self.slot()),
+            "Alpenglow rollback hard fork is already registered at the child slot"
+        );
+
+        // This runs before new-bank sysvar updates and after source replay.
+        self.register_hard_fork(self.slot());
+
+        self.deactivate_feature(&feature_set::alpenglow::id());
+        // Capitalization is recalculated by ledger-tool after these closures.
+        for address in [
+            feature_set::alpenglow::id(),
+            *GENESIS_CERTIFICATE_ACCOUNT,
+            *NANOSECOND_CLOCK_ACCOUNT,
+        ] {
+            if let Some(mut account) = self.get_account_with_fixed_root_no_cache(&address) {
+                let old_data_size = account.data().len();
+                account.set_lamports(0);
+                account.set_data_from_slice(&[]);
+                self.store_account(&address, &account);
+                self.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, 0);
+            }
+        }
+        self.is_alpenglow.store(false, Relaxed);
+
+        // Apply the Tower slot parameters to this already-created bank.
+        let tower_hashes_per_tick = self.current_slot_params().hashes_per_tick();
+        self.apply_slot_time_persistent_changes();
+        self.apply_activated_features();
+        self.set_hashes_per_tick(tower_hashes_per_tick);
+        self.assert_bank_matches_slot_params();
     }
 
     /// For use in the first Alpenglow block, set the genesis certificate.
@@ -7354,6 +7441,82 @@ impl Bank {
     /// Returns true when this bank is using slot params beyond its genesis baseline.
     pub fn slot_time_reduction_active(&self) -> bool {
         self.ns_per_slot != self.slot_params.baseline_params().ns_per_slot()
+    }
+}
+
+#[cfg(all(test, feature = "dev-context-only-utils"))]
+mod alpenglow_rollback_tests {
+    use {
+        super::*,
+        crate::genesis_utils::{activate_alpenglow_at_genesis, create_genesis_config},
+    };
+
+    #[test]
+    fn test_new_from_parent_for_alpenglow_rollback() {
+        const SLOTS_PER_EPOCH: Slot = 32;
+        let mut genesis_config = create_genesis_config(1_000_000).genesis_config;
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
+        let genesis_hashes_per_tick = genesis_config.poh_config.hashes_per_tick;
+        activate_alpenglow_at_genesis(&mut genesis_config);
+        genesis_config.poh_config.hashes_per_tick = genesis_hashes_per_tick;
+
+        let (genesis_bank, _bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        genesis_bank.set_hashes_per_tick(None);
+
+        let first_reduced_slot = genesis_bank.epoch_schedule().get_first_slot_in_epoch(1);
+        let reduced_epoch_bank = Arc::new(Bank::new_from_parent(
+            genesis_bank,
+            SlotLeader::default(),
+            first_reduced_slot,
+        ));
+        let source_slot = first_reduced_slot + 1;
+        let source = Arc::new(Bank::new_from_parent(
+            reduced_epoch_bank,
+            SlotLeader::default(),
+            source_slot,
+        ));
+        source.update_clock_from_footer(1_234_567_890);
+        let expected_tower_hashes_per_tick = source.current_slot_params().hashes_per_tick();
+        assert_ne!(expected_tower_hashes_per_tick, genesis_hashes_per_tick);
+        let source_capitalization = source.capitalization();
+        let source_data_size_discrepancy = i128::from(source.load_accounts_data_size())
+            - i128::from(source.calculate_accounts_data_size().unwrap());
+        let rollback_slot = source_slot + 1;
+
+        let bank = Bank::new_from_parent_for_alpenglow_rollback(
+            source,
+            SlotLeader::default(),
+            rollback_slot,
+        );
+
+        assert!(!bank.is_alpenglow());
+        assert!(!bank.feature_set.is_active(&feature_set::alpenglow::id()));
+        assert_eq!(bank.hashes_per_tick(), expected_tower_hashes_per_tick);
+        assert!(
+            [
+                feature_set::alpenglow::id(),
+                *GENESIS_CERTIFICATE_ACCOUNT,
+                *NANOSECOND_CLOCK_ACCOUNT,
+            ]
+            .iter()
+            .all(|address| bank.get_balance(address) == 0)
+        );
+        assert!(
+            bank.hard_forks()
+                .iter()
+                .any(|hard_fork| *hard_fork == (rollback_slot, 1))
+        );
+        let restart_slot: LastRestartSlot =
+            from_account(&bank.get_account(&sysvar::last_restart_slot::id()).unwrap()).unwrap();
+        assert_eq!(restart_slot.last_restart_slot, rollback_slot);
+        assert_eq!(bank.capitalization(), source_capitalization);
+        assert_eq!(
+            i128::from(bank.load_accounts_data_size())
+                - i128::from(bank.calculate_accounts_data_size().unwrap()),
+            source_data_size_discrepancy
+        );
     }
 }
 


### PR DESCRIPTION
#### Problem
In case of a disaster it would be nice to rollback the alpenglow feature activation with ledger-tool

#### Summary of Changes
add a `--rollback-alpenglow` option to `create-snapshot`:
- Deactivate the feature flag
- Remove the genesis certificate/alpenglow clock/ag rewards off-curve accounts
- Deal with rewards 😮‍💨 
  - Remove the migration marker for each vote account which indicates "all future credits should be paid as AG"
  - For the current AG epoch that has not yet been paid reset the epoch credits to 0
  - Reset delegations to credits observed 0
  - This ensures that further rewards will be calculated correctly, but loses historical tracking and any rewards for AG slots in the current epoch
- Restore PoH config

#### Limitations
Cannot be used when PER distribution is active or SIMD-123 is active
needs `--enable-capitilization-change` 

#### Testing
Tested on a 3 node `multinode-demo` cluster:

1. Start with AG inactive
2. Activate and migrate
3. Finalize some AG blocks
4. Before the migration epoch ended, kill the cluster
5. Hard fork with `--rollback-alpenglow` and WFSM
6. See that Tower proceeds as normal
7. Migrate again
8. This time wait for a couple epochs to rollover then kill the cluster
9. Hard fork with `--rollback-alpenglow` and WFSM
10. See that Tower proceeds as normal

Will test on the community cluster before merging as well