### PR TITLE
fix(core): gate external check workers on Unix

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/check_worker.rs
+++ b/core/src/banking_stage/transaction_scheduler/check_worker.rs
@@ -120,6 +120,7 @@ mod tests {
     }
 }
 
+#[cfg(unix)]
 pub(crate) mod external {
     use {
         crate::banking_stage::{


### PR DESCRIPTION
#### Problem
- #14915 broke windows because I forgot to gate a module on unix

#### Summary of Changes
- add cfg(unix) gate on external check worker module

#### Testing
- ran cargo check core with windows target

Fixes #
