### PR TITLE
Updates remaining `Block { ... }` to use `new_unique`

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -760,7 +760,6 @@ pub mod tests {
         },
         serial_test::serial,
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
-        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
             blockstore::BlockstoreSignals,
@@ -842,13 +841,7 @@ pub mod tests {
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let (leader_window_info_sender, _leader_window_info_receiver) = bounded(1024);
         let (optimistic_parent_sender, optimistic_parent_receiver) = bounded(1024);
-        let highest_parent_ready = Arc::new(RwLock::new((
-            0,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        )));
+        let highest_parent_ready = Arc::new(RwLock::new((0, Block::new_unique(0))));
         let (votor_event_sender, votor_event_receiver): (VotorEventSender, VotorEventReceiver) =
             bounded(1024);
         let key_notifiers = Arc::new(RwLock::new(KeyUpdaters::default()));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5250,12 +5250,10 @@ pub mod tests {
 
         let rpc = RpcHandler::start();
         // Seed the bank with a genesis certificate for the RPC to return.
+        let block = Block::new_unique(0);
         rpc.working_bank()
             .set_alpenglow_genesis_certificate(&GenesisCert {
-                block: Block {
-                    slot: 0,
-                    block_id: Hash::default(),
-                },
+                block,
                 signature: CertSignature {
                     signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                     bitmap: vec![1, 2, 3],
@@ -5267,7 +5265,7 @@ pub mod tests {
         let expected = json!({
             "block": {
                 "slot": 0,
-                "blockId": vec![0u8; 32],
+                "blockId": &block.block_id,
             },
             "signature": {
                 "signature": vec![0u8; BLS_SIGNATURE_AFFINE_SIZE],

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -254,10 +254,7 @@ pub mod tests {
         *highest_finalized.write().unwrap() =
             Some(ValidatedBlockFinalizationCert::from_validated_fast(
                 FastFinalizeCert {
-                    block: Block {
-                        slot: 30,
-                        block_id: Hash::default(),
-                    },
+                    block: Block::new_unique(30),
                     signature,
                 },
                 &bank0,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -1035,10 +1035,7 @@ mod tests {
     fn test_initialize_migration_status() {
         let ff_activation_slot = 5;
         let genesis_cert = GenesisCert {
-            block: Block {
-                slot: 1,
-                block_id: Hash::default(),
-            },
+            block: Block::new_unique(1),
             signature: CertSignature {
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -850,10 +850,7 @@ mod tests {
         let migration_slot = migration_status.record_feature_activation(0);
         assert!(genesis_slot < migration_slot);
 
-        let genesis_block = Block {
-            slot: genesis_slot,
-            block_id: Hash::default(),
-        };
+        let genesis_block = Block::new_unique(genesis_slot);
         migration_status.set_genesis_block(genesis_block);
         let cert = Arc::new(GenesisCert {
             block: genesis_block,

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -26,7 +26,6 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_fee_calculator::FeeRateGovernor,
         solana_genesis_config::GenesisConfig,
-        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_leader_schedule::SlotLeader,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -438,10 +437,7 @@ mod tests {
         let bank_with_tower_rewards = state.add_tower_rewards(bank_at_migration0);
 
         let genesis_cert = GenesisCert {
-            block: Block {
-                slot: bank_with_tower_rewards.slot(),
-                block_id: Hash::default(),
-            },
+            block: Block::new_unique(bank_with_tower_rewards.slot()),
             signature: CertSignature {
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -250,10 +250,7 @@ mod tests {
         let (root_bank, _bank_forks) =
             Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
         let genesis_cert = GenesisCert {
-            block: Block {
-                slot: migration_slot,
-                block_id: Hash::default(),
-            },
+            block: Block::new_unique(migration_slot),
             signature: CertSignature {
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: vec![],

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1087,9 +1087,25 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_add_vote_creates_notar_cert() {
+        let block = Block::new_unique(6);
+        test_add_vote_and_create_new_certificate_with_types(
+            Vote::new_notarization_vote(block),
+            vec![CertificateType::Notarize(block)],
+        );
+    }
+
+    #[test]
+    fn test_add_vote_creates_notar_fallback_cert() {
+        let block = Block::new_unique(6);
+        test_add_vote_and_create_new_certificate_with_types(
+            Vote::new_notarization_fallback_vote(block),
+            vec![CertificateType::NotarizeFallback(block)],
+        );
+    }
+
     #[test_case(Vote::new_finalization_vote(5), vec![CertificateType::Finalize(5)])]
-    #[test_case(Vote::new_notarization_vote(Block { slot: 6, block_id: Hash::default() }), vec![CertificateType::Notarize(Block { slot: 6, block_id: Hash::default() })])]
-    #[test_case(Vote::new_notarization_fallback_vote(Block { slot: 7, block_id: Hash::default() }), vec![CertificateType::NotarizeFallback(Block { slot: 7, block_id: Hash::default() })])]
     #[test_case(Vote::new_skip_vote(8), vec![CertificateType::Skip(8)])]
     #[test_case(Vote::new_skip_fallback_vote(9), vec![CertificateType::Skip(9)])]
     fn test_add_vote_and_create_new_certificate_with_types(
@@ -1104,10 +1120,7 @@ mod tests {
         // because finalization requires both Finalize and Notarize certificates
         if vote.is_finalize() {
             let notarize_cert = [Certificate {
-                cert_type: CertificateType::Notarize(Block {
-                    slot: vote.slot(),
-                    block_id: Hash::default(),
-                }),
+                cert_type: CertificateType::Notarize(Block::new_unique(vote.slot())),
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             }];
@@ -1183,19 +1196,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_finalize_fast_cert() {
+        let block = Block::new_unique(6);
+        test_add_certificate_with_types(
+            CertificateType::FinalizeFast(block),
+            Vote::new_notarization_vote(block),
+        );
+    }
+
+    #[test]
+    fn test_notar_cert() {
+        let block = Block::new_unique(6);
+        test_add_certificate_with_types(
+            CertificateType::Notarize(block),
+            Vote::new_notarization_vote(block),
+        );
+    }
+
+    #[test]
+    fn test_notar_fallback_cert() {
+        let block = Block::new_unique(6);
+        test_add_certificate_with_types(
+            CertificateType::NotarizeFallback(block),
+            Vote::new_notarization_fallback_vote(block),
+        );
+    }
+
     #[test_case(CertificateType::Finalize(5), Vote::new_finalization_vote(5))]
-    #[test_case(
-        CertificateType::FinalizeFast(Block { slot: 6, block_id: Hash::default() }),
-        Vote::new_notarization_vote(Block { slot: 6, block_id: Hash::default() })
-    )]
-    #[test_case(
-        CertificateType::Notarize(Block { slot: 6, block_id: Hash::default() }),
-        Vote::new_notarization_vote(Block { slot: 6, block_id: Hash::default() })
-    )]
-    #[test_case(
-        CertificateType::NotarizeFallback(Block { slot: 7, block_id: Hash::default() }),
-        Vote::new_notarization_fallback_vote(Block { slot: 7, block_id: Hash::default() })
-    )]
     #[test_case(CertificateType::Skip(8), Vote::new_skip_vote(8))]
     fn test_add_certificate_with_types(cert_type: CertificateType, vote: Vote) {
         let mut ctx = TestContext::new();
@@ -1210,10 +1238,7 @@ mod tests {
         // because finalization requires both certificates to be present
         if matches!(cert_type, CertificateType::Finalize(slot) if slot == 5) {
             let notarize_cert = Certificate {
-                cert_type: CertificateType::Notarize(Block {
-                    slot: 5,
-                    block_id: Hash::default(),
-                }),
+                cert_type: CertificateType::Notarize(Block::new_unique(5)),
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -188,12 +188,11 @@ mod tests {
         assert!(pending_safe_to_notar.is_empty());
         assert_eq!(stats.event_safe_to_notarize, 0);
 
+        let block = Block::new_unique(slot);
+        let vote = Vote::new_notarization_vote(block);
         // 40% of stake holders voted notarize
         counters.add_vote(
-            &Vote::new_notarization_vote(Block {
-                slot,
-                block_id: Hash::default(),
-            }),
+            &vote,
             40,
             false,
             &mut events,
@@ -203,9 +202,8 @@ mod tests {
         // First in leader window goes to events directly
         assert_eq!(events.len(), 1);
         match &events[0] {
-            VotorEvent::SafeToNotar(block) => {
-                assert_eq!(block.slot, slot);
-                assert_eq!(block.block_id, Hash::default());
+            VotorEvent::SafeToNotar(b) => {
+                assert_eq!(b, &block);
             }
             rest => panic!("unexpected: {rest:?}"),
         }
@@ -215,10 +213,7 @@ mod tests {
 
         // Adding more notarizations does not trigger more events
         counters.add_vote(
-            &Vote::new_notarization_vote(Block {
-                slot,
-                block_id: Hash::default(),
-            }),
+            &vote,
             20,
             false,
             &mut events,
@@ -340,10 +335,7 @@ mod tests {
         let slot = 2;
         // I voted for notarize b
         counters.add_vote(
-            &Vote::new_notarization_vote(Block {
-                slot,
-                block_id: Hash::default(),
-            }),
+            &Vote::new_notarization_vote(Block::new_unique(slot)),
             10,
             true,
             &mut events,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1657,21 +1657,8 @@ mod tests {
 
         // If there is a parent ready for block 1 Notarization is sent out.
         let slot = 1;
-        let parent_slot = 0;
-        test_context.send_parent_ready_event(
-            slot,
-            Block {
-                slot: parent_slot,
-                block_id: Hash::default(),
-            },
-        );
-        test_context.check_parent_ready_slot((
-            slot,
-            Block {
-                slot: parent_slot,
-                block_id: Hash::default(),
-            },
-        ));
+        test_context.send_parent_ready_event(slot, test_context.local_context.genesis_block);
+        test_context.check_parent_ready_slot((slot, test_context.local_context.genesis_block));
         test_context.check_alpenglow_slot(slot);
         let root_bank = test_context
             .bank_forks
@@ -1771,20 +1758,8 @@ mod tests {
         let block_id_1 = bank1.block_id().unwrap();
 
         // Add parent ready for 0 to trigger notar vote for 1
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
-        test_context.check_parent_ready_slot((
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        ));
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
+        test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 1,
             block_id: block_id_1,
@@ -1924,21 +1899,9 @@ mod tests {
             .root();
         let bank_1 = test_context.create_block_and_send_block_event(1, root_bank);
         let block_id_1_old = bank_1.block_id().unwrap();
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
-        test_context.check_parent_ready_slot((
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        ));
+        test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 1,
             block_id: block_id_1_old,
@@ -1997,21 +1960,9 @@ mod tests {
             .root();
         let bank_1 = test_context.create_block_and_send_block_event(1, root_bank);
         let block_id_1 = bank_1.block_id().unwrap();
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
-        test_context.check_parent_ready_slot((
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        ));
+        test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 1,
             block_id: block_id_1,
@@ -2036,14 +1987,7 @@ mod tests {
 
         // Produce a full window of blocks
         // Assume the leader for 1-3 is us, send produce window event
-        test_context.send_produce_window_event(
-            1,
-            3,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_produce_window_event(1, 3, test_context.local_context.genesis_block);
 
         // Check that leader_window_info is sent via channel
         let received_leader_window_info =
@@ -2052,10 +1996,7 @@ mod tests {
         assert_eq!(received_leader_window_info.end_slot, 3);
         assert_eq!(
             received_leader_window_info.parent_block,
-            Block {
-                slot: 0,
-                block_id: Hash::default()
-            }
+            test_context.local_context.genesis_block,
         );
 
         // Suddenly I found out I produced block 1 already, send new produce window event
@@ -2094,21 +2035,9 @@ mod tests {
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
         let block_id_1 = bank1.block_id().unwrap();
 
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
-        test_context.check_parent_ready_slot((
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        ));
+        test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 1,
             block_id: block_id_1,
@@ -2275,13 +2204,7 @@ mod tests {
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
         let block_id_1 = bank1.block_id().unwrap();
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 1,
@@ -2370,13 +2293,7 @@ mod tests {
             .sharable_banks()
             .root();
         let _ = test_context.create_block_and_send_block_event(1, root_bank.clone());
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
         // There should be no votes but we should see commitments for hot spares
         assert_eq!(
@@ -2393,13 +2310,7 @@ mod tests {
         let slot = 4;
         let bank4 = test_context.create_block_and_send_block_event(slot, root_bank);
         let block_id_4 = bank4.block_id().unwrap();
-        test_context.send_parent_ready_event(
-            slot,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
+        test_context.send_parent_ready_event(slot, test_context.local_context.genesis_block);
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot,
             block_id: block_id_4,
@@ -2606,17 +2517,12 @@ mod tests {
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
         let block_id_1 = bank1.block_id().unwrap();
-        test_context.send_parent_ready_event(
-            1,
-            Block {
-                slot: 0,
-                block_id: Hash::default(),
-            },
-        );
-        test_context.check_for_vote(&Vote::new_notarization_vote(Block {
+        test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
+        let block = Block {
             slot: 1,
             block_id: block_id_1,
-        }));
+        };
+        test_context.check_for_vote(&Vote::new_notarization_vote(block));
 
         // Send standstill event - should record the standstill slot
         test_context.send_standstill_event(0);

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -278,21 +278,12 @@ mod test {
         // The validator still casts a Finalize vote for each notarized block,
         // but no finalization certificate advances the root.
         for slot in 1..=MAX_SLOTS_WITHOUT_FINALIZATION as u64 {
-            let block = Block {
-                slot,
-                block_id: Hash::default(),
-            };
+            let block = Block::new_unique(slot);
             vote_history.add_vote(Vote::new_notarization_vote(block));
             vote_history.add_block_notarized(block);
             vote_history.add_vote(Vote::new_finalization_vote(slot));
             if slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64) {
-                vote_history.add_parent_ready(
-                    slot,
-                    Block {
-                        slot: slot - 1,
-                        block_id: Hash::default(),
-                    },
-                );
+                vote_history.add_parent_ready(slot, Block::new_unique(slot - 1));
             }
         }
         let saved_vote_history = SavedVoteHistory::new(&vote_history, &keypair).unwrap();


### PR DESCRIPTION
#### Problem

#14832 updated various `Block { ... }` constructs to use `new_unique`.  There were some remaining constructs.  


#### Summary of Changes

Some of the constructs could be simply updated to `new_unique`.  Others required minor changes to tests.  Some really do need to stay as they are.

#### Testing

No new tests added