### PR TITLE
geyser: mirror the block footer types in the plugin interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,8 +172,8 @@ name = "agave-geyser-plugin-interface"
 version = "4.4.0-alpha.2"
 dependencies = [
  "log",
+ "solana-bls-signatures",
  "solana-clock",
- "solana-entry",
  "solana-hash 4.6.0",
  "solana-message",
  "solana-signature",
@@ -8496,6 +8496,7 @@ name = "solana-geyser-plugin-manager"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-geyser-plugin-interface",
+ "agave-votor-messages",
  "arc-swap",
  "bs58",
  "crossbeam-channel",
@@ -8507,6 +8508,7 @@ dependencies = [
  "serde_json",
  "solana-account 4.6.0",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-entry",
  "solana-gossip",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -147,8 +147,8 @@ name = "agave-geyser-plugin-interface"
 version = "4.4.0-alpha.2"
 dependencies = [
  "log",
+ "solana-bls-signatures",
  "solana-clock",
- "solana-entry",
  "solana-hash 4.6.0",
  "solana-message",
  "solana-signature",

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -330,6 +330,30 @@ pub struct VotesAggregate {
 }
 
 impl VotesAggregate {
+    /// Creates a new `VotesAggregate` from a compressed signature and bitmap.
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new(signature: BLSSignatureCompressed, bitmap: Vec<u8>) -> Self {
+        Self { signature, bitmap }
+    }
+
+    /// Returns a reference to the compressed signature.
+    pub fn signature(&self) -> &BLSSignatureCompressed {
+        &self.signature
+    }
+
+    /// Returns a reference to the bitmap.
+    pub fn bitmap(&self) -> &[u8] {
+        &self.bitmap
+    }
+
+    /// Returns every field of the aggregate. Callers that must not silently
+    /// ignore new fields (e.g. the geyser boundary conversion) bind this
+    /// tuple exhaustively, so growing it breaks them at compile time.
+    pub fn as_parts(&self) -> (&BLSSignatureCompressed, &[u8]) {
+        let Self { signature, bitmap } = self;
+        (signature, bitmap)
+    }
+
     /// Creates a VotesAggregate from a Certificate's signature and bitmap.
     ///
     /// # Panics

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -20,9 +20,9 @@ agave-unstable-api = []
 
 [dependencies]
 log = { workspace = true, features = ["std"] }
+solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
-solana-entry = { workspace = true }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["copy"] }
 solana-message = { workspace = true }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true }

--- a/geyser-plugin-interface/src/block_footer.rs
+++ b/geyser-plugin-interface/src/block_footer.rs
@@ -1,0 +1,102 @@
+//! Borrowed mirrors of the Alpenglow block footer types from `solana-entry`.
+//!
+//! These types mirror `solana_entry::block_component::VersionedBlockFooter`
+//! and the certificate types it embeds, defined here so the plugin interface
+//! does not depend on agave-internal crates. Variable-length data is exposed
+//! as slices rather than owned `Vec`s: `Vec` is `#[repr(Rust)]` with no
+//! stable layout, so only references to slices cross the plugin boundary.
+//! The conversion happens at the agave boundary
+//! (`solana-geyser-plugin-manager`) before a plugin is notified and performs
+//! no allocation; if the internal types drift, that conversion fails to
+//! compile rather than silently breaking plugins.
+
+use {solana_bls_signatures::SignatureCompressed, solana_clock::Slot, solana_hash::Hash};
+
+/// A compressed BLS aggregate signature plus the validator bitmap it covers.
+///
+/// Mirrors `solana_entry::block_component::VotesAggregate`. See
+/// `solana-signer-store` for the bitmap encoding format.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct VotesAggregate<'a> {
+    /// The compressed BLS aggregate signature.
+    pub signature: SignatureCompressed,
+    /// The bitmap identifying the validators covered by the signature.
+    pub bitmap: &'a [u8],
+}
+
+/// Certificate attesting the finalization of a block.
+///
+/// Mirrors `solana_entry::block_component::BlockFinalizationCert`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct BlockFinalizationCert<'a> {
+    /// The slot the certificate is for.
+    pub slot: Slot,
+    /// The block id the certificate is for.
+    pub block_id: Hash,
+    /// The finalization vote aggregate.
+    pub final_aggregate: VotesAggregate<'a>,
+    /// The notarization vote aggregate, when present.
+    pub notar_aggregate: Option<VotesAggregate<'a>>,
+}
+
+/// Reward certificate for the validators that voted skip.
+///
+/// Mirrors `agave_votor_messages::reward_certificate::SkipRewardCertificate`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct SkipRewardCertificate<'a> {
+    /// The slot the certificate is for.
+    pub slot: Slot,
+    /// The compressed BLS signature.
+    pub signature: SignatureCompressed,
+    /// The bitmap identifying the validators covered by the signature.
+    pub bitmap: &'a [u8],
+}
+
+/// Reward certificate for the validators that voted notar.
+///
+/// Mirrors `agave_votor_messages::reward_certificate::NotarRewardCertificate`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct NotarRewardCertificate<'a> {
+    /// The slot the certificate is for.
+    pub slot: Slot,
+    /// The block id the certificate is for.
+    pub block_id: Hash,
+    /// The compressed BLS signature.
+    pub signature: SignatureCompressed,
+    /// The bitmap identifying the validators covered by the signature.
+    pub bitmap: &'a [u8],
+}
+
+/// Block production metadata. User agent is capped at 255 bytes.
+///
+/// Mirrors `solana_entry::block_component::BlockFooterV1`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub struct BlockFooterV1<'a> {
+    /// The bank hash of the block.
+    pub bank_hash: Hash,
+    /// Block production time in nanoseconds since the unix epoch.
+    pub block_producer_time_nanos: u64,
+    /// The user agent of the block producer.
+    pub block_user_agent: &'a [u8],
+    /// Certificate attesting the finalization of the block, when present.
+    pub block_final_cert: Option<BlockFinalizationCert<'a>>,
+    /// Skip reward certificate, when present.
+    pub skip_reward_cert: Option<SkipRewardCertificate<'a>>,
+    /// Notar reward certificate, when present.
+    pub notar_reward_cert: Option<NotarRewardCertificate<'a>>,
+}
+
+/// A versioned Alpenglow block footer.
+///
+/// Mirrors `solana_entry::block_component::VersionedBlockFooter`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(C)]
+pub enum VersionedBlockFooter<'a> {
+    /// Version 1 of the block footer.
+    V1(BlockFooterV1<'a>),
+}

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,8 +3,8 @@
 //! In addition, the dynamic library must export a "C" function _create_plugin which
 //! creates the implementation of the plugin.
 use {
+    crate::block_footer::VersionedBlockFooter,
     solana_clock::{BankId, Slot, UnixTimestamp},
-    solana_entry::block_component::VersionedBlockFooter,
     solana_hash::Hash,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
@@ -350,13 +350,18 @@ pub struct ReplicaBlockFooterInfo<'a> {
     /// The slot containing the block footer.
     pub slot: Slot,
     /// The versioned block footer.
-    pub block_footer: &'a VersionedBlockFooter,
+    pub block_footer: &'a VersionedBlockFooter<'a>,
 }
 
 /// A wrapper to future-proof ReplicaBlockFooterInfo handling.
