### PR TITLE
fix(svm-timings): coalesce_error_timings leaves total_errored_units stale

### DIFF
--- a/svm-timings/src/lib.rs
+++ b/svm-timings/src/lib.rs
@@ -23,15 +23,6 @@ pub struct ProgramTiming {
 }
 
 impl ProgramTiming {
-    pub fn coalesce_error_timings(&mut self, current_estimated_program_cost: u64) {
-        for tx_error_compute_consumed in self.errored_txs_compute_consumed.drain(..) {
-            let compute_units_update =
-                std::cmp::max(current_estimated_program_cost, tx_error_compute_consumed);
-            self.accumulated_units += compute_units_update;
-            self.count += 1;
-        }
-    }
-
     pub fn accumulate_program_timings(&mut self, other: &ProgramTiming) {
         self.accumulated_us += other.accumulated_us;
         self.accumulated_units += other.accumulated_units;


### PR DESCRIPTION
`ProgramTiming` documents the invariant on the field itself:

```rust
pub errored_txs_compute_consumed: Vec<u64>,
// Sum of all units in `errored_txs_compute_consumed`
pub total_errored_units: Saturating<u64>,
```

`coalesce_error_timings` drains the vector and leaves the sum standing, so afterwards the field summarises an empty vector with a non-zero number. `accumulate_program_timings` then folds that value into another `ProgramTiming`, where it is added to a `total_errored_units` whose own vector never held those units.

There is no in-tree caller today, so this is reachable through the published `solana-svm-timings` API behind `agave-unstable-api` rather than through the validator.

`coalesce_error_timings` had no test at all, so the one added covers the whole call rather than the single line: two entries, 1000 and 100, drained against an estimate of 500, which exercises both sides of the `max` floor.

    accumulated_units  1000 + 500 = 1500
    count              2
    errored_txs_compute_consumed  empty
    total_errored_units           0

Reverting only the reset fails on `left: 1100, right: 0`; deleting the function body outright fails on `is_empty()`, so neither half passes on its own.

`cargo test -p solana-svm-timings --features agave-unstable-api` gives 4 passed. Without the feature the crate runs 0 tests and prints `ok`, because line 1 is `#![cfg(feature = "agave-unstable-api")]`.
