### PR TITLE
core: Update repair TokenBucket refund mechanism

### DIFF
--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1618,7 +1618,10 @@ impl ServeRepair {
             stats.processed += 1;
             let Some(rsp) = self.handle_repair(recycler, &from_addr, request, stats, ping_cache)
             else {
-                data_budget.add_tokens(max_response_cost as u64);
+                // some work was done to attempt to service the request so
+                // return 95% of the borrowed tokens
+                let partial_refund = max_response_cost.saturating_sub(max_response_cost / 20);
+                data_budget.add_tokens(partial_refund as u64);
                 continue;
             };
             let num_response_packets = rsp.len();


### PR DESCRIPTION
#### Problem
Repair uses a token system to throttle requests. The system works by:
- Reserve max number of tokens
- Attempt to serve the request
    - If successful, count the tokens used and refund the difference
    - If unsuccessful, refund the full amount

Even if an attempt is unsuccessful, some work has been done by the validator.

#### Summary of Changes
Update to give a partial (instead of full) refund when serving a request is attempted but unsuccessful (ie missing data)

#### Testing
None yet