+///
+/// `V0_0_1` carried `solana_entry::block_component::VersionedBlockFooter`
+/// and shipped through v4.3; it was removed when the payload became the
+/// `block_footer` mirror types. The explicit discriminant keeps the two
+/// formats distinguishable across plugin builds.
 #[repr(u32)]
 pub enum ReplicaBlockFooterInfoVersions<'a> {
-    V0_0_1(&'a ReplicaBlockFooterInfo<'a>),
+    V0_0_2(&'a ReplicaBlockFooterInfo<'a>) = 1,
 }
 
 #[derive(Clone, Debug)]

--- a/geyser-plugin-interface/src/lib.rs
+++ b/geyser-plugin-interface/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod block_footer;
 pub mod geyser_plugin_interface;

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -47,5 +47,10 @@ solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+agave-votor-messages = { workspace = true }
+solana-bls-signatures = { workspace = true }
+solana-entry = { path = "../entry", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
 [lints]
 workspace = true

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -1,18 +1,91 @@
 /// Module responsible for notifying plugins about entries
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
-    agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockFooterInfo, ReplicaBlockFooterInfoVersions, ReplicaEntryInfoV2,
-        ReplicaEntryInfoVersions, ReplicaEntryUpdateParentInfo,
-        ReplicaEntryUpdateParentInfoVersions,
+    agave_geyser_plugin_interface::{
+        block_footer,
+        geyser_plugin_interface::{
+            ReplicaBlockFooterInfo, ReplicaBlockFooterInfoVersions, ReplicaEntryInfoV2,
+            ReplicaEntryInfoVersions, ReplicaEntryUpdateParentInfo,
+            ReplicaEntryUpdateParentInfoVersions,
+        },
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::{BankId, Slot},
-    solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
+    solana_entry::{block_component, entry::EntrySummary},
     solana_ledger::entry_notifier_interface::{EntryNotifier, EntryUpdateParentInfo},
     std::sync::Arc,
 };
+
+/// Converts the internal block footer into the plugin interface mirror.
+///
+/// The mirror borrows all variable-length data from the internal footer, so
+/// the conversion allocates nothing. The exhaustive destructuring below is
+/// deliberate: if a field is added to any of the internal types, this stops
+/// compiling instead of silently dropping data on the plugin boundary.
+fn convert_block_footer(
+    footer: &block_component::VersionedBlockFooter,
+) -> block_footer::VersionedBlockFooter<'_> {
+    match footer {
+        block_component::VersionedBlockFooter::V1(block_component::BlockFooterV1 {
+            bank_hash,
+            block_producer_time_nanos,
+            block_user_agent,
+            block_final_cert,
+            skip_reward_cert,
+            notar_reward_cert,
+        }) => block_footer::VersionedBlockFooter::V1(block_footer::BlockFooterV1 {
+            bank_hash: *bank_hash,
+            block_producer_time_nanos: *block_producer_time_nanos,
+            block_user_agent,
+            block_final_cert: block_final_cert.as_ref().map(convert_finalization_cert),
+            skip_reward_cert: skip_reward_cert.as_ref().map(|cert| {
+                let (slot, signature, bitmap) = cert.as_parts();
+                block_footer::SkipRewardCertificate {
+                    slot,
+                    signature: *signature,
+                    bitmap,
+                }
+            }),
+            notar_reward_cert: notar_reward_cert.as_ref().map(|cert| {
+                let (slot, block_id, signature, bitmap) = cert.as_parts();
+                block_footer::NotarRewardCertificate {
+                    slot,
+                    block_id: *block_id,
+                    signature: *signature,
+                    bitmap,
+                }
+            }),
+        }),
+    }
+}
+
+fn convert_finalization_cert(
+    cert: &block_component::BlockFinalizationCert,
+) -> block_footer::BlockFinalizationCert<'_> {
+    let block_component::BlockFinalizationCert {
+        slot,
+        block_id,
+        final_aggregate,
+        notar_aggregate,
+    } = cert;
+    block_footer::BlockFinalizationCert {
+        slot: *slot,
+        block_id: *block_id,
+        final_aggregate: convert_votes_aggregate(final_aggregate),
+        notar_aggregate: notar_aggregate.as_ref().map(convert_votes_aggregate),
+    }
+}
+
+fn convert_votes_aggregate(
+    aggregate: &block_component::VotesAggregate,
+) -> block_footer::VotesAggregate<'_> {
+    let (signature, bitmap) = aggregate.as_parts();
+    block_footer::VotesAggregate {
+        signature: *signature,
+        bitmap,
+    }
+}
 
 pub(crate) struct EntryNotifierImpl {
     plugin_manager: Arc<ArcSwap<GeyserPluginManager>>,
@@ -60,20 +133,24 @@ impl EntryNotifier for EntryNotifierImpl {
         &self,
         slot: Slot,
         bank_id: BankId,
-        block_footer: &VersionedBlockFooter,
+        block_footer: &block_component::VersionedBlockFooter,
     ) {
         let plugin_manager = self.plugin_manager.load();
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
-        let block_footer_info = ReplicaBlockFooterInfo { slot, block_footer };
+        let block_footer = convert_block_footer(block_footer);
+        let block_footer_info = ReplicaBlockFooterInfo {
+            slot,
+            block_footer: &block_footer,
+        };
         for plugin in plugin_manager.plugins.iter() {
             if !plugin.block_footer_notifications_enabled() {
                 continue;
             }
             match plugin.notify_block_footer(
-                ReplicaBlockFooterInfoVersions::V0_0_1(&block_footer_info),
+                ReplicaBlockFooterInfoVersions::V0_0_2(&block_footer_info),
                 bank_id,
             ) {
                 Err(err) => error!(
@@ -140,16 +217,22 @@ mod tests {
         super::*,
         crate::geyser_plugin_manager::{GeyserPluginManager, LoadedGeyserPlugin},
         agave_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin, Result},
+        agave_votor_messages::reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
         arc_swap::ArcSwap,
         libloading::Library,
-        solana_entry::block_component::BlockFooterV1,
+        solana_bls_signatures::{BLS_SIGNATURE_COMPRESSED_SIZE, SignatureCompressed},
+        solana_entry::block_component::{
+            BlockFinalizationCert, BlockFooterV1, VersionedBlockFooter, VotesAggregate,
+        },
         solana_hash::Hash,
         std::sync::{Arc, Mutex},
     };
 
     type EntryUpdate = (Slot, BankId, usize, usize);
     type EntryUpdateParent = (Slot, BankId, Slot, Hash);
-    type BlockFooterUpdate = (Slot, BankId, VersionedBlockFooter);
+    // The mirror borrows from the notifying call's stack, so the mock stores
+    // an owned Debug snapshot instead of the borrowed struct itself.
+    type BlockFooterUpdate = (Slot, BankId, String);
 
     #[derive(Debug)]
     struct TestEntryPlugin {
@@ -187,11 +270,11 @@ mod tests {
             block_footer: ReplicaBlockFooterInfoVersions,
             bank_id: BankId,
         ) -> Result<()> {
-            let ReplicaBlockFooterInfoVersions::V0_0_1(block_footer) = block_footer;
+            let ReplicaBlockFooterInfoVersions::V0_0_2(block_footer) = block_footer;
             self.block_footer_updates.lock().unwrap().push((
                 block_footer.slot,
                 bank_id,
-                block_footer.block_footer.clone(),
+                format!("{:?}", block_footer.block_footer),
             ));
             Ok(())
         }
@@ -264,14 +347,53 @@ mod tests {
             hash: Hash::new_unique(),
             num_transactions: 2,
         };
+        let bank_hash = Hash::new_unique();
+        let block_id = Hash::new_unique();
+        let signature = SignatureCompressed([7; BLS_SIGNATURE_COMPRESSED_SIZE]);
         let block_footer = VersionedBlockFooter::V1(BlockFooterV1 {
-            bank_hash: Hash::new_unique(),
+            bank_hash,
             block_producer_time_nanos: 123,
             block_user_agent: b"test-validator".to_vec(),
-            block_final_cert: None,
-            skip_reward_cert: None,
-            notar_reward_cert: None,
+            block_final_cert: Some(BlockFinalizationCert {
+                slot: 42,
+                block_id,
+                final_aggregate: VotesAggregate::new(signature, vec![1, 2, 3]),
+                notar_aggregate: Some(VotesAggregate::new(signature, vec![4, 5])),
+            }),
+            skip_reward_cert: Some(SkipRewardCertificate::try_new(41, signature, vec![6]).unwrap()),
+            notar_reward_cert: Some(
+                NotarRewardCertificate::try_new(42, block_id, signature, vec![8]).unwrap(),
+            ),
         });
+        let expected_block_footer =
+            block_footer::VersionedBlockFooter::V1(block_footer::BlockFooterV1 {
+                bank_hash,
+                block_producer_time_nanos: 123,
+                block_user_agent: b"test-validator",
+                block_final_cert: Some(block_footer::BlockFinalizationCert {
+                    slot: 42,
+                    block_id,
+                    final_aggregate: block_footer::VotesAggregate {
+                        signature,
+                        bitmap: &[1, 2, 3],
+                    },
+                    notar_aggregate: Some(block_footer::VotesAggregate {
+                        signature,
+                        bitmap: &[4, 5],
+                    }),
+                }),
+                skip_reward_cert: Some(block_footer::SkipRewardCertificate {
+                    slot: 41,
+                    signature,
+                    bitmap: &[6],
+                }),
+                notar_reward_cert: Some(block_footer::NotarRewardCertificate {
+                    slot: 42,
+                    block_id,
+                    signature,
+                    bitmap: &[8],
+                }),
+            });
         let parent_block_id = Hash::new_unique();
 
         notifier.notify_entry(42, 9, 3, &entry, 7);
@@ -301,7 +423,7 @@ mod tests {
         );
         assert_eq!(
             *block_footer_plugin_block_footer_updates.lock().unwrap(),
-            vec![(42, 9, block_footer)]
+            vec![(42, 9, format!("{expected_block_footer:?}"))]
         );
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -147,8 +147,8 @@ name = "agave-geyser-plugin-interface"
 version = "4.4.0-alpha.2"
 dependencies = [
  "log",
+ "solana-bls-signatures",
  "solana-clock",
- "solana-entry",
  "solana-hash 4.6.0",
  "solana-message",
  "solana-signature",

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -68,6 +68,19 @@ impl SkipRewardCertificate {
     pub fn into_bitmap(self) -> Vec<u8> {
         self.bitmap
     }
+
+    /// Returns every field of the certificate. Callers that must not
+    /// silently ignore new fields (e.g. the geyser boundary conversion)
+    /// bind this tuple exhaustively, so growing it breaks them at compile
+    /// time.
+    pub fn as_parts(&self) -> (Slot, &BLSSignatureCompressed, &[u8]) {
+        let Self {
+            slot,
+            signature,
+            bitmap,
+        } = self;
+        (*slot, signature, bitmap)
+    }
 }
 
 /// Reward certificate for the validators that voted notar.
@@ -107,6 +120,20 @@ impl NotarRewardCertificate {
     /// Returns a reference to the bitmap.
     pub fn bitmap(&self) -> &[u8] {
         &self.bitmap
+    }
+
+    /// Returns every field of the certificate. Callers that must not
+    /// silently ignore new fields (e.g. the geyser boundary conversion)
+    /// bind this tuple exhaustively, so growing it breaks them at compile
+    /// time.
+    pub fn as_parts(&self) -> (Slot, &Hash, &BLSSignatureCompressed, &[u8]) {
+        let Self {
+            slot,
+            block_id,
+            signature,
+            bitmap,
+        } = self;
+        (*slot, block_id, signature, bitmap)
     }
 
     /// Returns the bitmap consuming self.


### PR DESCRIPTION
Follow up to the discussion on #14905. First of the two type-unwrap PRs, the footer one since it's small and self-contained and it's what actually unblocks the alpenglow coupling.

`ReplicaBlockFooterInfo` currently embeds `solana_entry::block_component::VersionedBlockFooter`, which drags `solana-entry` (and through it `agave-votor-messages` and the BLS cert types, all `=` pinned and churning with alpenglow) into the plugin interface's dependency graph. That's one of the two blockers for moving the interface out of the monorepo.

This adds borrowed mirrors of `VersionedBlockFooter` / `BlockFooterV1` / `BlockFinalizationCert` / `VotesAggregate` / `SkipRewardCertificate` / `NotarRewardCertificate` to a new `block_footer` module in `agave-geyser-plugin-interface`. Per the FFI point raised in #14905, variable-length data is exposed as `&'a [u8]` slices rather than owned `Vec`s (`Vec` is `#[repr(Rust)]`, no stable layout), so the boundary conversion in `solana-geyser-plugin-manager` allocates nothing. The conversion destructures the internal types exhaustively, so if a field is added upstream this stops compiling rather than silently dropping data on the plugin boundary.

With this the interface crate drops its `solana-entry` dependency entirely.. its only remaining agave-internal dep on that side is `solana-transaction-status` (the `TransactionStatusMeta` blocker, which gets the same borrowed-mirror treatment in a follow-up PR).

Also adds `new()` / `signature()` / `bitmap()` to `VotesAggregate` in `solana-entry`, which previously had no non-consuming accessors.
