### PR TITLE
Cleanup - `last_modification_slot` in `ProgramCache`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -209,8 +209,6 @@ pub struct ProgramToLoad<'a> {
     ///
     /// For Loader V1/V2 and builtin programs, this is 0.
     pub deployment_slot: Slot,
-    /// When the program account was last written to (might be after the deployment slot)
-    pub last_modification_slot: Slot,
 }
 
 #[derive(Debug)]
@@ -2427,7 +2425,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 50,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &new_env, true, true);
@@ -2444,7 +2441,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 50,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -2531,7 +2527,6 @@ pub(crate) mod tests {
                         program_id: key,
                         loader: entry.account_owner,
                         deployment_slot: entry.deployment_slot,
-                        last_modification_slot: entry.deployment_slot,
                     })
             })
             .collect()
@@ -2822,7 +2817,6 @@ pub(crate) mod tests {
             program_id: &program,
             loader: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 5,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2834,7 +2828,6 @@ pub(crate) mod tests {
             program_id: &program,
             loader: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 11,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2989,7 +2982,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 0,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3016,7 +3008,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3044,7 +3035,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3060,7 +3050,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 150,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3092,7 +3081,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3124,7 +3112,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3140,7 +3127,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &other_env, true, true);
@@ -3170,7 +3156,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3193,7 +3178,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3249,7 +3233,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(batch_slot);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3324,7 +3307,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3339,7 +3321,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &other_env, true, true);
@@ -3404,7 +3385,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3431,7 +3411,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(101);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3491,7 +3470,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3505,7 +3483,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &other_env, true, true);
@@ -3531,7 +3508,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(
@@ -3569,7 +3545,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3614,13 +3589,11 @@ pub(crate) mod tests {
                 program_id: &found,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 100,
-                last_modification_slot: 0,
             },
             ProgramToLoad {
                 program_id: &missing,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             },
         ];
         let mut extracted = ProgramCacheForTxBatch::new(200);
@@ -3664,7 +3637,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
         assert_eq!(extracted.entries.len(), 2);
@@ -3684,7 +3656,6 @@ pub(crate) mod tests {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             })
             .collect();
         let mut extracted = ProgramCacheForTxBatch::new(100);
@@ -3709,7 +3680,6 @@ pub(crate) mod tests {
             program_id: program_ids.first().unwrap(),
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 0,
-            last_modification_slot: 0,
         }];
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
         assert_eq!(search_for.len(), 1);
@@ -3741,7 +3711,6 @@ pub(crate) mod tests {
             program_id: program_ids.first().unwrap(),
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 50,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(100);
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3767,7 +3736,6 @@ pub(crate) mod tests {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             })
             .collect();
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3782,7 +3750,6 @@ pub(crate) mod tests {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             })
             .collect();
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3811,7 +3778,6 @@ pub(crate) mod tests {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             })
             .collect();
         let task = cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3856,7 +3822,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3883,7 +3848,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 50,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3929,7 +3893,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 150,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -3959,7 +3922,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 150,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -4007,7 +3969,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 50,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -4031,7 +3992,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 150,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(200);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -4072,7 +4032,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 0,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(50);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);
