### PR TITLE
Revert "Various perf improvements to bls-sigverify (#14934)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9008,7 +9008,6 @@ dependencies = [
  "serial_test",
  "solana-account 4.6.0",
  "solana-accounts-db",
- "solana-bls-signatures",
  "solana-client-traits",
  "solana-clock",
  "solana-cluster-type",

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -562,9 +562,7 @@ mod tests {
         bitvec::prelude::{BitVec, Lsb0},
         bytes::Bytes,
         crossbeam_channel::{Receiver, TryRecvError, bounded},
-        solana_bls_signatures::{
-            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature, signature::SignatureAffine,
-        },
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature},
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
@@ -736,7 +734,7 @@ mod tests {
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
         let payload = get_vote_payload_to_sign(vote, shred_version);
-        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
+        let signature: Signature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,
             signature,
@@ -975,13 +973,10 @@ mod tests {
         expect_no_receive(&ctx.pool_receiver);
 
         // Send a packet with invalid rank
-        let vote = Vote::new_finalization_vote(5);
-        let payload = get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
-        let signature = SignatureAffine::from(ctx.validator_keypairs[0].bls_keypair.sign(&payload));
         let messages_invalid_rank = [(
             ConsensusMessage::Vote(VoteMessage {
                 vote: Vote::new_finalization_vote(5),
-                signature,
+                signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 rank: 1000, // Invalid rank
                 stake: NonZero::new(123).unwrap(),
             }),
@@ -1129,7 +1124,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
+            let signature: Signature = bls_keypair.sign(&vote_payload).into();
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1273,9 +1268,9 @@ mod tests {
             };
 
             let signature = if rank == invalid_rank {
-                SignatureAffine::from(bls_keypair.sign(&invalid_payload)) // Invalid signature
+                bls_keypair.sign(&invalid_payload).into() // Invalid signature
             } else {
-                SignatureAffine::from(bls_keypair.sign(payload))
+                bls_keypair.sign(payload).into()
             };
 
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
@@ -1336,9 +1331,9 @@ mod tests {
             let bls_keypair = &validator_keypair.bls_keypair;
 
             let signature = if rank == invalid_rank {
-                SignatureAffine::from(bls_keypair.sign(&invalid_vote_payload)) // Invalid signature
+                bls_keypair.sign(&invalid_vote_payload).into() // Invalid signature
             } else {
-                SignatureAffine::from(bls_keypair.sign(&valid_vote_payload)) // Valid signature
+                bls_keypair.sign(&valid_vote_payload).into() // Valid signature
             };
 
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
@@ -1541,7 +1536,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
+            let signature = bls_keypair.sign(&vote_payload).into();
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1611,7 +1606,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
-        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
+        let signature: Signature = bls_keypair.sign(&vote_payload).into();
 
         let consensus_message = ConsensusMessage::Vote(VoteMessage {
             vote,
@@ -1691,7 +1686,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, sig_verifier.cluster_info.my_shred_version());
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
-        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
+        let signature: Signature = bls_keypair.sign(&vote_payload).into();
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
             vote,
             signature,
@@ -1935,9 +1930,9 @@ mod tests {
             .take(5)
             .map(|(i, keypair)| {
                 let signature = if invalid_indexes.contains(&i) {
-                    SignatureAffine::from(keypair.bls_keypair.sign(&invalid_payload))
+                    keypair.bls_keypair.sign(&invalid_payload).into()
                 } else {
-                    SignatureAffine::from(keypair.bls_keypair.sign(&valid_payload))
+                    keypair.bls_keypair.sign(&valid_payload).into()
                 };
                 let message = ConsensusMessage::Vote(VoteMessage {
                     vote,

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -30,7 +30,6 @@ use {
     solana_bls_signatures::{
         BlsError, PreparedHashedMessage, PubkeyProjective, SignatureProjective,
         pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature},
-        signature::SignatureAffine,
     },
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
@@ -100,12 +99,11 @@ impl UnverifiedVotePayload {
         max_validators: usize,
         prepared_hashed_message: &PreparedHashedMessage,
     ) -> Result<VerifiedVotePayload, BlsError> {
-        let signature = SignatureAffine::try_from(self.vote_message.signature)?;
         self.sender_bls_pubkey
-            .verify_signature_prepared(&signature, prepared_hashed_message)?;
+            .verify_signature_prepared(&self.vote_message.signature, prepared_hashed_message)?;
         let vote_msg = VoteMessage {
             vote: self.vote_message.vote,
-            signature,
+            signature: self.vote_message.signature,
             rank: self.rank,
             stake: self.stake,
         };
@@ -339,31 +337,6 @@ fn verify_votes(
     thread_pool: &ThreadPool,
 ) -> (Vec<VerifiedVotePayload>, VoteVerificationStats) {
     let mut stats = VoteVerificationStats::default();
-
-    // no need to do optimistic verification when batch size == 1.
-    if let [unverified_vote] = unverified_votes.as_slice() {
-        let ((verification_result, sender_identity_pubkey), time_us) = measure_us!({
-            let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
-            let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
-            let sender_identity_pubkey = unverified_vote.sender_identity_pubkey;
-            (
-                unverified_vote.verify(max_validators, &prepared_hash_msg),
-                sender_identity_pubkey,
-            )
-        });
-        stats.fn_verify_individual_votes_stats.add_sample(time_us);
-        return match verification_result {
-            Ok(verified_vote) => {
-                stats.num_individual_verified += 1;
-                (vec![verified_vote], stats)
-            }
-            Err(error) => {
-                ban_invalid_vote_sender(ban_sender, &mut stats, sender_identity_pubkey, error);
-                (Vec::new(), stats)
-            }
-        };
-    }
-
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
     let res = verify_votes_optimistic(
         vote_payload_to_sign,
@@ -408,26 +381,17 @@ fn verify_votes(
                 ));
             stats.num_individual_verified += verified_votes.len() as u64;
             for (sender_identity_pubkey, error) in invalid_remote_pubkeys {
-                ban_invalid_vote_sender(ban_sender, &mut stats, sender_identity_pubkey, error);
+                stats.banning_validator += 1;
+                ban_sender.ban(sender_identity_pubkey, BAN_TIMEOUT);
+                info!(
+                    "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed \
+                     verification {error:?}"
+                );
             }
             stats.fn_verify_individual_votes_stats.add_sample(time_us);
             (verified_votes, stats)
         }
     }
-}
-
-fn ban_invalid_vote_sender(
-    ban_sender: &BanSender,
-    stats: &mut VoteVerificationStats,
-    sender_identity_pubkey: Pubkey,
-    error: BlsError,
-) {
-    stats.banning_validator += 1;
-    ban_sender.ban(sender_identity_pubkey, BAN_TIMEOUT);
-    info!(
-        "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed verification \
-         {error:?}"
-    );
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -40,7 +40,6 @@ rand = { workspace = true }
 rayon = { workspace = true }
 solana-account = { workspace = true, features = ["wincode"] }
 solana-accounts-db = { workspace = true }
-solana-bls-signatures = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -17,7 +17,6 @@ use {
     crossbeam_channel::{Receiver, bounded},
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
-    solana_bls_signatures::signature::SignatureAffine,
     solana_clock::{self as clock, Slot},
     solana_commitment_config::CommitmentConfig,
     solana_core::consensus::tower_storage::{
@@ -687,10 +686,9 @@ fn convert_datagram_to_vote_message(
     let bank = bank_forks.read().unwrap().root_bank();
     let rank_map = bank.get_rank_map(vote_msg.vote.slot())?;
     let (rank, sender_entry) = rank_map.get_ranked_entry_for_node(&sender)?;
-    let signature = SignatureAffine::try_from(vote_msg.signature).ok()?;
     Some(VoteMessage {
         vote: vote_msg.vote,
-        signature,
+        signature: vote_msg.signature,
         rank,
         stake: sender_entry.stake,
     })

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -422,6 +422,6 @@ impl ThreadArg for TvuBlsShredSigverifyThreadsArg {
                                 verification of received Alpenglow consensus messages";
 
     fn default() -> usize {
-        num_cpus::get() * 3 / 4
+        get_thread_count()
     }
 }

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -5,7 +5,7 @@ use {
         vote::Vote,
     },
     serde::{Deserialize, Serialize},
-    solana_bls_signatures::{Signature as BLSSignature, signature::SignatureAffine},
+    solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     solana_hash::Hash,
     std::num::NonZero,
@@ -65,12 +65,12 @@ impl Block {
 }
 
 /// A consensus vote.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
     /// The signature.
-    pub signature: SignatureAffine,
+    pub signature: BLSSignature,
     /// The rank of the validator.
     pub rank: u16,
     /// The stake of the validator
@@ -78,7 +78,7 @@ pub struct VoteMessage {
 }
 
 /// A consensus message sent between validators.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
     /// A vote from a single party.
@@ -89,12 +89,7 @@ pub enum ConsensusMessage {
 
 impl ConsensusMessage {
     /// Create a new vote message
-    pub fn new_vote(
-        vote: Vote,
-        signature: SignatureAffine,
-        rank: u16,
-        stake: NonZero<u64>,
-    ) -> Self {
+    pub fn new_vote(vote: Vote, signature: BLSSignature, rank: u16, stake: NonZero<u64>) -> Self {
         Self::Vote(VoteMessage {
             vote,
             signature,

--- a/votor-messages/src/sig_verified_messages.rs
+++ b/votor-messages/src/sig_verified_messages.rs
@@ -6,7 +6,7 @@ use {
         wire::VotePayloadToSign,
     },
     bitvec::vec::BitVec,
-    solana_bls_signatures::{SignatureProjective, signature::SignatureAffine},
+    solana_bls_signatures::{Signature as BLSSignature, SignatureProjective},
     std::num::NonZero,
 };
 
@@ -42,12 +42,12 @@ impl SigVerifiedBatch {
 ///
 /// NOTE: the fields should not be exposed outside of the crate so that users use approved paths to
 /// build it to ensure signature verification takes place.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VoteAggregate {
     /// The type of vote in the batch.
     vote: Vote,
     /// The aggregate signature of the votes in the batch.
-    signature: SignatureAffine,
+    signature: BLSSignature,
     /// The total stake in the batch.
     stake: NonZero<u64>,
     /// Ranks of the various validators whose votes are in the batch.
@@ -114,7 +114,7 @@ impl VoteAggregate {
     }
 
     /// Accessor for the signature.
-    pub fn signature(&self) -> &SignatureAffine {
+    pub fn signature(&self) -> &BLSSignature {
         &self.signature
     }
 

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -85,8 +85,9 @@ pub(crate) struct WireVoteSignature {
 
 impl From<VoteMessage> for WireVoteSignature {
     fn from(msg: VoteMessage) -> Self {
-        let signature = BLSSignature::from(msg.signature);
-        Self { signature }
+        Self {
+            signature: msg.signature,
+        }
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -584,7 +584,7 @@ mod tests {
         bitvec::vec::BitVec,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature, VerifiableSignature,
-            keypair::Keypair as BLSKeypair, signature::SignatureAffine,
+            keypair::Keypair as BLSKeypair,
         },
         solana_clock::Slot,
         solana_hash::Hash,
@@ -746,7 +746,7 @@ mod tests {
                 .unwrap()
                 .stake;
             let payload = get_vote_payload_to_sign(vote, self.pool.cluster_info.my_shred_version());
-            let signature = SignatureAffine::from(bls_keypair.sign(&payload));
+            let signature: BLSSignature = bls_keypair.sign(&payload).into();
             VoteMessage {
                 vote,
                 signature,
@@ -804,7 +804,7 @@ mod tests {
             .unwrap()
             .stake;
         let payload = get_vote_payload_to_sign(*vote, shred_version);
-        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
+        let signature: BLSSignature = bls_keypair.sign(&payload).into();
         let msg = VoteMessage {
             vote: *vote,
             signature,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1055,7 +1055,9 @@ mod tests {
         },
         crossbeam_channel::{Receiver, Sender, TryRecvError, bounded},
         parking_lot::RwLock as PlRwLock,
-        solana_bls_signatures::{keypair::Keypair as BLSKeypair, signature::SignatureAffine},
+        solana_bls_signatures::{
+            keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
+        },
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_ledger::{
@@ -1509,7 +1511,7 @@ mod tests {
         fn expected_vote_message(&self, expected_vote: &Vote) -> VoteMessage {
             let payload =
                 get_vote_payload_to_sign(*expected_vote, self.cluster_info.my_shred_version());
-            let signature = SignatureAffine::from(self.my_bls_keypair.sign(&payload));
+            let signature: BLSSignature = self.my_bls_keypair.sign(&payload).into();
             let root_bank = self.bank_forks.read().unwrap().root_bank();
             let rank_map = root_bank.get_rank_map(expected_vote.slot()).unwrap();
             let stake = rank_map.get_pubkey_stake_entry(0).unwrap().stake;

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -368,7 +368,6 @@ mod tests {
             consensus_message::{ConsensusMessage, VoteMessage},
             migration::MigrationStatus,
             vote::Vote,
-            wire::get_vote_payload_to_sign,
         },
         agave_votor_transport::{
             PeerList, PeerListReceiver, PeerListSender,
@@ -378,10 +377,7 @@ mod tests {
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded, unbounded},
         rand::Rng,
-        solana_bls_signatures::{
-            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BlsKeypair, Signature as BLSSignature,
-            signature::SignatureAffine,
-        },
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
@@ -415,21 +411,14 @@ mod tests {
         shred_verion: u16,
     ) -> VersionedWireConsensusMessage {
         VersionedWireConsensusMessage::new_from_vote(
-            test_vote(vote, rank, shred_verion),
+            VoteMessage {
+                vote,
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                rank,
+                stake: NonZero::new(123).unwrap(),
+            },
             shred_verion,
         )
-    }
-
-    fn test_vote(vote: Vote, rank: u16, shred_version: u16) -> VoteMessage {
-        let bls_keypair = BlsKeypair::new();
-        let payload = get_vote_payload_to_sign(vote, shred_version);
-        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
-        VoteMessage {
-            vote,
-            signature,
-            rank,
-            stake: NonZero::new(123).unwrap(),
-        }
     }
 
     fn test_certificate_message(
@@ -634,29 +623,45 @@ mod tests {
         )
     }
 
-    #[test_case(BLSOp::PushVote { vote: Arc::new(test_vote(Vote::new_skip_vote(5), 1, 0)) }, None)]
+    #[test_case(BLSOp::PushVote {
+        vote: Arc::new(VoteMessage {
+            vote: Vote::new_skip_vote(5),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            rank: 1,
+            stake:NonZero::new(123).unwrap()
+        }),
+    }, ConsensusMessage::Vote(VoteMessage {
+        vote: Vote::new_skip_vote(5),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+        rank: 1,
+        stake:NonZero::new(123).unwrap()
+    }))]
     #[test_case(BLSOp::PushCertificates {
         certificates: vec![Arc::new(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
         })],
-    }, Some(ConsensusMessage::Certificate(Certificate {
+    }, ConsensusMessage::Certificate(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
-    })))]
+    }))]
     #[test_case(BLSOp::RefreshVotes {
-        votes: vec![Arc::new(test_vote(Vote::new_skip_vote(6), 1, 0))],
-    }, None)]
-    fn test_send_message(bls_op: BLSOp, expected_message: Option<ConsensusMessage>) {
+        votes: vec![Arc::new(VoteMessage {
+        vote: Vote::new_skip_vote(6),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+        rank: 1,
+        stake:NonZero::new(123).unwrap()
+        })],
+    }, ConsensusMessage::Vote(VoteMessage {
+        vote: Vote::new_skip_vote(6),
+        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+        rank: 1,
+        stake:NonZero::new(123).unwrap()
+    }))]
+    fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {
         agave_logger::setup();
-
-        let expected_message = expected_message.unwrap_or_else(|| match &bls_op {
-            BLSOp::PushVote { vote } => ConsensusMessage::Vote((**vote).clone()),
-            BLSOp::RefreshVotes { votes } => ConsensusMessage::Vote((*votes[0]).clone()),
-            _ => panic!("expected message is required for certificate operations"),
-        });
 
         let listener_kp = Keypair::new();
         let listener_pubkey = listener_kp.pubkey();


### PR DESCRIPTION

#### Problem

We want to potentially backport some of these changes to 4.3.  Mainly the SignatureAffine fix and the singleton fast path fix but not the change in thread pool size.  So we will revert this change and land them in pieces.


#### Summary of Changes

This reverts commit 2c547f41aae1fcf5b45a8558128b424b5ae66bb0.
