### PR TITLE
fix: Parse stake instructions with reduced account layouts in jsonParsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 #### Changes
+* The `jsonParsed` encoding now parses stake instructions that use the reduced account layouts
+  accepted by the Core BPF stake program (v5.0.0, [SIMD-0490](https://github.com/solana-foundation/solana-improvement-documents/pull/490)),
+  which omit sysvar and stake config accounts. These instructions were previously returned in
+  `partiallyDecoded` form; they now return the same parsed fields as the legacy layouts with the
+  omitted accounts absent. Trailing stake authority accounts that the stake program no longer
+  reads are now optional when parsing the legacy layouts.
 ### Validator
 #### Breaking
 * scheduler-bindings version has been increased to 5. Connecting external schedulers must be updated.

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -47,7 +47,9 @@ pub fn parse_stake(
                 "lockup": lockup,
             });
             let map = value.as_object_mut().unwrap();
-            if instruction.accounts.len() >= 2 {
+            if instruction.accounts.len() >= 2
+                && account_keys[instruction.accounts[1] as usize] == sysvar::rent::ID
+            {
                 map.insert(
                     "rentSysvar".to_string(),
                     json!(account_keys[instruction.accounts[1] as usize].to_string()),
@@ -602,35 +604,45 @@ mod test {
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
 
-        // Minimal layout without the rent sysvar
-        let instruction = Instruction::new_with_bincode(
-            solana_sdk_ids::stake::ID,
-            &StakeInstruction::Initialize(authorized, lockup),
+        // Minimal layout without the rent sysvar; a second account is only
+        // labeled rentSysvar when it actually is the rent sysvar
+        let expected_parsed = ParsedInstructionEnum {
+            instruction_type: "initialize".to_string(),
+            info: json!({
+                "stakeAccount": stake_pubkey.to_string(),
+                "authorized": {
+                    "staker": authorized.staker.to_string(),
+                    "withdrawer": authorized.withdrawer.to_string(),
+                },
+                "lockup": {
+                    "unixTimestamp": lockup.unix_timestamp,
+                    "epoch": lockup.epoch,
+                    "custodian": lockup.custodian.to_string(),
+                }
+            }),
+        };
+        for account_metas in [
             vec![AccountMeta::new(stake_pubkey, false)],
-        );
-        let message = Message::new(&[instruction], None);
-        assert_eq!(
-            parse_stake(
-                &message.instructions[0],
-                &AccountKeys::new(&message.account_keys, None)
-            )
-            .unwrap(),
-            ParsedInstructionEnum {
-                instruction_type: "initialize".to_string(),
-                info: json!({
-                    "stakeAccount": stake_pubkey.to_string(),
-                    "authorized": {
-                        "staker": authorized.staker.to_string(),
-                        "withdrawer": authorized.withdrawer.to_string(),
-                    },
-                    "lockup": {
-                        "unixTimestamp": lockup.unix_timestamp,
-                        "epoch": lockup.epoch,
-                        "custodian": lockup.custodian.to_string(),
-                    }
-                }),
-            }
-        );
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(Pubkey::new_unique(), false),
+            ],
+        ] {
+            let instruction = Instruction::new_with_bincode(
+                solana_sdk_ids::stake::ID,
+                &StakeInstruction::Initialize(authorized, lockup),
+                account_metas,
+            );
+            let message = Message::new(&[instruction], None);
+            assert_eq!(
+                parse_stake(
+                    &message.instructions[0],
+                    &AccountKeys::new(&message.account_keys, None)
+                )
+                .unwrap(),
+                expected_parsed
+            );
+        }
     }
 
     #[test]

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -5,6 +5,7 @@ use {
     bincode::deserialize,
     serde_json::{Map, Value, json},
     solana_message::{AccountKeys, compiled_instruction::CompiledInstruction},
+    solana_sdk_ids::sysvar,
     solana_stake_interface::instruction::StakeInstruction,
 };
 
@@ -23,9 +24,14 @@ pub fn parse_stake(
             ));
         }
     }
