### PR TITLE
ledger-tool: Simplify latest-optimistic-slots output

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -678,10 +678,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let slots =
                 get_latest_optimistic_slots(&blockstore, num_slots, exclude_vote_only_slots);
 
-            println!(
-                "{:>20} {:>44} {:>32} {:>13}",
-                "Slot", "Bank Hash", "Timestamp", "Vote Only?"
-            );
             for (slot, hash_and_timestamp_opt, contains_nonvote) in slots.iter() {
                 let (time_str, hash_str) = if let Some((hash, timestamp)) = hash_and_timestamp_opt {
                     let secs: u64 = (timestamp / 1_000) as u64;
@@ -694,9 +690,10 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                     let unknown = "Unknown";
                     (String::from(unknown), String::from(unknown))
                 };
+                let vote_only = !contains_nonvote;
                 println!(
-                    "{:>20} {:>44} {:>32} {:>13}",
-                    slot, hash_str, time_str, !contains_nonvote
+                    "Slot {slot}\n  Bank Hash: {hash_str:>44}, Timestamp: {time_str}, Vote Only: \
+                     {vote_only}",
                 );
             }
         }


### PR DESCRIPTION
#### Problem
The command currently prints the output as a table with a header row. No other ledger-tool command prints output like this 

#### Summary of Changes
Remove the header and just print the output with colons and commas like other commands

#### Testing
Old
```
                Slot                                    Bank Hash                        Timestamp    Vote Only?
                  82 J5qHBXLG2KXDgrAbx1Yvg4q47DU4aUoNy87xYMduvtPW    2026-08-31T02:39:41.037+00:00          true
                  81 7KGGNbTTSPY61fqQnB9UjKGo8sPCxdC54JLEvqRCcTb4    2026-08-31T02:39:40.560+00:00          true
```
New
```
Slot 82
  Bank Hash: J5qHBXLG2KXDgrAbx1Yvg4q47DU4aUoNy87xYMduvtPW, Timestamp: 2026-08-31T02:39:41.037+00:00, Vote Only: true
Slot 81
  Bank Hash: 7KGGNbTTSPY61fqQnB9UjKGo8sPCxdC54JLEvqRCcTb4, Timestamp: 2026-08-31T02:39:40.560+00:00, Vote Only: true
```