### PR TITLE
Store SignatureAffine in VoteMessage and VoteAggregate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9008,6 +9008,7 @@ dependencies = [
  "serial_test",
  "solana-account 4.6.0",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-client-traits",
  "solana-clock",
  "solana-cluster-type",

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -562,7 +562,9 @@ mod tests {
         bitvec::prelude::{BitVec, Lsb0},
         bytes::Bytes,
         crossbeam_channel::{Receiver, TryRecvError, bounded},
-        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature},
+        solana_bls_signatures::{
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, Signature, signature::SignatureAffine,
+        },
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
@@ -734,7 +736,7 @@ mod tests {
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
         let payload = get_vote_payload_to_sign(vote, shred_version);
-        let signature: Signature = bls_keypair.sign(&payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
         VoteMessage {
             vote,
             signature,
@@ -973,10 +975,13 @@ mod tests {
         expect_no_receive(&ctx.pool_receiver);
 
         // Send a packet with invalid rank
+        let vote = Vote::new_finalization_vote(5);
+        let payload = get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
+        let signature = SignatureAffine::from(ctx.validator_keypairs[0].bls_keypair.sign(&payload));
         let messages_invalid_rank = [(
             ConsensusMessage::Vote(VoteMessage {
                 vote: Vote::new_finalization_vote(5),
-                signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                signature,
                 rank: 1000, // Invalid rank
                 stake: NonZero::new(123).unwrap(),
             }),
@@ -1124,7 +1129,7 @@ mod tests {
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
-            let signature: Signature = bls_keypair.sign(&vote_payload).into();
+            let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
             let consensus_message = ConsensusMessage::Vote(VoteMessage {
                 vote,
                 signature,
@@ -1606,7 +1611,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
-        let signature: Signature = bls_keypair.sign(&vote_payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
 
         let consensus_message = ConsensusMessage::Vote(VoteMessage {
             vote,
@@ -1686,7 +1691,7 @@ mod tests {
         let vote_payload =
             get_vote_payload_to_sign(vote, sig_verifier.cluster_info.my_shred_version());
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
-        let signature: Signature = bls_keypair.sign(&vote_payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&vote_payload));
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
             vote,
             signature,

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -30,6 +30,7 @@ use {
     solana_bls_signatures::{
         BlsError, PreparedHashedMessage, PubkeyProjective, SignatureProjective,
         pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature},
+        signature::SignatureAffine,
     },
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
@@ -99,11 +100,12 @@ impl UnverifiedVotePayload {
         max_validators: usize,
         prepared_hashed_message: &PreparedHashedMessage,
     ) -> Result<VerifiedVotePayload, BlsError> {
+        let signature = SignatureAffine::try_from(self.vote_message.signature)?;
         self.sender_bls_pubkey
-            .verify_signature_prepared(&self.vote_message.signature, prepared_hashed_message)?;
+            .verify_signature_prepared(&signature, prepared_hashed_message)?;
         let vote_msg = VoteMessage {
             vote: self.vote_message.vote,
-            signature: self.vote_message.signature,
+            signature,
             rank: self.rank,
             stake: self.stake,
         };

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -40,6 +40,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 solana-account = { workspace = true, features = ["wincode"] }
 solana-accounts-db = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -17,6 +17,7 @@ use {
     crossbeam_channel::{Receiver, bounded},
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
+    solana_bls_signatures::signature::SignatureAffine,
     solana_clock::{self as clock, Slot},
     solana_commitment_config::CommitmentConfig,
     solana_core::consensus::tower_storage::{
@@ -686,9 +687,10 @@ fn convert_datagram_to_vote_message(
     let bank = bank_forks.read().unwrap().root_bank();
     let rank_map = bank.get_rank_map(vote_msg.vote.slot())?;
     let (rank, sender_entry) = rank_map.get_ranked_entry_for_node(&sender)?;
+    let signature = SignatureAffine::try_from(vote_msg.signature).ok()?;
     Some(VoteMessage {
         vote: vote_msg.vote,
-        signature: vote_msg.signature,
+        signature,
         rank,
         stake: sender_entry.stake,
     })

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -5,7 +5,7 @@ use {
         vote::Vote,
     },
     serde::{Deserialize, Serialize},
-    solana_bls_signatures::Signature as BLSSignature,
+    solana_bls_signatures::{Signature as BLSSignature, signature::SignatureAffine},
     solana_clock::Slot,
     solana_hash::Hash,
     std::num::NonZero,
@@ -65,12 +65,12 @@ impl Block {
 }
 
 /// A consensus vote.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
     /// The signature.
-    pub signature: BLSSignature,
+    pub signature: SignatureAffine,
     /// The rank of the validator.
     pub rank: u16,
     /// The stake of the validator
@@ -78,7 +78,7 @@ pub struct VoteMessage {
 }
 
 /// A consensus message sent between validators.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
     /// A vote from a single party.
@@ -89,7 +89,12 @@ pub enum ConsensusMessage {
 
 impl ConsensusMessage {
     /// Create a new vote message
-    pub fn new_vote(vote: Vote, signature: BLSSignature, rank: u16, stake: NonZero<u64>) -> Self {
+    pub fn new_vote(
+        vote: Vote,
+        signature: SignatureAffine,
+        rank: u16,
+        stake: NonZero<u64>,
+    ) -> Self {
         Self::Vote(VoteMessage {
             vote,
             signature,

--- a/votor-messages/src/sig_verified_messages.rs
+++ b/votor-messages/src/sig_verified_messages.rs
@@ -6,7 +6,7 @@ use {
         wire::VotePayloadToSign,
     },
     bitvec::vec::BitVec,
-    solana_bls_signatures::{Signature as BLSSignature, SignatureProjective},
+    solana_bls_signatures::{SignatureProjective, signature::SignatureAffine},
     std::num::NonZero,
 };
 
@@ -42,12 +42,12 @@ impl SigVerifiedBatch {
 ///
 /// NOTE: the fields should not be exposed outside of the crate so that users use approved paths to
 /// build it to ensure signature verification takes place.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VoteAggregate {
     /// The type of vote in the batch.
     vote: Vote,
     /// The aggregate signature of the votes in the batch.
-    signature: BLSSignature,
+    signature: SignatureAffine,
     /// The total stake in the batch.
     stake: NonZero<u64>,
     /// Ranks of the various validators whose votes are in the batch.
@@ -114,7 +114,7 @@ impl VoteAggregate {
     }
 
     /// Accessor for the signature.
-    pub fn signature(&self) -> &BLSSignature {
+    pub fn signature(&self) -> &SignatureAffine {
         &self.signature
     }
 

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -85,9 +85,8 @@ pub(crate) struct WireVoteSignature {
 
 impl From<VoteMessage> for WireVoteSignature {
     fn from(msg: VoteMessage) -> Self {
-        Self {
-            signature: msg.signature,
-        }
+        let signature = BLSSignature::from(msg.signature);
+        Self { signature }
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -584,7 +584,7 @@ mod tests {
         bitvec::vec::BitVec,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature, VerifiableSignature,
-            keypair::Keypair as BLSKeypair,
+            keypair::Keypair as BLSKeypair, signature::SignatureAffine,
         },
         solana_clock::Slot,
         solana_hash::Hash,
@@ -746,7 +746,7 @@ mod tests {
                 .unwrap()
                 .stake;
             let payload = get_vote_payload_to_sign(vote, self.pool.cluster_info.my_shred_version());
-            let signature: BLSSignature = bls_keypair.sign(&payload).into();
+            let signature = SignatureAffine::from(bls_keypair.sign(&payload));
             VoteMessage {
                 vote,
                 signature,
@@ -804,7 +804,7 @@ mod tests {
             .unwrap()
             .stake;
         let payload = get_vote_payload_to_sign(*vote, shred_version);
-        let signature: BLSSignature = bls_keypair.sign(&payload).into();
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
         let msg = VoteMessage {
             vote: *vote,
             signature,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1055,9 +1055,7 @@ mod tests {
         },
         crossbeam_channel::{Receiver, Sender, TryRecvError, bounded},
         parking_lot::RwLock as PlRwLock,
-        solana_bls_signatures::{
-            keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
-        },
+        solana_bls_signatures::{keypair::Keypair as BLSKeypair, signature::SignatureAffine},
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_ledger::{
@@ -1511,7 +1509,7 @@ mod tests {
         fn expected_vote_message(&self, expected_vote: &Vote) -> VoteMessage {
             let payload =
                 get_vote_payload_to_sign(*expected_vote, self.cluster_info.my_shred_version());
-            let signature: BLSSignature = self.my_bls_keypair.sign(&payload).into();
+            let signature = SignatureAffine::from(self.my_bls_keypair.sign(&payload));
             let root_bank = self.bank_forks.read().unwrap().root_bank();
             let rank_map = root_bank.get_rank_map(expected_vote.slot()).unwrap();
             let stake = rank_map.get_pubkey_stake_entry(0).unwrap().stake;

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -368,6 +368,7 @@ mod tests {
             consensus_message::{ConsensusMessage, VoteMessage},
             migration::MigrationStatus,
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
         agave_votor_transport::{
             PeerList, PeerListReceiver, PeerListSender,
@@ -377,7 +378,10 @@ mod tests {
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded, unbounded},
         rand::Rng,
-        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_bls_signatures::{
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BlsKeypair, Signature as BLSSignature,
+            signature::SignatureAffine,
+        },
         solana_gossip::contact_info::ContactInfo,
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
@@ -408,17 +412,24 @@ mod tests {
     fn test_vote_message(
         vote: Vote,
         rank: u16,
-        shred_verion: u16,
+        shred_version: u16,
     ) -> VersionedWireConsensusMessage {
         VersionedWireConsensusMessage::new_from_vote(
-            VoteMessage {
-                vote,
-                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-                rank,
-                stake: NonZero::new(123).unwrap(),
-            },
-            shred_verion,
+            test_vote(vote, rank, shred_version),
+            shred_version,
         )
+    }
+
+    fn test_vote(vote: Vote, rank: u16, shred_version: u16) -> VoteMessage {
+        let bls_keypair = BlsKeypair::new();
+        let payload = get_vote_payload_to_sign(vote, shred_version);
+        let signature = SignatureAffine::from(bls_keypair.sign(&payload));
+        VoteMessage {
+            vote,
+            signature,
+            rank,
+            stake: NonZero::new(123).unwrap(),
+        }
     }
 
     fn test_certificate_message(
@@ -623,45 +634,29 @@ mod tests {
         )
     }
 
-    #[test_case(BLSOp::PushVote {
-        vote: Arc::new(VoteMessage {
-            vote: Vote::new_skip_vote(5),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            rank: 1,
-            stake:NonZero::new(123).unwrap()
-        }),
-    }, ConsensusMessage::Vote(VoteMessage {
-        vote: Vote::new_skip_vote(5),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-    }))]
+    #[test_case(BLSOp::PushVote { vote: Arc::new(test_vote(Vote::new_skip_vote(5), 1, 0)) }, None)]
     #[test_case(BLSOp::PushCertificates {
         certificates: vec![Arc::new(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
         })],
-    }, ConsensusMessage::Certificate(Certificate {
+    }, Some(ConsensusMessage::Certificate(Certificate {
         cert_type: CertificateType::Skip(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
         bitmap: Vec::new(),
-    }))]
+    })))]
     #[test_case(BLSOp::RefreshVotes {
-        votes: vec![Arc::new(VoteMessage {
-        vote: Vote::new_skip_vote(6),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-        })],
-    }, ConsensusMessage::Vote(VoteMessage {
-        vote: Vote::new_skip_vote(6),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        rank: 1,
-        stake:NonZero::new(123).unwrap()
-    }))]
-    fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {
+        votes: vec![Arc::new(test_vote(Vote::new_skip_vote(6), 1, 0))],
+    }, None)]
+    fn test_send_message(bls_op: BLSOp, expected_message: Option<ConsensusMessage>) {
         agave_logger::setup();
+
+        let expected_message = expected_message.unwrap_or_else(|| match &bls_op {
+            BLSOp::PushVote { vote } => ConsensusMessage::Vote((**vote).clone()),
+            BLSOp::RefreshVotes { votes } => ConsensusMessage::Vote((*votes[0]).clone()),
+            _ => panic!("expected message is required for certificate operations"),
+        });
 
         let listener_kp = Keypair::new();
         let listener_pubkey = listener_kp.pubkey();


### PR DESCRIPTION
#### Problem

This is a subset of https://github.com/anza-xyz/agave/pull/14934.  In particular, we noticed that storing BLSSignature in VoteAggregate and VoteMessage causes the consensus pool thread to do a lot of crypto operations.


#### Summary of Changes

The bls-sigverify already computes SignatureAffine so changing VoteAggregate and VoteMessage to store SignatureAffine in them avoids the crypto operations in the consensus thread pool.


#### Testing

See #14934 for more information on testing.