+    // Since its migration to Core BPF, the stake program accepts both the
+    // legacy account layouts (which include sysvar and config accounts) and
+    // minimal layouts that omit them. The program dispatches between the two
+    // by checking whether the pubkey at a given position is the relevant
+    // sysvar id, and this parser mirrors that dispatch.
     match stake_instruction {
         StakeInstruction::Initialize(authorized, lockup) => {
-            check_num_stake_accounts(&instruction.accounts, 2)?;
+            check_num_stake_accounts(&instruction.accounts, 1)?;
             let authorized = json!({
                 "staker": authorized.staker.to_string(),
                 "withdrawer": authorized.withdrawer.to_string(),
@@ -35,31 +41,58 @@ pub fn parse_stake(
                 "epoch": lockup.epoch,
                 "custodian": lockup.custodian.to_string(),
             });
+            let mut value = json!({
+                "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                "authorized": authorized,
+                "lockup": lockup,
+            });
+            let map = value.as_object_mut().unwrap();
+            if instruction.accounts.len() >= 2 {
+                map.insert(
+                    "rentSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "initialize".to_string(),
-                info: json!({
-                    "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "authorized": authorized,
-                    "lockup": lockup,
-                }),
+                info: value,
             })
         }
         StakeInstruction::Authorize(new_authorized, authority_type) => {
-            check_num_stake_accounts(&instruction.accounts, 3)?;
+            check_num_stake_accounts(&instruction.accounts, 2)?;
             let mut value = json!({
                 "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                "clockSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                "authority": account_keys[instruction.accounts[2] as usize].to_string(),
                 "newAuthority": new_authorized.to_string(),
                 "authorityType": authority_type,
             });
             let map = value.as_object_mut().unwrap();
-            if instruction.accounts.len() >= 4 {
+            if account_keys[instruction.accounts[1] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 3)?;
                 map.insert(
-                    "custodian".to_string(),
-                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
                 );
+                map.insert(
+                    "authority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 4 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "authority".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 3 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                    );
+                }
             }
             Ok(ParsedInstructionEnum {
                 instruction_type: "authorize".to_string(),
@@ -67,47 +100,101 @@ pub fn parse_stake(
             })
         }
         StakeInstruction::DelegateStake => {
-            check_num_stake_accounts(&instruction.accounts, 6)?;
+            check_num_stake_accounts(&instruction.accounts, 3)?;
+            let mut value = json!({
+                "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                "voteAccount": account_keys[instruction.accounts[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if account_keys[instruction.accounts[2] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 5)?;
+                map.insert(
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "stakeHistorySysvar".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+                map.insert(
+                    "stakeConfigAccount".to_string(),
+                    json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 6 {
+                    map.insert(
+                        "stakeAuthority".to_string(),
+                        json!(account_keys[instruction.accounts[5] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "stakeAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "delegate".to_string(),
-                info: json!({
-                    "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "voteAccount": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "clockSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "stakeHistorySysvar": account_keys[instruction.accounts[3] as usize].to_string(),
-                    "stakeConfigAccount": account_keys[instruction.accounts[4] as usize].to_string(),
-                    "stakeAuthority": account_keys[instruction.accounts[5] as usize].to_string(),
-                }),
+                info: value,
             })
         }
         StakeInstruction::Split(lamports) => {
-            check_num_stake_accounts(&instruction.accounts, 3)?;
-            Ok(ParsedInstructionEnum {
-                instruction_type: "split".to_string(),
-                info: json!({
-                    "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "newSplitAccount": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "stakeAuthority": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "lamports": lamports,
-                }),
-            })
-        }
-        StakeInstruction::Withdraw(lamports) => {
-            check_num_stake_accounts(&instruction.accounts, 5)?;
+            check_num_stake_accounts(&instruction.accounts, 2)?;
             let mut value = json!({
                 "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                "destination": account_keys[instruction.accounts[1] as usize].to_string(),
-                "clockSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
-                "stakeHistorySysvar": account_keys[instruction.accounts[3] as usize].to_string(),
-                "withdrawAuthority": account_keys[instruction.accounts[4] as usize].to_string(),
+                "newSplitAccount": account_keys[instruction.accounts[1] as usize].to_string(),
                 "lamports": lamports,
             });
             let map = value.as_object_mut().unwrap();
-            if instruction.accounts.len() >= 6 {
+            if instruction.accounts.len() >= 3 {
                 map.insert(
-                    "custodian".to_string(),
-                    json!(account_keys[instruction.accounts[5] as usize].to_string()),
+                    "stakeAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
                 );
+            }
+            Ok(ParsedInstructionEnum {
+                instruction_type: "split".to_string(),
+                info: value,
+            })
+        }
+        StakeInstruction::Withdraw(lamports) => {
+            check_num_stake_accounts(&instruction.accounts, 3)?;
+            let mut value = json!({
+                "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+                "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                "lamports": lamports,
+            });
+            let map = value.as_object_mut().unwrap();
+            if account_keys[instruction.accounts[2] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 5)?;
+                map.insert(
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "stakeHistorySysvar".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+                map.insert(
+                    "withdrawAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 6 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[5] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "withdrawAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 4 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                    );
+                }
             }
             Ok(ParsedInstructionEnum {
                 instruction_type: "withdraw".to_string(),
@@ -115,14 +202,31 @@ pub fn parse_stake(
             })
         }
         StakeInstruction::Deactivate => {
-            check_num_stake_accounts(&instruction.accounts, 3)?;
+            check_num_stake_accounts(&instruction.accounts, 2)?;
+            let mut value = json!({
+                "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if account_keys[instruction.accounts[1] as usize] == sysvar::clock::ID {
+                map.insert(
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 3 {
+                    map.insert(
+                        "stakeAuthority".to_string(),
+                        json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "stakeAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "deactivate".to_string(),
-                info: json!({
-                    "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "clockSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "stakeAuthority": account_keys[instruction.accounts[2] as usize].to_string(),
-                }),
+                info: value,
             })
         }
         StakeInstruction::SetLockup(lockup_args) => {
@@ -147,16 +251,37 @@ pub fn parse_stake(
             })
         }
         StakeInstruction::Merge => {
-            check_num_stake_accounts(&instruction.accounts, 5)?;
+            check_num_stake_accounts(&instruction.accounts, 3)?;
+            let mut value = json!({
+                "destination": account_keys[instruction.accounts[0] as usize].to_string(),
+                "source": account_keys[instruction.accounts[1] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if account_keys[instruction.accounts[2] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 4)?;
+                map.insert(
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "stakeHistorySysvar".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 5 {
+                    map.insert(
+                        "stakeAuthority".to_string(),
+                        json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "stakeAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "merge".to_string(),
-                info: json!({
-                    "destination": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "source": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "clockSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "stakeHistorySysvar": account_keys[instruction.accounts[3] as usize].to_string(),
-                    "stakeAuthority": account_keys[instruction.accounts[4] as usize].to_string(),
-                }),
+                info: value,
             })
         }
         StakeInstruction::AuthorizeWithSeed(args) => {
@@ -171,16 +296,23 @@ pub fn parse_stake(
             });
             let map = value.as_object_mut().unwrap();
             if instruction.accounts.len() >= 3 {
-                map.insert(
-                    "clockSysvar".to_string(),
-                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
-                );
-            }
-            if instruction.accounts.len() >= 4 {
-                map.insert(
-                    "custodian".to_string(),
-                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
-                );
+                if account_keys[instruction.accounts[2] as usize] == sysvar::clock::ID {
+                    map.insert(
+                        "clockSysvar".to_string(),
+                        json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                    );
+                    if instruction.accounts.len() >= 4 {
+                        map.insert(
+                            "custodian".to_string(),
+                            json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                        );
+                    }
+                } else {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                    );
+                }
             }
             Ok(ParsedInstructionEnum {
                 instruction_type: "authorizeWithSeed".to_string(),
@@ -188,32 +320,82 @@ pub fn parse_stake(
             })
         }
         StakeInstruction::InitializeChecked => {
-            check_num_stake_accounts(&instruction.accounts, 4)?;
+            check_num_stake_accounts(&instruction.accounts, 3)?;
+            let mut value = json!({
+                "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
+            });
+            let map = value.as_object_mut().unwrap();
+            if account_keys[instruction.accounts[1] as usize] == sysvar::rent::ID {
+                check_num_stake_accounts(&instruction.accounts, 4)?;
+                map.insert(
+                    "rentSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+                map.insert(
+                    "staker".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "withdrawer".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+            } else {
+                map.insert(
+                    "staker".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+                map.insert(
+                    "withdrawer".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+            }
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializeChecked".to_string(),
-                info: json!({
-                    "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "staker": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "withdrawer": account_keys[instruction.accounts[3] as usize].to_string(),
-                }),
+                info: value,
             })
         }
         StakeInstruction::AuthorizeChecked(authority_type) => {
-            check_num_stake_accounts(&instruction.accounts, 4)?;
+            check_num_stake_accounts(&instruction.accounts, 3)?;
             let mut value = json!({
                 "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
-                "clockSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
-                "authority": account_keys[instruction.accounts[2] as usize].to_string(),
-                "newAuthority": account_keys[instruction.accounts[3] as usize].to_string(),
                 "authorityType": authority_type,
             });
             let map = value.as_object_mut().unwrap();
-            if instruction.accounts.len() >= 5 {
+            if account_keys[instruction.accounts[1] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 4)?;
                 map.insert(
-                    "custodian".to_string(),
-                    json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
                 );
+                map.insert(
+                    "authority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                map.insert(
+                    "newAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 5 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "authority".to_string(),
+                    json!(account_keys[instruction.accounts[1] as usize].to_string()),
+                );
+                map.insert(
+                    "newAuthority".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 4 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                    );
+                }
             }
             Ok(ParsedInstructionEnum {
                 instruction_type: "authorizeChecked".to_string(),
@@ -221,22 +403,42 @@ pub fn parse_stake(
             })
         }
         StakeInstruction::AuthorizeCheckedWithSeed(args) => {
-            check_num_stake_accounts(&instruction.accounts, 4)?;
+            check_num_stake_accounts(&instruction.accounts, 3)?;
             let mut value = json!({
                     "stakeAccount": account_keys[instruction.accounts[0] as usize].to_string(),
                     "authorityBase": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "clockSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
-                    "newAuthorized": account_keys[instruction.accounts[3] as usize].to_string(),
                     "authorityType": args.stake_authorize,
                     "authoritySeed": args.authority_seed,
                     "authorityOwner": args.authority_owner.to_string(),
             });
             let map = value.as_object_mut().unwrap();
-            if instruction.accounts.len() >= 5 {
+            if account_keys[instruction.accounts[2] as usize] == sysvar::clock::ID {
+                check_num_stake_accounts(&instruction.accounts, 4)?;
                 map.insert(
-                    "custodian".to_string(),
-                    json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    "clockSysvar".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
                 );
+                map.insert(
+                    "newAuthorized".to_string(),
+                    json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 5 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    );
+                }
+            } else {
+                map.insert(
+                    "newAuthorized".to_string(),
+                    json!(account_keys[instruction.accounts[2] as usize].to_string()),
+                );
+                if instruction.accounts.len() >= 4 {
+                    map.insert(
+                        "custodian".to_string(),
+                        json!(account_keys[instruction.accounts[3] as usize].to_string()),
+                    );
+                }
             }
             Ok(ParsedInstructionEnum {
                 instruction_type: "authorizeCheckedWithSeed".to_string(),
@@ -331,7 +533,7 @@ fn check_num_stake_accounts(accounts: &[u8], num: usize) -> Result<(), ParseInst
 mod test {
     use {
         super::*,
-        solana_instruction::Instruction,
+        solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
         solana_sdk_ids::sysvar,
@@ -399,6 +601,36 @@ mod test {
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the rent sysvar
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::Initialize(authorized, lockup),
+            vec![AccountMeta::new(stake_pubkey, false)],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initialize".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "authorized": {
+                        "staker": authorized.staker.to_string(),
+                        "withdrawer": authorized.withdrawer.to_string(),
+                    },
+                    "lockup": {
+                        "unixTimestamp": lockup.unix_timestamp,
+                        "epoch": lockup.epoch,
+                        "custodian": lockup.custodian.to_string(),
+                    }
+                }),
+            }
+        );
     }
 
     #[test]
@@ -481,6 +713,41 @@ mod test {
         message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the clock sysvar, with and without custodian
+        for custodian in [None, Some(custodian_pubkey)] {
+            let mut account_metas = vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+            ];
+            let mut expected_info = json!({
+                "stakeAccount": stake_pubkey.to_string(),
+                "authority": authorized_pubkey.to_string(),
+                "newAuthority": new_authorized_pubkey.to_string(),
+                "authorityType": StakeAuthorize::Staker,
+            });
+            if let Some(custodian) = custodian {
+                account_metas.push(AccountMeta::new_readonly(custodian, true));
+                expected_info["custodian"] = json!(custodian.to_string());
+            }
+            let instruction = Instruction::new_with_bincode(
+                solana_sdk_ids::stake::ID,
+                &StakeInstruction::Authorize(new_authorized_pubkey, StakeAuthorize::Staker),
+                account_metas,
+            );
+            let message = Message::new(&[instruction], None);
+            assert_eq!(
+                parse_stake(
+                    &message.instructions[0],
+                    &AccountKeys::new(&message.account_keys, None)
+                )
+                .unwrap(),
+                ParsedInstructionEnum {
+                    instruction_type: "authorize".to_string(),
+                    info: expected_info,
+                }
+            );
+        }
     }
 
     #[test]
@@ -516,9 +783,51 @@ mod test {
             )
             .is_err()
         );
+        // The stake authority is optional in the legacy layout
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
+        assert_eq!(
+            parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "delegate".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "voteAccount": vote_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                    "stakeHistorySysvar": sysvar::stake_history::ID.to_string(),
+                    "stakeConfigAccount": config::ID.to_string(),
+                }),
+            }
+        );
+        message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without sysvar or config accounts
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::DelegateStake,
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(vote_pubkey, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "delegate".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "voteAccount": vote_pubkey.to_string(),
+                    "stakeAuthority": authorized_pubkey.to_string(),
+                }),
+            }
+        );
     }
 
     #[test]
@@ -560,6 +869,32 @@ mod test {
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the stake authority
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::Split(lamports),
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new(split_stake_pubkey, false),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "split".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "newSplitAccount": split_stake_pubkey.to_string(),
+                    "lamports": lamports,
+                }),
+            }
+        );
     }
 
     #[test]
@@ -633,6 +968,42 @@ mod test {
         message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without sysvar accounts, with and without custodian
+        for custodian in [None, Some(custodian_pubkey)] {
+            let mut account_metas = vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new(to_pubkey, false),
+                AccountMeta::new_readonly(withdrawer_pubkey, true),
+            ];
+            let mut expected_info = json!({
+                "stakeAccount": stake_pubkey.to_string(),
+                "destination": to_pubkey.to_string(),
+                "withdrawAuthority": withdrawer_pubkey.to_string(),
+                "lamports": lamports,
+            });
+            if let Some(custodian) = custodian {
+                account_metas.push(AccountMeta::new_readonly(custodian, true));
+                expected_info["custodian"] = json!(custodian.to_string());
+            }
+            let instruction = Instruction::new_with_bincode(
+                solana_sdk_ids::stake::ID,
+                &StakeInstruction::Withdraw(lamports),
+                account_metas,
+            );
+            let message = Message::new(&[instruction], None);
+            assert_eq!(
+                parse_stake(
+                    &message.instructions[0],
+                    &AccountKeys::new(&message.account_keys, None)
+                )
+                .unwrap(),
+                ParsedInstructionEnum {
+                    instruction_type: "withdraw".to_string(),
+                    info: expected_info,
+                }
+            );
+        }
     }
 
     #[test]
@@ -663,9 +1034,46 @@ mod test {
             )
             .is_err()
         );
+        // The stake authority is optional in the legacy layout
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
+        assert_eq!(
+            parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "deactivate".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                }),
+            }
+        );
+        message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the clock sysvar
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::Deactivate,
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "deactivate".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "stakeAuthority": authorized_pubkey.to_string(),
+                }),
+            }
+        );
     }
 
     #[test]
