### PR TITLE
chore(dep): bump shuttle from 0.7.1 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03efed02df0504d71e44bfd51d3329f401b8303a2fd14254acf05c95a0af0153"
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +1966,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "corosensei"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6886a0c0f263965933c438626e7179139a62b978a33aa18281cbf0cd5a975f34"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.4",
+ "libc",
+ "scopeguard",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -4878,6 +4897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "owo-colors"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,11 +6620,80 @@ dependencies = [
  "bitvec",
  "generator",
  "hex",
- "owo-colors",
+ "owo-colors 3.5.0",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_pcg 0.3.1",
  "scoped-tls",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "shuttle"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786792d8bc94c770b53a938f0ae68726387a3a0a3762f9cc2c38d5e1bb40f0c0"
+dependencies = [
+ "bitvec",
+ "cfg-if 1.0.4",
+ "const-siphasher",
+ "corosensei",
+ "hex",
+ "owo-colors 4.4.0",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_pcg 0.3.1",
+ "scoped-tls",
+ "shuttle-engine",
+ "shuttle-schedulers",
+ "shuttle-std",
+ "tracing",
+]
+
+[[package]]
+name = "shuttle-engine"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb03d6daa3cf319f53bef382ee4431203c770912209703452033d19fb71e813b"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if 1.0.4",
+ "const-siphasher",
+ "corosensei",
+ "hex",
+ "owo-colors 4.4.0",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_pcg 0.3.1",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "shuttle-schedulers"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7673a579e1660404067f5aa1344d6530f15b59f53b0fe98767d7ab117d14067"
+dependencies = [
+ "rand 0.8.6",
+ "rand_pcg 0.3.1",
+ "shuttle-engine",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "shuttle-std"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4a3088fd2d19e5ebc24bc3779bc85a68228fafde2d87d138e475b8591dc721"
+dependencies = [
+ "assoc",
+ "owo-colors 4.4.0",
+ "shuttle-engine",
  "smallvec",
  "tracing",
 ]
@@ -7253,7 +7347,7 @@ dependencies = [
  "criterion",
  "qualifier_attr",
  "rand 0.9.4",
- "shuttle",
+ "shuttle 0.9.3",
  "solana-account 4.6.0",
  "solana-bincode",
  "solana-bpf-loader-program",
@@ -8879,7 +8973,7 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
- "shuttle",
+ "shuttle 0.9.3",
  "smallvec",
  "solana-account 4.6.0",
  "solana-accounts-db",
@@ -9153,7 +9247,7 @@ dependencies = [
  "pcap-file",
  "rand 0.9.4",
  "serde",
- "shuttle",
+ "shuttle 0.9.3",
  "socket2 0.6.5",
  "solana-net-utils",
  "solana-serde",
@@ -9326,7 +9420,7 @@ dependencies = [
  "log",
  "qualifier_attr",
  "rand 0.9.4",
- "shuttle",
+ "shuttle 0.9.3",
  "solana-clock",
  "solana-entry",
  "solana-hash 4.6.0",
@@ -10086,7 +10180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shuttle",
+ "shuttle 0.9.3",
  "smallvec",
  "solana-account 4.6.0",
  "solana-account-decoder",
@@ -10238,7 +10332,7 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "rustc-demangle",
- "shuttle",
+ "shuttle 0.7.1",
  "thiserror 2.0.20",
  "winapi",
 ]
@@ -10710,7 +10804,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "shuttle",
+ "shuttle 0.9.3",
  "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
@@ -10829,7 +10923,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "futures 0.3.34",
  "rand 0.9.4",
- "shuttle",
+ "shuttle 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,7 +339,7 @@ serde_with = { version = "3.22.0", default-features = false }
 serde_yaml = "0.9.34"
 serial_test = "4.0.1"
 shaq = { version = "4.0.0" }
-shuttle = "0.7.1"
+shuttle = "0.9.3"
 signal-hook = "0.4.4"
 slab = "0.4.12"
 slotmap = "1.0.7"


### PR DESCRIPTION
#### Problem


#### Summary of Changes


#### Testing


Fixes #