@@ -4117,7 +4076,6 @@ pub(crate) mod tests {
             program_id: &program_id,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: 100,
-            last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(300);
         cache.extract(&mut search_for, &mut extracted, &env, true, true);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -399,7 +399,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         &mut self,
         program_runtime_environment: &ProgramRuntimeEnvironment,
         key: Pubkey,
-        _last_modification_slot: Slot,
+        _current_slot: Slot,
         entry: Arc<ProgramCacheEntry>,
     ) -> bool {
         debug_assert!(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -730,7 +730,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         program_runtime_environment: &ProgramRuntimeEnvironment,
         current_slot: Slot,
         key: Pubkey,
-        last_modification_slot: Slot,
         loaded_program: Arc<ProgramCacheEntry>,
     ) -> bool {
         match &mut self.index {
@@ -758,7 +757,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 let was_occupied = self.assign_program(
                     program_runtime_environment,
                     key,
-                    last_modification_slot,
+                    current_slot,
                     loaded_program,
                 );
                 self.loading_task_waiter.notify();
@@ -3696,7 +3695,6 @@ pub(crate) mod tests {
             &env,
             100,
             *program_ids.first().unwrap(),
-            50,
             Arc::clone(&loaded),
         );
         assert_ne!(cache.loading_task_waiter.wait(cookie), cookie);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -783,7 +783,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 
     /// Returns the list of entries which are verified and compiled.
-    pub fn get_flattened_entries(&self) -> Vec<(Pubkey, Slot, Arc<ProgramCacheEntry>)> {
+    pub fn get_flattened_entries(&self) -> Vec<(Pubkey, Arc<ProgramCacheEntry>)> {
         match &self.index {
             IndexImplementation::V1 { entries, .. } => entries
                 .iter()
@@ -791,7 +791,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     second_level
                         .iter()
                         .filter_map(move |program| match program.program {
-                            ProgramCacheEntryType::Loaded(_) => Some((*id, 0, program.clone())),
+                            ProgramCacheEntryType::Loaded(_) => Some((*id, program.clone())),
                             _ => None,
                         })
                 })
@@ -825,15 +825,12 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     /// Unloads programs which were used infrequently
     pub fn sort_and_unload(&mut self, shrink_to_percent: Percent) {
         let mut sorted_candidates = self.get_flattened_entries();
-        sorted_candidates.sort_by_cached_key(|(_id, _last_modification_slot, program)| {
-            program.stats.uses.load(Ordering::Relaxed)
-        });
+        sorted_candidates
+            .sort_by_cached_key(|(_id, program)| program.stats.uses.load(Ordering::Relaxed));
         let num_to_unload = sorted_candidates
             .len()
             .saturating_sub(percent_of_max_entries(shrink_to_percent));
-        for (program, _last_modification_slot, entry) in
-            sorted_candidates.iter().take(num_to_unload)
-        {
+        for (program, entry) in sorted_candidates.iter().take(num_to_unload) {
             self.unload_program_entry(*program, entry);
         }
     }
@@ -852,7 +849,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         let num_to_unload = candidates
             .len()
             .saturating_sub(percent_of_max_entries(shrink_to_percent));
-        let mut sample_entry = |candidates: &Vec<(Pubkey, u64, Arc<ProgramCacheEntry>)>| {
+        let mut sample_entry = |candidates: &Vec<(Pubkey, Arc<ProgramCacheEntry>)>| {
             // gen_range is deprecated in favor of random_range in rand>=0.9, but we also get
             // rnd() from shuttle, which doesn't yet support rand 0.9 APIs
             #[cfg(feature = "shuttle-test")]
@@ -862,7 +859,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             let usage_counter = candidates
                 .get(index)
                 .expect("Failed to get cached entry")
-                .2
+                .1
                 .retention_score();
             (index, usage_counter)
         };
@@ -888,7 +885,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     break;
                 }
             }
-            let (id, _last_modification_slot, entry) = candidates.swap_remove(index);
+            let (id, entry) = candidates.swap_remove(index);
             self.unload_program_entry(id, &entry);
         }
     }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -831,9 +831,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         let num_to_unload = sorted_candidates
             .len()
             .saturating_sub(percent_of_max_entries(shrink_to_percent));
-        for (program, last_modification_slot, entry) in sorted_candidates.iter().take(num_to_unload)
+        for (program, _last_modification_slot, entry) in
+            sorted_candidates.iter().take(num_to_unload)
         {
-            self.unload_program_entry(*program, *last_modification_slot, entry);
+            self.unload_program_entry(*program, entry);
         }
     }
 
@@ -887,8 +888,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     break;
                 }
             }
-            let (id, last_modification_slot, entry) = candidates.swap_remove(index);
-            self.unload_program_entry(id, last_modification_slot, &entry);
+            let (id, _last_modification_slot, entry) = candidates.swap_remove(index);
+            self.unload_program_entry(id, &entry);
         }
     }
 
@@ -905,12 +906,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
 
     /// This function removes the given entry for the given program from the cache.
     /// The function expects that the program and entry exists in the cache. Otherwise it'll panic.