@@ -703,9 +1111,50 @@ mod test {
             )
             .is_err()
         );
+        // The stake authority is optional in the legacy layout
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
+        assert_eq!(
+            parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "merge".to_string(),
+                info: json!({
+                    "destination": destination_stake_pubkey.to_string(),
+                    "source": source_stake_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                    "stakeHistorySysvar": sysvar::stake_history::ID.to_string(),
+                }),
+            }
+        );
+        message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without sysvar accounts
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::Merge,
+            vec![
+                AccountMeta::new(destination_stake_pubkey, false),
+                AccountMeta::new(source_stake_pubkey, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "merge".to_string(),
+                info: json!({
+                    "destination": destination_stake_pubkey.to_string(),
+                    "source": source_stake_pubkey.to_string(),
+                    "stakeAuthority": authorized_pubkey.to_string(),
+                }),
+            }
+        );
     }
 
     #[test]
@@ -800,6 +1249,44 @@ mod test {
         message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the clock sysvar; the custodian follows the
+        // authority base directly
+        let args = instruction::AuthorizeWithSeedArgs {
+            new_authorized_pubkey,
+            stake_authorize: StakeAuthorize::Withdrawer,
+            authority_seed: seed.to_string(),
+            authority_owner: authority_owner_pubkey,
+        };
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::AuthorizeWithSeed(args),
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authority_base_pubkey, true),
+                AccountMeta::new_readonly(custodian_pubkey, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "authorizeWithSeed".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "authorityOwner": authority_owner_pubkey.to_string(),
+                    "newAuthorized": new_authorized_pubkey.to_string(),
+                    "authorityBase": authority_base_pubkey.to_string(),
+                    "authoritySeed": seed,
+                    "authorityType": StakeAuthorize::Withdrawer,
+                    "custodian": custodian_pubkey.to_string(),
+                }),
+            }
+        );
     }
 
     #[test]
