### PR TITLE
accounts-db: get_account_data_lens() takes offsets as IntoIterator

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -12,7 +12,9 @@ use {
     solana_pubkey::Pubkey,
     std::{
         fs::File,
-        io, mem,
+        io,
+        iter::ExactSizeIterator,
+        mem,
         path::{Path, PathBuf},
     },
     thiserror::Error,
@@ -209,10 +211,13 @@ impl AccountsFile {
         }
     }
 
-    /// for each offset in `sorted_offsets`, get the data size
-    pub(crate) fn get_account_data_lens(&self, sorted_offsets: &[usize]) -> Vec<usize> {
+    /// Returns the account data size for each account in `offsets`.
+    pub(crate) fn get_account_data_lens<'a>(
+        &self,
+        offsets: impl IntoIterator<Item = &'a Offset, IntoIter: ExactSizeIterator>,
+    ) -> Vec<usize> {
         match self {
-            Self::AppendVec(av) => av.get_account_data_lens(sorted_offsets),
+            Self::AppendVec(av) => av.get_account_data_lens(offsets),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -38,6 +38,7 @@ use {
         convert::TryFrom,
         fs::{File, OpenOptions, remove_file},
         io,
+        iter::ExactSizeIterator,
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,
@@ -873,13 +874,17 @@ impl AppendVec {
         STORE_META_OVERHEAD.checked_add(data_len)
     }
 
-    /// for each offset in `sorted_offsets`, get the the amount of data stored in the account.
-    pub(crate) fn get_account_data_lens(&self, sorted_offsets: &[usize]) -> Vec<usize> {
+    /// Returns the account data size for each account in `offsets`.
+    pub(crate) fn get_account_data_lens<'a>(
+        &self,
+        offsets: impl IntoIterator<Item = &'a Offset, IntoIter: ExactSizeIterator>,
+    ) -> Vec<usize> {
         // self.len() is an atomic load, so only do it once
         let self_len = self.len();
-        let mut account_sizes = Vec::with_capacity(sorted_offsets.len());
+        let offsets = offsets.into_iter();
+        let mut account_sizes = Vec::with_capacity(offsets.len());
         let mut buffer = [MaybeUninit::<u8>::uninit(); mem::size_of::<StoredMeta>()];
-        for &offset in sorted_offsets {
+        for &offset in offsets {
             // SAFETY: `read_into_buffer` will only write to uninitialized memory.
             let Some(bytes_read) = read_into_buffer(
                 &self.file,


### PR DESCRIPTION
#### Problem

The `AccountInfo::Offset` type (alias) is currently a file offset, and specifically for append vec. To support new account file formats, the Offset type will need to change to be a *logical* offset.

The `AccountsFile::get_account_data_lens()` fn takes in a slice of Offsets, which means updating the Offset is more constrained. E.g. if a caller has `Vec<u64>` and this fn goes from `&[u64]` -> `&[u32]`, the caller needs a new Vec/equiv. to make the call.

This is the case in `remove_dead_accounts()`.

I'd like to transition Offset layer-by-later. So AppendVec then AccountsFile, then AccountsDb/AccountInfo/Index (may have some additional layers in here).


#### Summary of Changes

Change the `offsets` param in `get_account_data_lens()` to be an iterator. The callers can then `.map()` to a new offset type when needed, without needing a new allocation.


#### Testing

Nothing additional.