### PR TITLE
ci: trying use git fetch with cli

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -133,6 +133,7 @@ ARGS+=(
   --env CI_JOB_ID
   --env CI_PULL_REQUEST
   --env CI_REPO_SLUG
+  --env "CARGO_NET_GIT_FETCH_WITH_CLI=true"
 )
 
 CODECOV_ENVS=


### PR DESCRIPTION
#### Problem

afaik cargo uses libgit2 by default. we've already seen quite a few cases where it gets stuck or behaves inconsistently. not sure whether it's due to github connectivity issues or cargo itself. let's try using the git cli instead for a while and see if it helps

#### Summary of Changes

pass `CARGO_NET_GIT_FETCH_WITH_CLI=true` to container