### PR TITLE
ledger-tool: fix incorrect leader on child bank

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -55,6 +55,7 @@ use {
         blockstore::{Blockstore, PurgeType, banking_trace_path, create_new_ledger},
         blockstore_options::{AccessType, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, LedgerColumnOptions},
         blockstore_processor::ProcessSlotCallback,
+        leader_schedule_cache::LeaderScheduleCache,
         shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_measure::{measure::Measure, measure_time},
@@ -2208,8 +2209,17 @@ fn main() {
                         || bootstrap_validator_pubkeys.is_some();
 
                     if child_bank_required {
-                        let mut child_bank =
-                            Bank::new_from_parent(bank.clone(), *bank.leader(), bank.slot() + 1);
+                        let child_slot = bank.slot() + 1;
+                        let child_leader = LeaderScheduleCache::new_from_bank(&bank)
+                            .slot_leader_at(child_slot, Some(&bank))
+                            .unwrap_or_else(|| {
+                                eprintln!(
+                                    "Error: Unable to determine the leader of child slot \
+                                     {child_slot}"
+                                );
+                                exit(1);
+                            });
+                        let mut child_bank = Bank::new_from_parent(bank, child_leader, child_slot);
 
                         if let Ok(rent_burn_percentage) = rent_burn_percentage {
                             child_bank.set_rent_burn_percentage(rent_burn_percentage);


### PR DESCRIPTION
#### Problem
When `ledger-tool` creates an artificial child bank as part of `create-snapshot` it uses the same leader as the parent bank.

In v4.1 we introduced a startup check to verify that the leader is correct:
https://github.com/anza-xyz/agave/blob/4df92ed59babbed50d61d246eb1dcf8cb428c4c4/runtime/src/bank.rs#L2199-L2202

If the artificial child bank is for a different leader window than the parent bank, the snapshot will be rejected.

#### Summary of Changes
Check the leader schedule cache and use the correct leader for the child bank

#### Testing
Verified on a snapshot from the AG community cluster