### PR TITLE
ci: only run benchmark.yml for anza-xyz/agave

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   benchmark:
-    if: github.repository_owner == 'anza-xyz'
+    if: github.repository == 'anza-xyz/agave'
     name: benchmark
     runs-on: benchmark
     strategy:


### PR DESCRIPTION
#### Problem

benchmark workflow requires a special runner. let's restrict it to `anza-xyz/agave` only

#### Summary of Changes

only run benchmark.yml for anza-xyz/agave