### PR TITLE
local-cluster: only compare full snapshots in test_boot_from_local_state

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5016,7 +5016,7 @@ fn test_boot_from_local_state() {
     // so use it as the comparison for others.
     // - wait for validator1 to take new snapshots
     // - wait for the other validators to have high enough snapshots
-    // - ensure the other validators' snapshots match validator1's
+    // - ensure the other validators' full snapshots match validator1's
     //
     // NOTE: There's a chance validator 2 or 3 has crossed the next full snapshot past what
     // validator 1 has.  If that happens, validator 2 or 3 may have purged the snapshots needed
@@ -5042,9 +5042,6 @@ fn test_boot_from_local_state() {
     #[allow(dead_code)]
     #[derive(Debug)]
     struct SnapshotSlot(Slot);
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    struct BaseSlot(Slot);
 
     for (i, other_validator_config) in [(2, &validator2_config), (3, &validator3_config)] {
         info!("Checking if validator{i} has the same snapshots as validator1...");
@@ -5098,46 +5095,6 @@ fn test_boot_from_local_state() {
                 .collect::<Vec<_>>(),
         );
 
-        let other_incremental_snapshot_archives =
-            snapshot_paths::incremental_snapshot_archives_iter(
-                other_validator_config
-                    .incremental_snapshot_archives_dir
-                    .path(),
-            )
-            .collect::<Vec<_>>();
-        debug!(
-            "validator{i} incremental snapshot archives: {other_incremental_snapshot_archives:?}"
-        );
-        assert!(
-            other_incremental_snapshot_archives
-                .iter()
-                .any(
-                    |other_incremental_snapshot_archive| other_incremental_snapshot_archive
-                        .base_slot()
-                        == incremental_snapshot_archive.base_slot()
-                        && other_incremental_snapshot_archive.slot()
-                            == incremental_snapshot_archive.slot()
-                        && other_incremental_snapshot_archive.hash()
-                            == incremental_snapshot_archive.hash()
-                ),
-            "incremental snapshot archive does not match!\n  validator1: {:?}\n  validator{i}: \
-             {:?}",
-            (
-                BaseSlot(incremental_snapshot_archive.base_slot()),
-                SnapshotSlot(incremental_snapshot_archive.slot()),
-                incremental_snapshot_archive.hash(),
-            ),
-            other_incremental_snapshot_archives
-                .iter()
-                .sorted_unstable()
-                .rev()
-                .map(|snap| (
-                    BaseSlot(snap.base_slot()),
-                    SnapshotSlot(snap.slot()),
-                    snap.hash(),
-                ))
-                .collect::<Vec<_>>(),
-        );
         info!("Checking if validator{i} has the same snapshots as validator1... DONE");
     }
 }


### PR DESCRIPTION
#### Problem
Test is flaky as sometimes the validators pick different slots to make incremental snapshots at:
```
thread 'test_boot_from_local_state' (120366) panicked at local-cluster/tests/local_cluster.rs:5091:9:
incremental snapshot archive does not match!
  validator1: (BaseSlot(300), SnapshotSlot(340), SnapshotHash(3LixUvtYGN9UvYhCyue9Fb7kGLKqYda4YJfb8R9FP9sy))
  validator3: [(BaseSlot(300), SnapshotSlot(360), SnapshotHash(7E1eU8x6KuRwSZ95B84a5RY5rv3983LiaweatSTJXvRF)), (BaseSlot(200), SnapshotSlot(290), SnapshotHash(7vPVtX891dF5BfmSr76EQJ8Z1NTM4iV427S4UKoCVCiU)), (BaseSlot(100), SnapshotSlot(190), SnapshotHash(CBtjKYBBwx5KjZForqfFTDErshk7unQWKXiGKmTrsP5f))]
```

Attempting to switch this test to Alpenglow in #14861 made the flake more frequent as `set_root` is now called async.

#### Summary of Changes
Don't compare incremental snapshots

#### Testing
CI