### PR TITLE
feat(scheduling-utils): validate external scheduler interface versions

### DIFF
--- a/scheduling-utils/src/handshake/client.rs
+++ b/scheduling-utils/src/handshake/client.rs
@@ -1,7 +1,7 @@
 use {
     crate::handshake::{
-        ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession,
-        shared::{LOGON_FAILURE, MAX_WORKERS, VERSION},
+        ClientHandshakeError, ClientLogon, ClientSession, ClientWorkerSession, ProtocolVersions,
+        shared::{LOGON_FAILURE, MAX_WORKERS},
     },
     agave_scheduler_bindings::{CheckWorkerToPackMessage, PackToCheckWorkerMessage},
     libc::CMSG_LEN,
@@ -44,13 +44,14 @@ pub fn connect(
     logon: ClientLogon,
     timeout: Duration,
 ) -> Result<ClientSession, ClientHandshakeError> {
-    connect_path(path.as_ref(), logon, timeout)
+    connect_path(path.as_ref(), logon, timeout, ProtocolVersions::current())
 }
 
-fn connect_path(
+pub(crate) fn connect_path(
     path: &Path,
     logon: ClientLogon,
     timeout: Duration,
+    versions: ProtocolVersions,
 ) -> Result<ClientSession, ClientHandshakeError> {
     // NB: Technically this connect call can block indefinitely if the receiver's connection queue
     // is full. In practice this should almost never happen. If it does work arounds are:
@@ -64,7 +65,7 @@ fn connect_path(
     stream.set_write_timeout(Some(timeout))?;
 
     // Send the logon message to the server.
-    send_logon(&mut stream, logon)?;
+    send_logon(&mut stream, logon, versions)?;
 
     // Receive the server's response & on success the files for the newly allocated shared memory.
     let files = recv_response(&mut stream)?;
@@ -75,17 +76,25 @@ fn connect_path(
     Ok(session)
 }
 
-fn send_logon(stream: &mut UnixStream, logon: ClientLogon) -> Result<(), ClientHandshakeError> {
+fn send_logon(
+    stream: &mut UnixStream,
+    logon: ClientLogon,
+    versions: ProtocolVersions,
+) -> Result<(), ClientHandshakeError> {
     // Send the logon message.
     let mut buf = [0; 1024];
-    buf[..8].copy_from_slice(&VERSION.to_le_bytes());
-    const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
-    let ptr = buf[8..LOGON_END].as_mut_ptr().cast::<ClientLogon>();
+    let versions_ptr = buf.as_mut_ptr().cast::<ProtocolVersions>();
+    const LOGON_END: usize =
+        ProtocolVersions::SERIALIZED_SIZE + core::mem::size_of::<ClientLogon>();
+    let logon_ptr = buf[ProtocolVersions::SERIALIZED_SIZE..LOGON_END]
+        .as_mut_ptr()
+        .cast::<ClientLogon>();
     // SAFETY:
     // - `buf` is valid for writes.
-    // - `buf.len()` has enough space for logon's size in memory.
+    // - `buf.len()` has enough space for both values.
     unsafe {
-        core::ptr::write_unaligned(ptr, logon);
+        core::ptr::write_unaligned(versions_ptr, versions);
+        core::ptr::write_unaligned(logon_ptr, logon);
     }
     stream.write_all(&buf)?;
 

--- a/scheduling-utils/src/handshake/server.rs
+++ b/scheduling-utils/src/handshake/server.rs
@@ -1,10 +1,10 @@
 use {
     crate::handshake::{
         AgaveCheckWorkerSession, AgaveHandshakeError, AgaveTpuToPackSession, AgaveWorkerSession,
-        ClientLogon,
+        ClientLogon, ProtocolVersions,
         shared::{
             AgaveSession, GLOBAL_ALLOCATORS, LOGON_FAILURE, LOGON_SUCCESS, MAX_ALLOCATOR_HANDLES,
-            MAX_WORKERS, VERSION,
+            MAX_WORKERS,
         },
     },
     agave_scheduler_bindings::{
@@ -115,20 +115,25 @@ impl Server {
             }
         }
 
-        // Ensure exact version match, version will be bumped any time a backwards incompatible
-        // change is made to handshake/shared memory objects.
-        let version = u64::from_le_bytes(self.buffer[..8].try_into().unwrap());
-        if version != VERSION {
+        // Ensure exact version matches for the handshake and all shared-memory interfaces.
+        let client_versions =
+            ProtocolVersions::try_from_bytes(&self.buffer[..ProtocolVersions::SERIALIZED_SIZE])
+                .unwrap();
+        let server_versions = ProtocolVersions::current();
+        if client_versions != server_versions {
             return Err(AgaveHandshakeError::Version {
-                server: VERSION,
-                client: version,
+                server: server_versions,
+                client: client_versions,
             });
         }
 
         // Read the logon message, cannot panic as we ensure the correct buf size at compile time
         // (hence the const just below).
-        const LOGON_END: usize = 8 + core::mem::size_of::<ClientLogon>();
-        let logon = ClientLogon::try_from_bytes(&self.buffer[8..LOGON_END]).unwrap();
+        const LOGON_END: usize =
+            ProtocolVersions::SERIALIZED_SIZE + core::mem::size_of::<ClientLogon>();
+        let logon =
+            ClientLogon::try_from_bytes(&self.buffer[ProtocolVersions::SERIALIZED_SIZE..LOGON_END])
+                .unwrap();
 
         // Put a hard limit of 64 worker threads for now.
         if !(1..=MAX_WORKERS).contains(&logon.worker_count) {

--- a/scheduling-utils/src/handshake/shared.rs
+++ b/scheduling-utils/src/handshake/shared.rs
@@ -4,6 +4,7 @@ use {
         PackToExecutionWorkerMessage, ProgressMessage, TpuToPackMessage,
     },
     rts_alloc::Allocator,
+    std::fmt,
     thiserror::Error,
 };
 
@@ -12,12 +13,61 @@ pub(crate) type ShaqError = shaq::error::Error;
 
 pub const MAX_WORKERS: usize = 64;
 
-/// Protocol version.
-pub(crate) const VERSION: u64 = 5;
+/// Handshake protocol version.
+pub(crate) const HANDSHAKE_VERSION: u64 = 6;
 pub(crate) const LOGON_SUCCESS: u8 = 0x01;
 pub(crate) const LOGON_FAILURE: u8 = 0x02;
 pub(crate) const MAX_ALLOCATOR_HANDLES: usize = 128;
 pub(crate) const GLOBAL_ALLOCATORS: usize = 1;
+
+/// Versions of the interfaces shared by Agave and an external scheduler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct ProtocolVersions {
+    /// Version of the handshake protocol.
+    pub handshake: u64,
+    /// Version of the scheduler bindings.
+    pub scheduler_bindings: u64,
+    /// Version of the shared-memory queues.
+    pub shaq: u64,
+    /// Version of the shared-memory allocator.
+    pub rts_alloc: u64,
+}
+
+impl ProtocolVersions {
+    pub(crate) const SERIALIZED_SIZE: usize = core::mem::size_of::<Self>();
+
+    /// Returns the versions used by this build.
+    pub fn current() -> Self {
+        Self {
+            handshake: HANDSHAKE_VERSION,
+            scheduler_bindings: agave_scheduler_bindings::version(),
+            shaq: u64::from(shaq::VERSION),
+            rts_alloc: u64::from(rts_alloc::VERSION),
+        }
+    }
+
+    pub(crate) fn try_from_bytes(buffer: &[u8]) -> Option<Self> {
+        if buffer.len() != Self::SERIALIZED_SIZE {
+            return None;
+        }
+
+        // SAFETY:
+        // - buffer is correctly sized, initialized and readable.
+        // - `Self` is valid for any byte pattern.
+        Some(unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast()) })
+    }
+}
+
+impl fmt::Display for ProtocolVersions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "handshake={}, scheduler-bindings={}, shaq={}, rts-alloc={}",
+            self.handshake, self.scheduler_bindings, self.shaq, self.rts_alloc
+        )
+    }
+}
 
 /// The logon message sent by the client to the server.
 #[derive(Debug, Default, Clone, Copy)]
@@ -143,8 +193,11 @@ pub enum AgaveHandshakeError {
     Timeout,
     #[error("Close during handshake")]
     EofDuringHandshake,
-    #[error("Version; server={server}; client={client}")]
-    Version { server: u64, client: u64 },
+    #[error("Version; server=({server}); client=({client})")]
+    Version {
+        server: ProtocolVersions,
+        client: ProtocolVersions,
+    },
     #[error("Worker count; count={0}")]
     WorkerCount(usize),
     #[error("Check worker count; count={0}")]

--- a/scheduling-utils/src/handshake/tests.rs
+++ b/scheduling-utils/src/handshake/tests.rs
@@ -1,6 +1,8 @@
 use {
     crate::handshake::{
-        AgaveHandshakeError, ClientHandshakeError, ClientLogon, client::connect, server::Server,
+        AgaveHandshakeError, ClientHandshakeError, ClientLogon, ProtocolVersions,
+        client::{connect, connect_path},
+        server::Server,
         shared::MAX_WORKERS,
     },
     agave_scheduler_bindings::{
@@ -12,6 +14,57 @@ use {
     std::time::Duration,
     tempfile::NamedTempFile,
 };
+
+#[test]
+fn reject_version_mismatches() {
+    let current = ProtocolVersions::current();
+    let mismatched_versions = [
+        ProtocolVersions {
+            handshake: current.handshake.checked_add(1).unwrap(),
+            ..current
+        },
+        ProtocolVersions {
+            scheduler_bindings: current.scheduler_bindings.checked_add(1).unwrap(),
+            ..current
+        },
+        ProtocolVersions {
+            shaq: current.shaq.checked_add(1).unwrap(),
+            ..current
+        },
+        ProtocolVersions {
+            rts_alloc: current.rts_alloc.checked_add(1).unwrap(),
+            ..current
+        },
+    ];
+
+    for client_versions in mismatched_versions {
+        let ipc = NamedTempFile::new().unwrap();
+        std::fs::remove_file(ipc.path()).unwrap();
+        let mut server = Server::new(ipc.path()).unwrap();
+        let server_handle = std::thread::spawn(move || {
+            let Err(AgaveHandshakeError::Version { server, client }) = server.accept() else {
+                panic!();
+            };
+            assert_eq!(server, current);
+            assert_eq!(client, client_versions);
+        });
+
+        let result = connect_path(
+            ipc.path(),
+            ClientLogon::default(),
+            Duration::from_secs(1),
+            client_versions,
+        );
+        let Err(ClientHandshakeError::Rejected(reason)) = result else {
+            panic!();
+        };
+        assert_eq!(
+            reason,
+            format!("Version; server=({current}); client=({client_versions})")
+        );
+        server_handle.join().unwrap();
+    }
+}
 
 #[test]
 fn message_passing_on_all_queues() {


### PR DESCRIPTION
#### Problem
- current handshake version currently represents a globbing together of multiple things (handshake itself, scheduler-bindings, shaq version, rts-alloc version) this means we need to be careful around upgrading shaq/rts-alloc if they break abi => need to remember to bump this version

#### Summary of Changes
- Just expose individual versions for the 4 protocols (handshake, scheduler-bindings messages, shaq, rts-alloc)

#### Testing
- CI

Fixes #