@@ -1038,6 +1525,33 @@ mod test {
         let keys = message.account_keys.clone();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the rent sysvar
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::InitializeChecked,
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authorized.staker, false),
+                AccountMeta::new_readonly(authorized.withdrawer, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "initializeChecked".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "staker": authorized.staker.to_string(),
+                    "withdrawer": authorized.withdrawer.to_string(),
+                }),
+            }
+        );
     }
 
     #[test]
@@ -1121,6 +1635,42 @@ mod test {
         message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the clock sysvar, with and without custodian
+        for custodian in [None, Some(custodian_pubkey)] {
+            let mut account_metas = vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+                AccountMeta::new_readonly(new_authorized_pubkey, true),
+            ];
+            let mut expected_info = json!({
+                "stakeAccount": stake_pubkey.to_string(),
+                "authority": authorized_pubkey.to_string(),
+                "newAuthority": new_authorized_pubkey.to_string(),
+                "authorityType": StakeAuthorize::Staker,
+            });
+            if let Some(custodian) = custodian {
+                account_metas.push(AccountMeta::new_readonly(custodian, true));
+                expected_info["custodian"] = json!(custodian.to_string());
+            }
+            let instruction = Instruction::new_with_bincode(
+                solana_sdk_ids::stake::ID,
+                &StakeInstruction::AuthorizeChecked(StakeAuthorize::Staker),
+                account_metas,
+            );
+            let message = Message::new(&[instruction], None);
+            assert_eq!(
+                parse_stake(
+                    &message.instructions[0],
+                    &AccountKeys::new(&message.account_keys, None)
+                )
+                .unwrap(),
+                ParsedInstructionEnum {
+                    instruction_type: "authorizeChecked".to_string(),
+                    info: expected_info,
+                }
+            );
+        }
     }
 
     #[test]
