### PR TITLE
runtime: Bench external commission receiver during epoch turnover

### DIFF
--- a/runtime/benches/epoch_turnover.rs
+++ b/runtime/benches/epoch_turnover.rs
@@ -43,6 +43,7 @@ const DELEGATED_STAKE_LAMPORTS: u64 = 1_000 * LAMPORTS_PER_SOL;
 const VALIDATOR_STAKE_LAMPORTS: u64 = 1_000 * LAMPORTS_PER_SOL;
 const GENESIS_MINT_LAMPORTS: u64 = 1_000_000 * LAMPORTS_PER_SOL;
 const SYNTHETIC_VOTE_SLOTS: u64 = (MAX_LOCKOUT_HISTORY as u64) + 42;
+const PENDING_DELEGATOR_REWARDS: u64 = 1_000;
 
 fn create_stake_account(
     vote_pubkey: &Pubkey,
@@ -80,13 +81,26 @@ fn create_stake_account(
     Account::from(account)
 }
 
-fn populate_vote_accounts(bank: &Bank, vote_pubkeys: Vec<Pubkey>) {
+fn populate_vote_accounts(
+    bank: &Bank,
+    vote_pubkeys: Vec<Pubkey>,
+    external_inflation_collector: bool,
+) {
     for vote_pubkey in vote_pubkeys.into_iter() {
         let mut vote_account = bank.get_account(&vote_pubkey).unwrap();
 
-        let mut vote_state = VoteStateHandler::new_v4(
-            VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap(),
-        );
+        let mut v4 = VoteStateV4::deserialize(vote_account.data(), &vote_pubkey).unwrap();
+        v4.pending_delegator_rewards = PENDING_DELEGATOR_REWARDS;
+        if external_inflation_collector {
+            let commission_collector = Pubkey::new_unique();
+            v4.inflation_rewards_collector = commission_collector;
+            let lamports = bank.rent_collector().rent.minimum_balance(0);
+            let account =
+                AccountSharedData::new(lamports, 0, &solana_sdk_ids::system_program::id());
+            bank.store_account(&commission_collector, &account);
+        }
+
+        let mut vote_state = VoteStateHandler::new_v4(v4);
 
         for i in 0..SYNTHETIC_VOTE_SLOTS {
             process_slot_vote_unchecked(&mut vote_state, i);
@@ -103,6 +117,7 @@ fn setup_bank(
     vote_accounts: usize,
     stake_accounts: usize,
     inactive_accounts: usize,
+    external_inflation_collector: bool,
 ) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
     let validators = (0..vote_accounts)
         .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -147,7 +162,7 @@ fn setup_bank(
     let (initial_bank, bank_forks) =
         Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
 
-    populate_vote_accounts(&initial_bank, vote_pubkeys);
+    populate_vote_accounts(&initial_bank, vote_pubkeys, external_inflation_collector);
 
     let last_slot_in_epoch = initial_bank.get_slots_in_epoch(0).checked_sub(1).unwrap();
 
@@ -165,16 +180,37 @@ fn setup_bank(
 fn bench_epoch_turnover(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_epoch_turnover");
 
-    let mut cases =
-        iproduct!(VOTE_ACCOUNTS, STAKE_ACCOUNTS, [ONE_INACTIVE_ACCOUNT]).collect::<Vec<_>>();
-    cases.push((VOTE_ACCOUNTS[1], STAKE_ACCOUNTS[1], MANY_INACTIVE_ACCOUNTS));
+    let mut cases = iproduct!(
+        VOTE_ACCOUNTS,
+        STAKE_ACCOUNTS,
+        [ONE_INACTIVE_ACCOUNT],
+        [false, true]
+    )
+    .collect::<Vec<_>>();
+    cases.push((
+        VOTE_ACCOUNTS[1],
+        STAKE_ACCOUNTS[1],
+        MANY_INACTIVE_ACCOUNTS,
+        false,
+    ));
 
-    for (vote_accounts, stake_accounts, inactive_accounts) in cases.into_iter() {
+    for (vote_accounts, stake_accounts, inactive_accounts, external_inflation_collector) in
+        cases.into_iter()
+    {
+        let collector_type = if external_inflation_collector {
+            "external"
+        } else {
+            "vote_account"
+        };
         let name =
-            format!("{vote_accounts}_votes_{stake_accounts}_stakes_{inactive_accounts}_inactive");
+            format!("{vote_accounts}_votes_{stake_accounts}_stakes_{inactive_accounts}_inactive_{collector_type}_collector");
 
-        let (initial_bank, bank_forks) =
-            setup_bank(vote_accounts, stake_accounts, inactive_accounts);
+        let (initial_bank, bank_forks) = setup_bank(
+            vote_accounts,
+            stake_accounts,
+            inactive_accounts,
+            external_inflation_collector,
+        );
         let first_epoch_slot = initial_bank.slot() + 1;
 
         group.bench_function(name.as_str(), move |b| {
@@ -200,7 +236,7 @@ fn bench_epoch_rewards_period(c: &mut Criterion) {
         let name = format!("{vote_accounts}_votes_{stake_accounts}_stakes");
 
         let (initial_bank, bank_forks) =
-            setup_bank(vote_accounts, stake_accounts, ONE_INACTIVE_ACCOUNT);
+            setup_bank(vote_accounts, stake_accounts, ONE_INACTIVE_ACCOUNT, false);
         let first_epoch_slot = initial_bank.slot() + 1;
 
         let bank = Arc::new(Bank::new_from_parent(


### PR DESCRIPTION
#### Problem

The epoch rollover benches are very useful for quickly profiling the impact of any code changes in the new epoch code, but they are missing pending delegator rewards and external commission collectors, which can both impact the timing of new epoch changes.

Specifically, an external commission collector means that two account updates must be performed instead of one: the collector account is credited lamports, and the vote account has its pending delegator rewards swept.

#### Summary of changes

Update the bench to set some pending delegator rewards, and also allow for setting an external inflation commission collector.

Very helpful for #14946

#### Testing

Running the bench