-    fn unload_program_entry(
-        &mut self,
-        id: Pubkey,
-        _last_modification_slot: Slot,
-        remove_entry: &Arc<ProgramCacheEntry>,
-    ) {
+    fn unload_program_entry(&mut self, id: Pubkey, remove_entry: &Arc<ProgramCacheEntry>) {
         match &mut self.index {
             IndexImplementation::V1 { entries, .. } => {
                 let second_level = entries.get_mut(&id).expect("Cache lookup failed");
@@ -4104,7 +4100,7 @@ pub(crate) mod tests {
             // Check that unload_program_entry() does nothing for this entry
             let program_id = Pubkey::new_unique();
             cache.assign_program(&env, program_id, entry.deployment_slot, entry.clone());
-            cache.unload_program_entry(program_id, entry.deployment_slot, &entry);
+            cache.unload_program_entry(program_id, &entry);
             assert_eq!(cache.get_slot_versions_for_tests(&program_id).len(), 1);
             assert!(cache.stats.evictions.is_empty());
         }
@@ -4123,7 +4119,7 @@ pub(crate) mod tests {
         // Check that unload_program_entry() does its work
         let program_id = Pubkey::new_unique();
         cache.assign_program(&env, program_id, entry.deployment_slot, entry.clone());
-        cache.unload_program_entry(program_id, entry.deployment_slot, &entry);
+        cache.unload_program_entry(program_id, &entry);
         assert!(cache.stats.evictions.contains_key(&program_id));
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7319,7 +7319,6 @@ impl Bank {
             self.slot(),
             &mut ExecuteTimings::default(), // Called by ledger-tool, metrics not accumulated.
         )
-        .map(|(loaded_program, _last_modification_slot)| loaded_program)
     }
 
     pub fn withdraw(&self, pubkey: &Pubkey, lamports: u64) -> Result<()> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1731,11 +1731,8 @@ impl Bank {
                     .global_program_cache
                     .read()
                     .unwrap();
-                epoch_boundary_preparation.programs_to_recompile = program_cache_guard
-                    .get_flattened_entries()
-                    .into_iter()
-                    .map(|(id, _last_modification_slot, entry)| (id, entry))
-                    .collect();
+                epoch_boundary_preparation.programs_to_recompile =
+                    program_cache_guard.get_flattened_entries();
                 epoch_boundary_preparation
                     .programs_to_recompile
                     .sort_by_cached_key(|(_id, program)| program.retention_score());

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -776,7 +776,6 @@ pub(crate) mod tests {
                     program_id: &self.target_program_address,
                     loader: ProgramCacheEntryOwner::LoaderV3,
                     deployment_slot: migration_or_upgrade_slot,
-                    last_modification_slot: migration_or_upgrade_slot,
                 }],
                 &bank.transaction_processor.program_runtime_environment,
                 &mut program_cache_for_tx_batch,

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -170,7 +170,7 @@ pub fn fill_program_cache_from_accounts(
             {
                 continue;
             }
-            if let Some((loaded_program, _last_modification_slot)) = load_program_with_pubkey(
+            if let Some(loaded_program) = load_program_with_pubkey(
                 &FillFromAccountsCallback(accounts),
                 program_runtime_environment,
                 &acc.0,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -500,16 +500,11 @@ mod tests {
             .insert(program_key, (program_account.clone(), 50));
 
         // Fail: programdata account missing
-        // This is a bit of a footgun. The programdata account is missing, but
-        // we get a modification slot of 0. This is okay as long as we know 0
-        // means "not available" or null.
         let result = load_program_accounts(&mock_bank, &program_key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
 
         // Fail: programdata wrong owner
-        // We also need to be careful here as well, since the load fails but
-        // we still get the *actual* last modified slot.
         let mut programdata_account = loader_v3_programdata_account(7, &[]);
         programdata_account.set_owner(Pubkey::new_unique());
         mock_bank
@@ -1385,9 +1380,7 @@ mod tests {
                 .insert(key, (empty, 40));
             assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
-            // Any non-empty data is considered to *maybe* be a program, and
-            // both loaders always use deployment slot 0. The modification slot
-            // is the program account's own.
+            // Any non-empty data is considered to *maybe* be a program.
             let mut account = AccountSharedData::default();
             account.set_owner(owner);
             account.set_data_from_slice(&[1u8; 4]);
@@ -1442,8 +1435,6 @@ mod tests {
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Successfully queued.
-        // Both fields come from the programdata account: the deployment slot
-        // *and* the modification slot.
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -1495,8 +1486,6 @@ mod tests {
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Successfully queued.
-        // Both fields come from the program account: the deployment slot from
-        // its state, the modification slot from the account itself.
         mock_bank.account_shared_data.borrow_mut().insert(
             key,
             (loader_v4_account(9, LoaderV4Status::Deployed, &[]), 100),

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -102,7 +102,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     pubkey: &Pubkey,
     current_slot: Slot,
     execute_timings: &mut ExecuteTimings,
-) -> Option<(Arc<ProgramCacheEntry>, Slot)> {
+) -> Option<Arc<ProgramCacheEntry>> {
     #[cfg(feature = "metrics")]
     let mut load_program_metrics = LoadProgramMetrics {
         program_id: pubkey.to_string(),
@@ -111,7 +111,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     #[cfg(not(feature = "metrics"))]
     let _ = execute_timings;
 
-    let (load_result, last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
+    let (load_result, _last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
     let loaded_program = match load_result {
         ProgramAccountLoadResult::InvalidAccountData(owner) => {
             Ok(ProgramCacheEntry::new_closed_tombstone(current_slot, owner))
@@ -185,7 +185,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     #[cfg(feature = "metrics")]
     load_program_metrics.submit_datapoint(&mut execute_timings.details);
     loaded_program.update_access_slot(current_slot);
-    Some((Arc::new(loaded_program), last_modification_slot))
+    Some(Arc::new(loaded_program))
 }
 
 /// Find the slot in which the program was most recently re-/deployed.
@@ -695,21 +695,20 @@ mod tests {
         assert_eq!(last_modification_slot, 60);
 
         // This is key, because we should now get a `Closed` tombstone.
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(20),
             &program_key,
             100, // Slot 100
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
 
         // Assert the result matches a `Closed` tombstone.
         let closed_tombstone = ProgramCacheEntry::new_closed_tombstone(
             100, // Slot 100
             ProgramCacheEntryOwner::LoaderV3,
         );
-        let (entry, last_modification_slot) = result.unwrap();
-        assert_eq!(last_modification_slot, 60);
         assert_eq!(entry, Arc::new(closed_tombstone));
 
         // Assert that it is NOT a `FailedVerification` tombstone.
@@ -768,13 +767,14 @@ mod tests {
 
         // This is key, because the ELF fails to verify, so we should now get a
         // `FailedVerification` tombstone.
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(20),
             &program_key,
             100, // Slot 100
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
 
         // Assert the result matches a `FailedVerification` tombstone.
         let fv_tombstone = ProgramCacheEntry::new_failed_verification_tombstone(
@@ -782,8 +782,6 @@ mod tests {
             ProgramCacheEntryOwner::LoaderV3,
             batch_processor.program_runtime_environment_for_epoch(20),
         );
-        let (entry, last_modification_slot) = result.unwrap();
-        assert_eq!(last_modification_slot, 60);
         assert_eq!(entry, Arc::new(fv_tombstone));
 
         // Assert that it is NOT a `Closed` tombstone.
@@ -815,19 +813,20 @@ mod tests {
             .insert(key, (account_data.clone(), 0));
 
         // This should return an error
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
         let loaded_program = ProgramCacheEntry::new_failed_verification_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV2,
             batch_processor.program_runtime_environment_for_epoch(20),
         );
-        assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
+        assert_eq!(entry, Arc::new(loaded_program));
 
         let buffer = load_test_program();
         account_data.set_data_from_slice(&buffer);
@@ -837,13 +836,14 @@ mod tests {
             .borrow_mut()
             .insert(key, (account_data.clone(), 0));
 
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(20),
             &key,
             200,
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
 
         let program_runtime_environment = get_mock_program_runtime_environment();
         let expected = ProgramCacheEntry::load(
@@ -855,7 +855,7 @@ mod tests {
             &mut LoadProgramMetrics::default(),
         );
 
-        assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
+        assert_eq!(entry, Arc::new(expected.unwrap()));
     }
 
     #[test]
@@ -890,16 +890,17 @@ mod tests {
 
         // The programdata account is not owned by the loader, so this is a
         // `Closed` tombstone rather than a `FailedVerification` one.
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(0),
             &key1,
             0,
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
         let loaded_program =
             ProgramCacheEntry::new_closed_tombstone(0, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
+        assert_eq!(entry, Arc::new(loaded_program));
 
         let mut buffer = load_test_program();
         let mut header = bincode::serialize(&state).unwrap();
@@ -919,13 +920,14 @@ mod tests {
             .borrow_mut()
             .insert(key2, (account_data.clone(), 0));
 
-        let result = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &batch_processor.program_runtime_environment_for_epoch(20),
             &key1,
             200,
             &mut ExecuteTimings::default(),
-        );
+        )
+        .unwrap();
 
         let data = account_data.data().to_vec();
         account_data
@@ -940,7 +942,7 @@ mod tests {
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
         );
-        assert_eq!(result.unwrap(), (Arc::new(expected.unwrap()), 0));
+        assert_eq!(entry, Arc::new(expected.unwrap()));
     }
 
     #[test]
@@ -955,7 +957,7 @@ mod tests {
             key,
             (loader_v4_account(9, LoaderV4Status::Retracted, &[]), 100),
         );
-        let (entry, _) = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
             &key,
@@ -971,7 +973,7 @@ mod tests {
             key,
             (loader_v4_account(9, LoaderV4Status::Deployed, &[]), 100),
         );
-        let (entry, _) = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
             &key,
@@ -994,7 +996,7 @@ mod tests {
             .account_shared_data
             .borrow_mut()
             .insert(key, (account, 100));
-        let (entry, _) = load_program_with_pubkey(
+        let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
             &key,
@@ -1029,7 +1031,7 @@ mod tests {
             .insert(key, (account_data.clone(), 0));
 
         for is_upcoming_env in [false, true] {
-            let (result, _last_modification_slot) = load_program_with_pubkey(
+            let result = load_program_with_pubkey(
                 &mock_bank,
                 &batch_processor.program_runtime_environment_for_epoch(is_upcoming_env as u64),
                 &key,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -31,9 +31,8 @@ pub(crate) enum ProgramAccountLoadResult {
 pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     pubkey: &Pubkey,
-) -> Option<(ProgramAccountLoadResult, Slot)> {
-    let (program_account, mut last_modification_slot) =
-        callbacks.get_account_shared_data(pubkey)?;
+) -> Option<ProgramAccountLoadResult> {
+    let (program_account, _last_modification_slot) = callbacks.get_account_shared_data(pubkey)?;
 
     let load_result = if loader_v4::check_id(program_account.owner()) {
         loader_v4_get_state(program_account.data())
@@ -50,10 +49,9 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
             programdata_address,
         }) = bincode::deserialize(program_account.data())
         {
-            if let Some((programdata_account, slot)) =
+            if let Some((programdata_account, _slot)) =
                 callbacks.get_account_shared_data(&programdata_address)
             {
-                last_modification_slot = slot;
                 if bpf_loader_upgradeable::check_id(programdata_account.owner()) {
                     if let Ok(UpgradeableLoaderState::ProgramData {
                         slot,
@@ -74,7 +72,6 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
                     ProgramAccountLoadResult::InvalidAccountData(ProgramCacheEntryOwner::LoaderV3)
                 }
             } else {
-                last_modification_slot = 0;
                 ProgramAccountLoadResult::InvalidAccountData(ProgramCacheEntryOwner::LoaderV3)
             }
         } else {
@@ -88,7 +85,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
         return None;
     };
 
-    Some((load_result, last_modification_slot))
+    Some(load_result)
 }
 
 /// Loads the program with the given pubkey.
@@ -111,7 +108,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     #[cfg(not(feature = "metrics"))]
     let _ = execute_timings;
 
-    let (load_result, _last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
+    let load_result = load_program_accounts(callbacks, pubkey)?;
     let loaded_program = match load_result {
         ProgramAccountLoadResult::InvalidAccountData(owner) => {
             Ok(ProgramCacheEntry::new_closed_tombstone(current_slot, owner))
@@ -402,10 +399,10 @@ mod tests {
     }
 
     macro_rules! unwrap_as {
-        ($result:expr, $variant:ident($($field:ident),*), $slot:ident) => {
-            let ($($field,)* $slot) = match $result {
-                Some((ProgramAccountLoadResult::$variant($($field),*), slot)) => {
-                    ($($field,)* slot)
+        ($result:expr, $variant:ident($($field:ident),*) $(,)?) => {
+            let ($($field,)*) = match $result {
+                Some(ProgramAccountLoadResult::$variant($($field),*)) => {
+                    ($($field,)*)
                 }
                 other => panic!("Invalid result: {other:?}"),
             };
@@ -451,9 +448,8 @@ mod tests {
             .insert(key, (account_data.clone(), 40));
 
         let result = load_program_accounts(&mock_bank, &key);
-        unwrap_as!(result, ProgramOfLoaderV1(program), last_modification_slot);
+        unwrap_as!(result, ProgramOfLoaderV1(program));
         assert_eq!(program, account_data);
-        assert_eq!(last_modification_slot, 40);
     }
 
     #[test]
@@ -472,9 +468,8 @@ mod tests {
             .insert(key, (account_data.clone(), 40));
 
         let result = load_program_accounts(&mock_bank, &key);
-        unwrap_as!(result, ProgramOfLoaderV2(program), last_modification_slot);
+        unwrap_as!(result, ProgramOfLoaderV2(program));
         assert_eq!(program, account_data);
-        assert_eq!(last_modification_slot, 40);
     }
 
     #[test]
@@ -487,8 +482,7 @@ mod tests {
         assert!(load_program_accounts(&mock_bank, &program_key).is_none());
 
         // Fail: program account invalid state
-        // The load gives up before it ever looks the programdata account up,
-        // so the last_modified_slot we get back is the *program* account's.
+        // The load gives up before it ever looks the programdata account up.
         let mut invalid_program_account = AccountSharedData::default();
         invalid_program_account.set_owner(bpf_loader_upgradeable::id());
         mock_bank
@@ -496,9 +490,8 @@ mod tests {
             .borrow_mut()
             .insert(program_key, (invalid_program_account, 40));
         let result = load_program_accounts(&mock_bank, &program_key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(last_modification_slot, 40); // <-- the program account's
 
         let program_account = loader_v3_program_account(programdata_key);
         mock_bank
@@ -511,9 +504,8 @@ mod tests {
         // we get a modification slot of 0. This is okay as long as we know 0
         // means "not available" or null.
         let result = load_program_accounts(&mock_bank, &program_key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(last_modification_slot, 0); // <-- slot is 0
 
         // Fail: programdata wrong owner
         // We also need to be careful here as well, since the load fails but
@@ -525,9 +517,8 @@ mod tests {
             .borrow_mut()
             .insert(programdata_key, (programdata_account, 60));
         let result = load_program_accounts(&mock_bank, &program_key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(last_modification_slot, 60); // <-- slot persists
 
         // Fail: programdata invalid state
         // Same here, fails the load but the last modified slot is returned.
@@ -539,9 +530,8 @@ mod tests {
             .borrow_mut()
             .insert(programdata_key, (programdata_account, 60));
         let result = load_program_accounts(&mock_bank, &program_key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(last_modification_slot, 60); // <-- slot again persists
 
         // Success
         let programdata_account = loader_v3_programdata_account(7, &[]);
@@ -553,12 +543,10 @@ mod tests {
         unwrap_as!(
             result,
             ProgramOfLoaderV3(program, programdata, deployment_slot),
-            last_modification_slot
         );
         assert_eq!(program, program_account);
         assert_eq!(programdata, programdata_account);
         assert_eq!(deployment_slot, 7);
-        assert_eq!(last_modification_slot, 60);
     }
 
     #[test]
@@ -578,9 +566,8 @@ mod tests {
             .borrow_mut()
             .insert(key, (program_account, 100));
         let result = load_program_accounts(&mock_bank, &key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
-        assert_eq!(last_modification_slot, 100); // <-- slot still persists
 
         // Fail: "gifted" state
         // Sized correctly, all-zeroes. Since `LoaderV4Status::Retracted` holds
@@ -593,9 +580,8 @@ mod tests {
             .borrow_mut()
             .insert(key, (program_account, 100));
         let result = load_program_accounts(&mock_bank, &key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
-        assert_eq!(last_modification_slot, 100);
 
         // Fail: status is Retracted
         mock_bank.account_shared_data.borrow_mut().insert(
@@ -603,9 +589,8 @@ mod tests {
             (loader_v4_account(9, LoaderV4Status::Retracted, &[]), 100),
         );
         let result = load_program_accounts(&mock_bank, &key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
-        assert_eq!(last_modification_slot, 100);
 
         // Success: any status but `Retracted`, and the state's slot is the
         // deployment slot
@@ -616,14 +601,9 @@ mod tests {
                 .borrow_mut()
                 .insert(key, (program_account.clone(), 100));
             let result = load_program_accounts(&mock_bank, &key);
-            unwrap_as!(
-                result,
-                ProgramOfLoaderV4(program, deployment_slot),
-                last_modification_slot
-            );
+            unwrap_as!(result, ProgramOfLoaderV4(program, deployment_slot));
             assert_eq!(program, program_account);
             assert_eq!(deployment_slot, 9);
-            assert_eq!(last_modification_slot, 100);
         }
     }
 
@@ -690,9 +670,8 @@ mod tests {
         // Just like we saw earlier in `test_load_program_accounts_loader_v3`,
         // the load result should be `InvalidAccountData(owner)`.
         let result = load_program_accounts(&mock_bank, &program_key);
-        unwrap_as!(result, InvalidAccountData(owner), last_modification_slot);
+        unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
-        assert_eq!(last_modification_slot, 60);
 
         // This is key, because we should now get a `Closed` tombstone.
         let entry = load_program_with_pubkey(
@@ -760,10 +739,8 @@ mod tests {
         unwrap_as!(
             result,
             ProgramOfLoaderV3(_program, _programdata, deployment_slot),
-            last_modification_slot
         );
         assert_eq!(deployment_slot, 7);
-        assert_eq!(last_modification_slot, 60);
 
         // This is key, because the ELF fails to verify, so we should now get a
         // `FailedVerification` tombstone.

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -249,24 +249,12 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
     for account_key in keys {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
-        } else if let Some((account, mut last_modification_slot)) =
+        } else if let Some((account, _last_modification_slot)) =
             callbacks.get_account_shared_data(account_key)
         {
             let loader = if loader_v4::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV4
             } else if bpf_loader_upgradeable::check_id(account.owner()) {
-                if let Ok(UpgradeableLoaderState::Program {
-                    programdata_address,
-                }) = bincode::deserialize(account.data())
-                {
-                    last_modification_slot = if let Some((_programdata, slot)) =
-                        callbacks.get_account_shared_data(&programdata_address)
-                    {
-                        slot
-                    } else {
-                        0
-                    };
-                }
                 ProgramCacheEntryOwner::LoaderV3
             } else if bpf_loader::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV2
@@ -283,7 +271,6 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
                 program_id: account_key,
                 loader,
                 deployment_slot,
-                last_modification_slot,
             });
         }
     }
@@ -1328,13 +1315,11 @@ mod tests {
                     program_id: &program_ids[1],
                     loader: ProgramCacheEntryOwner::LoaderV2,
                     deployment_slot: 0,
-                    last_modification_slot: 0,
                 },
                 ProgramToLoad {
                     program_id: &program_ids[2],
                     loader: ProgramCacheEntryOwner::LoaderV3,
                     deployment_slot: 0,
-                    last_modification_slot: 0,
                 },
             ]
         );
@@ -1437,7 +1422,6 @@ mod tests {
             let program_to_load = result.first().unwrap();
             assert_eq!(program_to_load.loader, loader);
             assert_eq!(program_to_load.deployment_slot, 0);
-            assert_eq!(program_to_load.last_modification_slot, 40);
         }
     }
 
@@ -1490,7 +1474,6 @@ mod tests {
         let program_to_load = result.first().unwrap();
         assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV3);
         assert_eq!(program_to_load.deployment_slot, 7);
-        assert_eq!(program_to_load.last_modification_slot, 60);
     }
 
     #[test]
@@ -1544,7 +1527,6 @@ mod tests {
         let program_to_load = result.first().unwrap();
         assert_eq!(program_to_load.loader, ProgramCacheEntryOwner::LoaderV4);
         assert_eq!(program_to_load.deployment_slot, 9);
-        assert_eq!(program_to_load.last_modification_slot, 100);
     }
 
     #[test]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -354,7 +354,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 program_id,
                 loader: ProgramCacheEntryOwner::NativeLoader,
                 deployment_slot: 0,
-                last_modification_slot: 0,
             })
             .collect();
         self.global_program_cache.read().unwrap().extract(
@@ -2146,7 +2145,6 @@ mod tests {
                     program_id: &key,
                     loader: ProgramCacheEntryOwner::NativeLoader,
                     deployment_slot: 0,
-                    last_modification_slot: 0,
                 }],
                 &mut loaded_programs_for_tx_batch,
                 &program_runtime_environment,
@@ -2377,7 +2375,6 @@ mod tests {
             program_id: &key,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: MIGRATION_SLOT,
-            last_modification_slot: MIGRATION_SLOT,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(MIGRATION_SLOT);
         batch_processor
@@ -2415,7 +2412,6 @@ mod tests {
             program_id: &key,
             loader: ProgramCacheEntryOwner::LoaderV3,
             deployment_slot: MIGRATION_SLOT,
-            last_modification_slot: MIGRATION_SLOT,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(NEXT_SLOT);
         next_slot.global_program_cache.read().unwrap().extract(
@@ -2434,7 +2430,6 @@ mod tests {
             program_id: &key,
             loader: ProgramCacheEntryOwner::NativeLoader,
             deployment_slot: BUILTIN_SLOT,
-            last_modification_slot: BUILTIN_SLOT,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(NEXT_SLOT);
         next_slot.global_program_cache.read().unwrap().extract(
@@ -3222,7 +3217,6 @@ mod tests {
                 program_id: &program_id,
                 loader,
                 deployment_slot: expected_deployment_slot,
-                last_modification_slot: 0,
             }]
         );
 
@@ -3276,7 +3270,6 @@ mod tests {
                     program_id: &program_id,
                     loader,
                     deployment_slot: 0,
-                    last_modification_slot: 0,
                 }],
                 &environment,
                 &mut program_cache_for_tx_batch,
@@ -3336,7 +3329,6 @@ mod tests {
                     program_id: &program_id,
                     loader,
                     deployment_slot: 0,
-                    last_modification_slot: 0,
                 }],
                 &environment,
                 &mut program_cache_for_tx_batch,
@@ -3490,7 +3482,6 @@ mod tests {
                     program_id: &program_id,
                     loader: ProgramCacheEntryOwner::LoaderV3,
                     deployment_slot: DEPLOYMENT_SLOT,
-                    last_modification_slot: 100, // Don't care
                 }],
                 &environment,
                 &mut program_cache_for_tx_batch,
@@ -3558,7 +3549,6 @@ mod tests {
                     program_id: &program_id,
                     loader: ProgramCacheEntryOwner::LoaderV4,
                     deployment_slot: if just_zeroes { 0 } else { 9 },
-                    last_modification_slot: 0,
                 }],
                 &environment,
                 &mut program_cache_for_tx_batch,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -957,7 +957,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
             let program_to_store = program_to_load.map(|key| {
                 // Load, verify and compile one program.
-                let (program, _last_modification_slot) = load_program_with_pubkey(
+                let program = load_program_with_pubkey(
                     account_loader,
                     program_runtime_environment_for_execution,
                     &key,
@@ -1032,7 +1032,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // Maybe the enqueued program was already loaded and can be skipped.
         if let Some(key) = program_to_load {
             // Load, verify and compile one program.
-            let (recompiled, _last_modification_slot) = load_program_with_pubkey(
+            let recompiled = load_program_with_pubkey(
                 account_loader,
                 upcoming_environment,
                 &key,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -957,7 +957,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
             let program_to_store = program_to_load.map(|key| {
                 // Load, verify and compile one program.
-                let (program, last_modification_slot) = load_program_with_pubkey(
+                let (program, _last_modification_slot) = load_program_with_pubkey(
                     account_loader,
                     program_runtime_environment_for_execution,
                     &key,
@@ -965,10 +965,10 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     execute_timings,
                 )
                 .expect("called load_program_with_pubkey() with nonexistent account");
-                (key, program, last_modification_slot)
+                (key, program)
             });
 
-            if let Some((key, program, last_modification_slot)) = program_to_store {
+            if let Some((key, program)) = program_to_store {
                 program_cache_for_tx_batch.loaded_missing = true;
                 let mut global_program_cache = self.global_program_cache.write().unwrap();
                 // Submit our last completed loading task.
@@ -976,7 +976,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     program_runtime_environment_for_execution,
                     self.slot,
                     key,
-                    last_modification_slot,
                     program,
                 ) && limit_to_load_programs
                 {
@@ -1033,7 +1032,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // Maybe the enqueued program was already loaded and can be skipped.
         if let Some(key) = program_to_load {
             // Load, verify and compile one program.
-            let (recompiled, last_modification_slot) = load_program_with_pubkey(
+            let (recompiled, _last_modification_slot) = load_program_with_pubkey(
                 account_loader,
                 upcoming_environment,
                 &key,
@@ -1049,7 +1048,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 upcoming_environment,
                 self.slot,
                 key,
-                last_modification_slot,
                 recompiled,
             );
         }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -63,7 +63,6 @@ fn program_cache_execution(threads: usize) {
                         program_id,
                         loader: ProgramCacheEntryOwner::LoaderV3,
                         deployment_slot: 0,
-                        last_modification_slot: 0,
                     })
                     .collect();
                 let feature_set = SVMFeatureSet::all_enabled();

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -369,7 +369,6 @@ impl SvmTestEnvironment<'_> {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
                 deployment_slot,
-                last_modification_slot: deployment_slot,
             }],
             self.processing_environment
                 .program_runtime_environments


### PR DESCRIPTION
#### Problem

We are now using `deployment_slot` everywhere, and read the `last_modification_slot` nowhere.

#### Summary of Changes

- Removes `ProgramToLoad::last_modification_slot`.
- Removes `last_modification_slot` parameter from `ProgramCache::finish_cooperative_loading_task()`.
- Turns parameter `_last_modification_slot` into `_current_slot` in `ProgramCache::assign_program()`.
- Removes `last_modification_slot` from return value of `load_program_with_pubkey()`.
- Removes `last_modification_slot` from return value of `load_program_accounts()`.
- Removes parameter `_last_modification_slot` from `ProgramCache::unload_program_entry()`.
- Removes `last_modification_slot` from return value of `ProgramCache::get_flattened_entries()`.