@@ -1214,6 +1764,49 @@ mod test {
         message.instructions[0].accounts.pop();
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Minimal layout without the clock sysvar, with and without custodian
+        for custodian in [None, Some(custodian_pubkey)] {
+            let mut account_metas = vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(authority_base_pubkey, true),
+                AccountMeta::new_readonly(new_authorized_pubkey, true),
+            ];
+            let mut expected_info = json!({
+                "stakeAccount": stake_pubkey.to_string(),
+                "authorityOwner": authority_owner_pubkey.to_string(),
+                "newAuthorized": new_authorized_pubkey.to_string(),
+                "authorityBase": authority_base_pubkey.to_string(),
+                "authoritySeed": seed,
+                "authorityType": StakeAuthorize::Staker,
+            });
+            if let Some(custodian) = custodian {
+                account_metas.push(AccountMeta::new_readonly(custodian, true));
+                expected_info["custodian"] = json!(custodian.to_string());
+            }
+            let args = instruction::AuthorizeCheckedWithSeedArgs {
+                stake_authorize: StakeAuthorize::Staker,
+                authority_seed: seed.to_string(),
+                authority_owner: authority_owner_pubkey,
+            };
+            let instruction = Instruction::new_with_bincode(
+                solana_sdk_ids::stake::ID,
+                &StakeInstruction::AuthorizeCheckedWithSeed(args),
+                account_metas,
+            );
+            let message = Message::new(&[instruction], None);
+            assert_eq!(
+                parse_stake(
+                    &message.instructions[0],
+                    &AccountKeys::new(&message.account_keys, None)
+                )
+                .unwrap(),
+                ParsedInstructionEnum {
+                    instruction_type: "authorizeCheckedWithSeed".to_string(),
+                    info: expected_info,
+                }
+            );
+        }
     }
 
     #[test]

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -6,7 +6,7 @@ use {
     serde_json::{Map, Value, json},
     solana_message::{AccountKeys, compiled_instruction::CompiledInstruction},
     solana_sdk_ids::sysvar,
-    solana_stake_interface::instruction::StakeInstruction,
+    solana_stake_interface::{config as stake_config, instruction::StakeInstruction},
 };
 
 pub fn parse_stake(
@@ -118,14 +118,24 @@ pub fn parse_stake(
                     "stakeHistorySysvar".to_string(),
                     json!(account_keys[instruction.accounts[3] as usize].to_string()),
                 );
-                map.insert(
-                    "stakeConfigAccount".to_string(),
-                    json!(account_keys[instruction.accounts[4] as usize].to_string()),
-                );
-                if instruction.accounts.len() >= 6 {
+                // The program requires a fifth account in this layout but
+                // never reads the stake config account, so clients may pass
+                // the stake authority in its position instead
+                if account_keys[instruction.accounts[4] as usize] == stake_config::ID {
+                    map.insert(
+                        "stakeConfigAccount".to_string(),
+                        json!(account_keys[instruction.accounts[4] as usize].to_string()),
+                    );
+                    if instruction.accounts.len() >= 6 {
+                        map.insert(
+                            "stakeAuthority".to_string(),
+                            json!(account_keys[instruction.accounts[5] as usize].to_string()),
+                        );
+                    }
+                } else {
                     map.insert(
                         "stakeAuthority".to_string(),
-                        json!(account_keys[instruction.accounts[5] as usize].to_string()),
+                        json!(account_keys[instruction.accounts[4] as usize].to_string()),
                     );
                 }
             } else {
@@ -813,6 +823,38 @@ mod test {
         );
         message.instructions[0].accounts.pop();
         assert!(parse_stake(&message.instructions[0], &AccountKeys::new(&keys, None)).is_err());
+
+        // Reduced layout that omits only the (unused) stake config account,
+        // leaving the stake authority in its position
+        let instruction = Instruction::new_with_bincode(
+            solana_sdk_ids::stake::ID,
+            &StakeInstruction::DelegateStake,
+            vec![
+                AccountMeta::new(stake_pubkey, false),
+                AccountMeta::new_readonly(vote_pubkey, false),
+                AccountMeta::new_readonly(sysvar::clock::ID, false),
+                AccountMeta::new_readonly(sysvar::stake_history::ID, false),
+                AccountMeta::new_readonly(authorized_pubkey, true),
+            ],
+        );
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_stake(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "delegate".to_string(),
+                info: json!({
+                    "stakeAccount": stake_pubkey.to_string(),
+                    "voteAccount": vote_pubkey.to_string(),
+                    "clockSysvar": sysvar::clock::ID.to_string(),
+                    "stakeHistorySysvar": sysvar::stake_history::ID.to_string(),
+                    "stakeAuthority": authorized_pubkey.to_string(),
+                }),
+            }
+        );
 
         // Minimal layout without sysvar or config accounts
         let instruction = Instruction::new_with_bincode(


### PR DESCRIPTION
Fixes #14991

Since the stake program's move to core BPF (and the v5 upgrade), most stake instructions accept a minimal account layout that omits the sysvar and config accounts. The program dispatches between the legacy and minimal layouts by checking whether the pubkey at a fixed position is the Clock sysvar (Rent for InitializeChecked), not by account count. The jsonParsed stake parser still hardcoded the legacy layouts, so any transaction using the new form fell back to partiallyDecoded, and the Authorize variants could pass the length check and silently mislabel fields (e.g. a custodian reported as clockSysvar).

This mirrors the on-chain dispatch in parse_stake for Initialize, Authorize, DelegateStake, Split, Withdraw, Deactivate, Merge, AuthorizeWithSeed, InitializeChecked, AuthorizeChecked and AuthorizeCheckedWithSeed. It also treats trailing authority accounts the v5 processor no longer reads as optional. Legacy output schemas are unchanged and the minimal forms emit the same field names with the sysvar/config fields omitted.

SetLockup and SetLockupChecked need no change since no sysvar ever sat between their accounts, same for MoveStake, MoveLamports and DeactivateDelinquent. Verified against the mainnet transaction in the issue: the added minimal form delegate test is exactly its shape.