### PR TITLE
Cleanup - `last_modification_slot` in SVM

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6943,10 +6943,11 @@ impl InvokeContextCallback for Bank {
 }
 
 impl TransactionProcessingCallback for Bank {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.rc
             .accounts
             .load_with_fixed_root(&self.ancestors, pubkey, None::<fn(_, &_, _) -> _>)
+            .map(|(account, _slot)| account)
     }
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1908,7 +1908,7 @@ fn test_load_and_execute_commit_transactions_fees_only(define_ltds_fee_only_sema
         for key in &transaction.message.account_keys {
             if let Some(n) = bank
                 .get_account_shared_data(key)
-                .map(|(account, _)| account.data().len())
+                .map(|account| account.data().len())
             {
                 loaded_accounts_data_size += (n + TRANSACTION_ACCOUNT_BASE_SIZE) as u32
             }

--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "agave-unstable-api")]
 use {
-    solana_account::AccountSharedData, solana_clock::Slot,
-    solana_precompile_error::PrecompileError, solana_pubkey::Pubkey,
+    solana_account::AccountSharedData, solana_precompile_error::PrecompileError,
+    solana_pubkey::Pubkey,
 };
 
 /// Callback used by InvokeContext in SVM
@@ -34,7 +34,7 @@ pub trait InvokeContextCallback {
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
     }

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -128,7 +128,7 @@ information.
 
 ```rust
 pub trait TransactionProcessingCallback {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
 
     fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
 }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -288,7 +288,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             };
 
             (option_account, false)
-        } else if let Some((account, _slot)) = self.callbacks.get_account_shared_data(account_key) {
+        } else if let Some(account) = self.callbacks.get_account_shared_data(account_key) {
             (Some(account), true)
         } else {
             (None, true)
@@ -341,8 +341,8 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
 // that if we fall back to accounts-db, we cannot store the state for future loads.
 // In practice, all accounts we load this way will already be in our accounts store.
 impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for AccountLoader<'_, CB> {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(pubkey).0.map(|account| (account, 0))
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        self.do_load(pubkey).0
     }
 }
 
@@ -737,7 +737,7 @@ mod tests {
 
     #[derive(Clone)]
     struct TestCallbacks {
-        accounts_map: HashMap<Pubkey, (AccountSharedData, Slot)>,
+        accounts_map: HashMap<Pubkey, AccountSharedData>,
         #[allow(clippy::type_complexity)]
         inspected_accounts:
             RefCell<HashMap<Pubkey, Vec<(Option<AccountSharedData>, /* is_writable */ bool)>>>,
@@ -755,10 +755,8 @@ mod tests {
     }
 
     impl TransactionProcessingCallback for TestCallbacks {
-        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
-            self.accounts_map
-                .get(pubkey)
-                .map(|(account, slot)| (account.clone(), *slot))
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+            self.accounts_map.get(pubkey).cloned()
         }
 
         fn inspect_account(
@@ -801,7 +799,7 @@ mod tests {
         let fee_payer_account = accounts[0].1.clone();
         let mut accounts_map = HashMap::new();
         for (pubkey, account) in accounts {
-            accounts_map.insert(*pubkey, (account.clone(), 1));
+            accounts_map.insert(*pubkey, account.clone());
         }
         let callbacks = TestCallbacks {
             accounts_map,
@@ -1133,7 +1131,7 @@ mod tests {
         let mut error_metrics = TransactionErrorMetrics::default();
         let mut accounts_map = HashMap::new();
         for (pubkey, account) in accounts {
-            accounts_map.insert(*pubkey, (account.clone(), 1));
+            accounts_map.insert(*pubkey, account.clone());
         }
         let callbacks = TestCallbacks {
             accounts_map,
@@ -1515,7 +1513,7 @@ mod tests {
         fee_payer_account.set_lamports(fee_payer_balance);
         mock_bank
             .accounts_map
-            .insert(fee_payer_address, (fee_payer_account.clone(), 1));
+            .insert(fee_payer_address, fee_payer_account.clone());
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1564,12 +1562,12 @@ mod tests {
         let mut mock_bank = TestCallbacks::default();
         mock_bank
             .accounts_map
-            .insert(native_loader::id(), (AccountSharedData::default(), 0));
+            .insert(native_loader::id(), AccountSharedData::default());
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_lamports(200);
         mock_bank
             .accounts_map
-            .insert(key1.pubkey(), (fee_payer_account.clone(), 1));
+            .insert(key1.pubkey(), fee_payer_account.clone());
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1621,9 +1619,7 @@ mod tests {
         let mut mock_bank = TestCallbacks::default();
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(200);
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1668,9 +1664,7 @@ mod tests {
         let mut mock_bank = TestCallbacks::default();
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(200);
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1720,15 +1714,13 @@ mod tests {
         account_data.set_owner(native_loader::id());
         account_data.set_lamports(1);
         account_data.set_executable(true);
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_lamports(200);
         mock_bank
             .accounts_map
-            .insert(key2.pubkey(), (fee_payer_account.clone(), 1));
+            .insert(key2.pubkey(), fee_payer_account.clone());
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1761,7 +1753,7 @@ mod tests {
                 (key2.pubkey(), fee_payer_account),
                 (
                     key1.pubkey(),
-                    mock_bank.accounts_map[&key1.pubkey()].0.clone()
+                    mock_bank.accounts_map[&key1.pubkey()].clone()
                 ),
             ],
             result.unwrap(),
@@ -1792,15 +1784,11 @@ mod tests {
         let mut mock_bank = TestCallbacks::default();
         let mut account_data = AccountSharedData::default();
         account_data.set_executable(true);
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(200);
-        mock_bank
-            .accounts_map
-            .insert(key2.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1848,18 +1836,14 @@ mod tests {
         account_data.set_lamports(1);
         account_data.set_executable(true);
         account_data.set_owner(key3.pubkey());
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(200);
+        mock_bank.accounts_map.insert(key2.pubkey(), account_data);
         mock_bank
             .accounts_map
-            .insert(key2.pubkey(), (account_data, 1));
-        mock_bank
-            .accounts_map
-            .insert(key3.pubkey(), (AccountSharedData::default(), 0));
+            .insert(key3.pubkey(), AccountSharedData::default());
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1910,15 +1894,13 @@ mod tests {
         account_data.set_lamports(1);
         account_data.set_executable(true);
         account_data.set_owner(bpf_loader::id());
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 1));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_lamports(200);
         mock_bank
             .accounts_map
-            .insert(key2.pubkey(), (fee_payer_account.clone(), 1));
+            .insert(key2.pubkey(), fee_payer_account.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(1);
@@ -1926,7 +1908,7 @@ mod tests {
         account_data.set_owner(native_loader::id());
         mock_bank
             .accounts_map
-            .insert(bpf_loader::id(), (account_data, 0));
+            .insert(bpf_loader::id(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -1959,7 +1941,7 @@ mod tests {
                 (key2.pubkey(), fee_payer_account),
                 (
                     key1.pubkey(),
-                    mock_bank.accounts_map[&key1.pubkey()].0.clone()
+                    mock_bank.accounts_map[&key1.pubkey()].clone()
                 ),
             ],
             result.unwrap(),
@@ -2000,15 +1982,13 @@ mod tests {
         account_data.set_lamports(1);
         account_data.set_executable(true);
         account_data.set_owner(bpf_loader::id());
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 0));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_lamports(200);
         mock_bank
             .accounts_map
-            .insert(key2.pubkey(), (fee_payer_account.clone(), 1));
+            .insert(key2.pubkey(), fee_payer_account.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(1);
@@ -2016,7 +1996,7 @@ mod tests {
         account_data.set_owner(native_loader::id());
         mock_bank
             .accounts_map
-            .insert(bpf_loader::id(), (account_data, 0));
+            .insert(bpf_loader::id(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -2051,7 +2031,7 @@ mod tests {
                 (key2.pubkey(), fee_payer_account),
                 (
                     key1.pubkey(),
-                    mock_bank.accounts_map[&key1.pubkey()].0.clone()
+                    mock_bank.accounts_map[&key1.pubkey()].clone()
                 ),
                 (key3.pubkey(), account_data),
             ],
@@ -2075,14 +2055,13 @@ mod tests {
         system_data.set_executable(true);
         system_data.set_owner(native_loader::id());
         bank.accounts_map
-            .insert(Pubkey::new_from_array([0u8; 32]), (system_data, 0));
+            .insert(Pubkey::new_from_array([0u8; 32]), system_data);
 
         let mut mint_data = AccountSharedData::default();
         mint_data.set_lamports(2);
+        bank.accounts_map.insert(mint_keypair.pubkey(), mint_data);
         bank.accounts_map
-            .insert(mint_keypair.pubkey(), (mint_data, 0));
-        bank.accounts_map
-            .insert(recipient, (AccountSharedData::default(), 1));
+            .insert(recipient, AccountSharedData::default());
         let mut account_loader = (&bank).into();
 
         let tx = transfer(&mint_keypair, &recipient, LAMPORTS_PER_SOL, last_block_hash);
@@ -2165,15 +2144,13 @@ mod tests {
         account_data.set_lamports(1);
         account_data.set_executable(true);
         account_data.set_owner(bpf_loader::id());
-        mock_bank
-            .accounts_map
-            .insert(key1.pubkey(), (account_data, 0));
+        mock_bank.accounts_map.insert(key1.pubkey(), account_data);
 
         let mut fee_payer_account = AccountSharedData::default();
         fee_payer_account.set_lamports(200);
         mock_bank
             .accounts_map
-            .insert(key2.pubkey(), (fee_payer_account.clone(), 1));
+            .insert(key2.pubkey(), fee_payer_account.clone());
 
         let mut account_data = AccountSharedData::default();
         account_data.set_lamports(1);
@@ -2181,7 +2158,7 @@ mod tests {
         account_data.set_owner(native_loader::id());
         mock_bank
             .accounts_map
-            .insert(bpf_loader::id(), (account_data, 0));
+            .insert(bpf_loader::id(), account_data);
         let mut account_loader = (&mock_bank).into();
 
         let mut error_metrics = TransactionErrorMetrics::default();
@@ -2223,11 +2200,11 @@ mod tests {
                 accounts: vec![
                     (
                         key2.pubkey(),
-                        mock_bank.accounts_map[&key2.pubkey()].0.clone()
+                        mock_bank.accounts_map[&key2.pubkey()].clone()
                     ),
                     (
                         key1.pubkey(),
-                        mock_bank.accounts_map[&key1.pubkey()].0.clone()
+                        mock_bank.accounts_map[&key1.pubkey()].clone()
                     ),
                     (key3.pubkey(), account_data),
                 ],
@@ -2401,15 +2378,11 @@ mod tests {
 
         let mut account0 = AccountSharedData::default();
         account0.set_lamports(1_000_000_000);
-        mock_bank
-            .accounts_map
-            .insert(address0, (account0.clone(), 1));
+        mock_bank.accounts_map.insert(address0, account0.clone());
 
         let mut account1 = AccountSharedData::default();
         account1.set_lamports(2_000_000_000);
-        mock_bank
-            .accounts_map
-            .insert(address1, (account1.clone(), 1));
+        mock_bank.accounts_map.insert(address1, account1.clone());
 
         // account2 *not* added to the bank's accounts_map
 
@@ -2417,9 +2390,7 @@ mod tests {
         account3.set_lamports(4_000_000_000);
         account3.set_executable(true);
         account3.set_owner(bpf_loader::id());
-        mock_bank
-            .accounts_map
-            .insert(address3, (account3.clone(), 0));
+        mock_bank.accounts_map.insert(address3, account3.clone());
         let mut account_loader = (&mock_bank).into();
 
         let message = Message {
@@ -2496,7 +2467,7 @@ mod tests {
         let mut mock_bank = TestCallbacks::default();
         mock_bank
             .accounts_map
-            .insert(fee_payer, (fee_payer_account.clone(), 1));
+            .insert(fee_payer, fee_payer_account.clone());
 
         // test without stored account
         let mut account_loader: AccountLoader<_> = (&mock_bank).into();
@@ -2525,10 +2496,7 @@ mod tests {
 
         let account_loader: AccountLoader<_> = (&mock_bank).into();
         assert_eq!(
-            account_loader
-                .get_account_shared_data(&fee_payer)
-                .unwrap()
-                .0,
+            account_loader.get_account_shared_data(&fee_payer).unwrap(),
             fee_payer_account
         );
 
@@ -2555,10 +2523,7 @@ mod tests {
             fee_payer_account
         );
         assert_eq!(
-            account_loader
-                .get_account_shared_data(&fee_payer)
-                .unwrap()
-                .0,
+            account_loader.get_account_shared_data(&fee_payer).unwrap(),
             fee_payer_account
         );
 
@@ -2599,9 +2564,7 @@ mod tests {
                 rng.random(),
                 u64::MAX,
             );
-            mock_bank
-                .accounts_map
-                .insert(Pubkey::new_unique(), (account, 1));
+            mock_bank.accounts_map.insert(Pubkey::new_unique(), account);
         }
 
         // fee-payers
@@ -2615,7 +2578,7 @@ mod tests {
                 rng.random(),
                 u64::MAX,
             );
-            mock_bank.accounts_map.insert(fee_payer, (account, 1));
+            mock_bank.accounts_map.insert(fee_payer, account);
             fee_payers.push(fee_payer);
         }
 
@@ -2657,7 +2620,7 @@ mod tests {
                         );
                         mock_bank
                             .accounts_map
-                            .insert(programdata_address, (programdata_account, 1));
+                            .insert(programdata_address, programdata_account);
                         loader_owned_accounts.push(programdata_address);
                     }
 
@@ -2672,7 +2635,7 @@ mod tests {
                     }
                 }
 
-                mock_bank.accounts_map.insert(program_id, (account, 1));
+                mock_bank.accounts_map.insert(program_id, account);
                 loader_owned_accounts.push(program_id);
             }
         }
@@ -2723,7 +2686,7 @@ mod tests {
 
             fee_payers.shuffle(&mut rng);
             let fee_payer = fee_payers[0];
-            let fee_payer_account = mock_bank.accounts_map.get(&fee_payer).cloned().unwrap().0;
+            let fee_payer_account = mock_bank.accounts_map.get(&fee_payer).cloned().unwrap();
 
             let transaction = SanitizedTransaction::from_transaction_for_tests(
                 Transaction::new_with_payer(&instructions, Some(&fee_payer)),
@@ -2737,8 +2700,7 @@ mod tests {
                 .collect::<AHashSet<_>>();
 
             for pubkey in transaction.account_keys().iter() {
-                if let Some((account, _last_modification_slot)) = mock_bank.accounts_map.get(pubkey)
-                {
+                if let Some(account) = mock_bank.accounts_map.get(pubkey) {
                     expected_size += TRANSACTION_ACCOUNT_BASE_SIZE + account.data().len();
                 };
 
@@ -2786,7 +2748,7 @@ mod tests {
         let expected_hit_account = AccountSharedData::default();
         mock_bank
             .accounts_map
-            .insert(hit_address, (expected_hit_account.clone(), 1));
+            .insert(hit_address, expected_hit_account.clone());
 
         let mut account_loader: AccountLoader<_> = (&mock_bank).into();
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -185,7 +185,7 @@ pub struct NoOpTransaction {
 // account states mid-batch.
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct AccountLoader<'a, CB: TransactionProcessingCallback> {
-    loaded_accounts: AHashMap<Pubkey, (AccountSharedData, Slot)>,
+    loaded_accounts: AHashMap<Pubkey, AccountSharedData>,
     callbacks: &'a CB,
     pub(crate) feature_set: &'a SVMFeatureSet,
 }
@@ -206,7 +206,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         if let Some(slot_history) =
             account_overrides.and_then(|overrides| overrides.get(&slot_history::id()))
         {
-            loaded_accounts.insert(slot_history::id(), (slot_history.clone(), 0));
+            loaded_accounts.insert(slot_history::id(), slot_history.clone());
         }
 
         Self {
@@ -256,19 +256,18 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     pub(crate) fn load_account(&mut self, account_key: &Pubkey) -> Option<AccountSharedData> {
         match self.do_load(account_key) {
             // Exists, from AccountLoader.
-            (Some((account, _last_modification_slot)), false) => Some(account),
+            (Some(account), false) => Some(account),
             // Not allocated, but has an AccountLoader placeholder already.
             (None, false) => None,
             // Exists in accounts-db. Store it in AccountLoader for future loads.
-            (Some((account, last_modification_slot)), true) => {
-                self.loaded_accounts
-                    .insert(*account_key, (account.clone(), last_modification_slot));
+            (Some(account), true) => {
+                self.loaded_accounts.insert(*account_key, account.clone());
                 Some(account)
             }
             // Does not exist and has never been seen.
             (None, true) => {
                 self.loaded_accounts
-                    .insert(*account_key, (AccountSharedData::default(), 0));
+                    .insert(*account_key, AccountSharedData::default());
                 None
             }
         }
@@ -277,20 +276,20 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     // Internal helper for core loading logic to prevent code duplication. Returns a bool
     // indicating whether an accounts-db lookup was performed, which allows wrappers with
     // &mut self to insert the account. Wrappers with &self ignore it.
-    fn do_load(&self, account_key: &Pubkey) -> (Option<(AccountSharedData, Slot)>, bool) {
-        if let Some((account, slot)) = self.loaded_accounts.get(account_key) {
+    fn do_load(&self, account_key: &Pubkey) -> (Option<AccountSharedData>, bool) {
+        if let Some(account) = self.loaded_accounts.get(account_key) {
             // If lamports is 0, a previous transaction deallocated this account.
             // We return None instead of the account we found so it can be created fresh.
             // We *never* remove accounts, or else we would fetch stale state from accounts-db.
             let option_account = if account.lamports() == 0 {
                 None
             } else {
-                Some((account.clone(), *slot))
+                Some(account.clone())
             };
 
             (option_account, false)
-        } else if let Some((account, slot)) = self.callbacks.get_account_shared_data(account_key) {
-            (Some((account, slot)), true)
+        } else if let Some((account, _slot)) = self.callbacks.get_account_shared_data(account_key) {
+            (Some(account), true)
         } else {
             (None, true)
         }
@@ -299,11 +298,11 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
     pub(crate) fn update_accounts_for_failed_tx(
         &mut self,
         rollback_accounts: &RollbackAccounts,
-        current_slot: Slot,
+        _current_slot: Slot,
     ) {
         for (account_address, account) in rollback_accounts {
             self.loaded_accounts
-                .insert(*account_address, (account.clone(), current_slot));
+                .insert(*account_address, account.clone());
         }
     }
 
@@ -312,7 +311,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         message: &impl SVMMessage,
         transaction_accounts: &[KeyedAccountSharedData],
         touched_flags: &[bool],
-        current_slot: Slot,
+        _current_slot: Slot,
     ) {
         for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
             if !message.is_writable(i) {
@@ -332,8 +331,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
                 continue;
             }
 
-            self.loaded_accounts
-                .insert(*address, (account.clone(), current_slot));
+            self.loaded_accounts.insert(*address, account.clone());
         }
     }
 }
@@ -344,7 +342,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
 // In practice, all accounts we load this way will already be in our accounts store.
 impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for AccountLoader<'_, CB> {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(pubkey).0
+        self.do_load(pubkey).0.map(|account| (account, 0))
     }
 }
 
@@ -2796,10 +2794,9 @@ mod tests {
         account_loader.load_account(&hit_address);
         let actual_hit_account = account_loader.loaded_accounts.get(&hit_address);
 
-        assert_eq!(actual_hit_account.as_ref().unwrap().0, expected_hit_account);
-        assert_eq!(actual_hit_account.as_ref().unwrap().1, 1);
+        assert_eq!(actual_hit_account.unwrap(), &expected_hit_account);
         assert!(Arc::ptr_eq(
-            &actual_hit_account.unwrap().0.data_clone(),
+            &actual_hit_account.unwrap().data_clone(),
             &expected_hit_account.data_clone()
         ));
 
@@ -2807,10 +2804,9 @@ mod tests {
         account_loader.load_account(&hit_address);
         let actual_hit_account = account_loader.loaded_accounts.get(&hit_address);
 
-        assert_eq!(actual_hit_account.as_ref().unwrap().0, expected_hit_account);
-        assert_eq!(actual_hit_account.as_ref().unwrap().1, 1);
+        assert_eq!(actual_hit_account.unwrap(), &expected_hit_account);
         assert!(Arc::ptr_eq(
-            &actual_hit_account.unwrap().0.data_clone(),
+            &actual_hit_account.unwrap().data_clone(),
             &expected_hit_account.data_clone()
         ));
 
@@ -2823,7 +2819,7 @@ mod tests {
             .clone();
 
         assert!(!Arc::ptr_eq(
-            &expected_miss_account.0.data_clone(),
+            &expected_miss_account.data_clone(),
             &expected_hit_account.data_clone()
         ));
 
@@ -2833,8 +2829,8 @@ mod tests {
 
         assert_eq!(actual_miss_account, Some(&expected_miss_account));
         assert!(Arc::ptr_eq(
-            &actual_miss_account.unwrap().0.data_clone(),
-            &expected_miss_account.0.data_clone()
+            &actual_miss_account.unwrap().data_clone(),
+            &expected_miss_account.data_clone()
         ));
     }
 }

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -186,10 +186,10 @@ pub fn fill_program_cache_from_accounts(
 struct FillFromAccountsCallback<'a>(&'a [(Pubkey, Account)]);
 
 impl TransactionProcessingCallback for FillFromAccountsCallback<'_> {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, u64)> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.0
             .iter()
             .find(|(found_pubkey, _)| *found_pubkey == *pubkey)
-            .map(|(_, account)| (AccountSharedData::from(account.clone()), 0u64))
+            .map(|(_, account)| AccountSharedData::from(account.clone()))
     }
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -32,7 +32,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     pubkey: &Pubkey,
 ) -> Option<ProgramAccountLoadResult> {
-    let (program_account, _last_modification_slot) = callbacks.get_account_shared_data(pubkey)?;
+    let program_account = callbacks.get_account_shared_data(pubkey)?;
 
     let load_result = if loader_v4::check_id(program_account.owner()) {
         loader_v4_get_state(program_account.data())
@@ -49,7 +49,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
             programdata_address,
         }) = bincode::deserialize(program_account.data())
         {
-            if let Some((programdata_account, _slot)) =
+            if let Some(programdata_account) =
                 callbacks.get_account_shared_data(&programdata_address)
             {
                 if bpf_loader_upgradeable::check_id(programdata_account.owner()) {
@@ -207,7 +207,7 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
                 programdata_address,
             }) = bincode::deserialize(program.data())
             {
-                let (programdata, _slot) = callbacks
+                let programdata = callbacks
                     .get_account_shared_data(&programdata_address)
                     .ok_or(TransactionError::ProgramAccountNotFound)?;
                 if !bpf_loader_upgradeable::check_id(programdata.owner()) {
@@ -246,9 +246,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
     for account_key in keys {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
-        } else if let Some((account, _last_modification_slot)) =
-            callbacks.get_account_shared_data(account_key)
-        {
+        } else if let Some(account) = callbacks.get_account_shared_data(account_key) {
             let loader = if loader_v4::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV4
             } else if bpf_loader_upgradeable::check_id(account.owner()) {
@@ -389,11 +387,11 @@ mod tests {
 
     #[derive(Default, Clone)]
     pub(crate) struct MockBankCallback {
-        pub(crate) account_shared_data: RefCell<HashMap<Pubkey, (AccountSharedData, Slot)>>,
+        pub(crate) account_shared_data: RefCell<HashMap<Pubkey, AccountSharedData>>,
     }
 
     impl TransactionProcessingCallback for MockBankCallback {
-        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data.borrow().get(pubkey).cloned()
         }
     }
@@ -418,7 +416,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data, 0));
+            .insert(key, account_data);
         assert!(load_program_accounts(&mock_bank, &key).is_none());
 
         // The native loader is not one of the four this checks for, so a
@@ -428,7 +426,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data, 0));
+            .insert(key, account_data);
         assert!(load_program_accounts(&mock_bank, &key).is_none());
     }
 
@@ -445,7 +443,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data.clone(), 40));
+            .insert(key, account_data.clone());
 
         let result = load_program_accounts(&mock_bank, &key);
         unwrap_as!(result, ProgramOfLoaderV1(program));
@@ -465,7 +463,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data.clone(), 40));
+            .insert(key, account_data.clone());
 
         let result = load_program_accounts(&mock_bank, &key);
         unwrap_as!(result, ProgramOfLoaderV2(program));
@@ -488,7 +486,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(program_key, (invalid_program_account, 40));
+            .insert(program_key, invalid_program_account);
         let result = load_program_accounts(&mock_bank, &program_key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
@@ -497,7 +495,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(program_key, (program_account.clone(), 50));
+            .insert(program_key, program_account.clone());
 
         // Fail: programdata account missing
         let result = load_program_accounts(&mock_bank, &program_key);
@@ -510,7 +508,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         let result = load_program_accounts(&mock_bank, &program_key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
@@ -523,7 +521,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         let result = load_program_accounts(&mock_bank, &program_key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV3);
@@ -533,7 +531,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account.clone(), 60));
+            .insert(programdata_key, programdata_account.clone());
         let result = load_program_accounts(&mock_bank, &program_key);
         unwrap_as!(
             result,
@@ -559,7 +557,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (program_account, 100));
+            .insert(key, program_account);
         let result = load_program_accounts(&mock_bank, &key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
@@ -573,16 +571,16 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (program_account, 100));
+            .insert(key, program_account);
         let result = load_program_accounts(&mock_bank, &key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
 
         // Fail: status is Retracted
-        mock_bank.account_shared_data.borrow_mut().insert(
-            key,
-            (loader_v4_account(9, LoaderV4Status::Retracted, &[]), 100),
-        );
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, loader_v4_account(9, LoaderV4Status::Retracted, &[]));
         let result = load_program_accounts(&mock_bank, &key);
         unwrap_as!(result, InvalidAccountData(owner));
         assert_eq!(owner, ProgramCacheEntryOwner::LoaderV4);
@@ -594,7 +592,7 @@ mod tests {
             mock_bank
                 .account_shared_data
                 .borrow_mut()
-                .insert(key, (program_account.clone(), 100));
+                .insert(key, program_account.clone());
             let result = load_program_accounts(&mock_bank, &key);
             unwrap_as!(result, ProgramOfLoaderV4(program, deployment_slot));
             assert_eq!(program, program_account);
@@ -652,7 +650,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(program_key, (program_account.clone(), 50));
+            .insert(program_key, program_account.clone());
 
         // Create the programdata account as loader-owned, but with no state.
         let mut programdata_account = AccountSharedData::default();
@@ -660,7 +658,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
 
         // Just like we saw earlier in `test_load_program_accounts_loader_v3`,
         // the load result should be `InvalidAccountData(owner)`.
@@ -714,7 +712,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(program_key, (program_account.clone(), 50));
+            .insert(program_key, program_account.clone());
 
         // Create a valid programdata account, but with invalid ELF bytes after
         // the metadata.
@@ -726,7 +724,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
 
         // The accounts themselves are fine, so the load result carries the
         // deployment slot the programdata account named.
@@ -782,7 +780,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
+            .insert(key, account_data.clone());
 
         // This should return an error
         let entry = load_program_with_pubkey(
@@ -806,7 +804,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
+            .insert(key, account_data.clone());
 
         let entry = load_program_with_pubkey(
             &mock_bank,
@@ -847,7 +845,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key1, (account_data.clone(), 0));
+            .insert(key1, account_data.clone());
 
         let state = UpgradeableLoaderState::ProgramData {
             slot: 0,
@@ -858,7 +856,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, (account_data2.clone(), 0));
+            .insert(key2, account_data2.clone());
 
         // The programdata account is not owned by the loader, so this is a
         // `Closed` tombstone rather than a `FailedVerification` one.
@@ -890,7 +888,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key2, (account_data.clone(), 0));
+            .insert(key2, account_data.clone());
 
         let entry = load_program_with_pubkey(
             &mock_bank,
@@ -925,10 +923,10 @@ mod tests {
         let environment = batch_processor.program_runtime_environment_for_epoch(20);
 
         // Retracted, closed tombstone.
-        mock_bank.account_shared_data.borrow_mut().insert(
-            key,
-            (loader_v4_account(9, LoaderV4Status::Retracted, &[]), 100),
-        );
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, loader_v4_account(9, LoaderV4Status::Retracted, &[]));
         let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
@@ -941,10 +939,10 @@ mod tests {
         assert_eq!(entry.deployment_slot, 200);
 
         // No ELF, fail verification.
-        mock_bank.account_shared_data.borrow_mut().insert(
-            key,
-            (loader_v4_account(9, LoaderV4Status::Deployed, &[]), 100),
-        );
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, loader_v4_account(9, LoaderV4Status::Deployed, &[]));
         let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
@@ -967,7 +965,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account, 100));
+            .insert(key, account);
         let entry = load_program_with_pubkey(
             &mock_bank,
             &environment,
@@ -1000,7 +998,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account_data.clone(), 0));
+            .insert(key, account_data.clone());
 
         for is_upcoming_env in [false, true] {
             let result = load_program_with_pubkey(
@@ -1081,7 +1079,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         assert_eq!(
             get_program_deployment_slot(
                 &mock_bank,
@@ -1099,7 +1097,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         assert_eq!(
             get_program_deployment_slot(
                 &mock_bank,
@@ -1114,7 +1112,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (loader_v3_programdata_account(7, &[]), 60));
+            .insert(programdata_key, loader_v3_programdata_account(7, &[]));
         assert_eq!(
             get_program_deployment_slot(
                 &mock_bank,
@@ -1224,17 +1222,17 @@ mod tests {
                     latest_access_slot: AtomicU64::default(),
                 }),
             );
-            mock_bank.account_shared_data.borrow_mut().insert(
-                loader_ids[i],
-                (AccountSharedData::new(1, 1, &program_ids[3]), 0),
-            );
-            mock_bank.account_shared_data.borrow_mut().insert(
-                program_ids[i],
-                (AccountSharedData::new(1, 1, &loader_ids[i]), 0),
-            );
+            mock_bank
+                .account_shared_data
+                .borrow_mut()
+                .insert(loader_ids[i], AccountSharedData::new(1, 1, &program_ids[3]));
+            mock_bank
+                .account_shared_data
+                .borrow_mut()
+                .insert(program_ids[i], AccountSharedData::new(1, 1, &loader_ids[i]));
             mock_bank.account_shared_data.borrow_mut().insert(
                 account_ids[i],
-                (AccountSharedData::new(1, 1, &program_ids[i]), 0),
+                AccountSharedData::new(1, 1, &program_ids[i]),
             );
         }
 
@@ -1247,7 +1245,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(program_ids[2], (program, 0));
+            .insert(program_ids[2], program);
         let state = UpgradeableLoaderState::ProgramData {
             slot: 0,
             upgrade_authority_address: None,
@@ -1257,7 +1255,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_address, (programdata, 0));
+            .insert(programdata_address, programdata);
 
         let tx = Transaction::new_with_compiled_instructions(
             &[&feepayer],
@@ -1311,7 +1309,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account, 0));
+            .insert(key, account);
 
         let entry = Arc::new(ProgramCacheEntry::new_closed_tombstone(
             0,
@@ -1350,7 +1348,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (account, 0));
+            .insert(key, account);
 
         let keys = [key];
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
@@ -1377,7 +1375,7 @@ mod tests {
             mock_bank
                 .account_shared_data
                 .borrow_mut()
-                .insert(key, (empty, 40));
+                .insert(key, empty);
             assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
             // Any non-empty data is considered to *maybe* be a program.
@@ -1387,7 +1385,7 @@ mod tests {
             mock_bank
                 .account_shared_data
                 .borrow_mut()
-                .insert(key, (account, 40));
+                .insert(key, account);
 
             let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
             assert_eq!(result.len(), 1);
@@ -1407,7 +1405,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (loader_v3_program_account(programdata_key), 50));
+            .insert(key, loader_v3_program_account(programdata_key));
 
         // Case: programdata account does not exist.
         // Can't read deployment slot, nothing is queued.
@@ -1420,7 +1418,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Case: programdata account exists, but wrong state.
@@ -1431,14 +1429,14 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (programdata_account, 60));
+            .insert(programdata_key, programdata_account);
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Successfully queued.
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(programdata_key, (loader_v3_programdata_account(7, &[]), 60));
+            .insert(programdata_key, loader_v3_programdata_account(7, &[]));
         let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
         assert_eq!(result.len(), 1);
         let program_to_load = result.first().unwrap();
@@ -1461,7 +1459,7 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (too_small, 100));
+            .insert(key, too_small);
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Case: program account is sized correctly, but all-zeroes. Since
@@ -1473,23 +1471,23 @@ mod tests {
         mock_bank
             .account_shared_data
             .borrow_mut()
-            .insert(key, (gifted, 100));
+            .insert(key, gifted);
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Case: program account holds valid state, but is `Retracted`.
         // `load_program_accounts` calls this invalid, so nothing should be
         // queued here either.
-        mock_bank.account_shared_data.borrow_mut().insert(
-            key,
-            (loader_v4_account(9, LoaderV4Status::Retracted, &[]), 100),
-        );
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, loader_v4_account(9, LoaderV4Status::Retracted, &[]));
         assert!(filter_executable_program_accounts(&mock_bank, &batch, keys.iter()).is_empty());
 
         // Successfully queued.
-        mock_bank.account_shared_data.borrow_mut().insert(
-            key,
-            (loader_v4_account(9, LoaderV4Status::Deployed, &[]), 100),
-        );
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(key, loader_v4_account(9, LoaderV4Status::Deployed, &[]));
         let result = filter_executable_program_accounts(&mock_bank, &batch, keys.iter());
         assert_eq!(result.len(), 1);
         let program_to_load = result.first().unwrap();

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1371,7 +1371,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         callbacks: &CB,
     ) {
         sysvar_cache.fill_missing_entries(|pubkey, set_sysvar| {
-            if let Some((account, _slot)) = callbacks.get_account_shared_data(pubkey) {
+            if let Some(account) = callbacks.get_account_shared_data(pubkey) {
                 set_sysvar(account.data());
             }
         });
@@ -1528,12 +1528,12 @@ mod tests {
     impl InvokeContextCallback for MockBankCallback {}
 
     impl TransactionProcessingCallback for MockBankCallback {
-        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
+        fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
             self.account_shared_data
                 .read()
                 .unwrap()
                 .get(pubkey)
-                .map(|account| (account.clone(), 0))
+                .cloned()
         }
 
         fn inspect_account(

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -69,12 +69,12 @@ pub struct MockBankCallback {
 impl InvokeContextCallback for MockBankCallback {}
 
 impl TransactionProcessingCallback for MockBankCallback {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.account_shared_data
             .read()
             .unwrap()
             .get(pubkey)
-            .map(|account| (account.clone(), 0))
+            .cloned()
     }
 
     fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {


### PR DESCRIPTION
#### Problem

Followup of #15001. See https://github.com/anza-xyz/agave/pull/15001#discussion_r3910192157

#### Summary of Changes

- Removes `last_modification_slot` from `AccountLoader::loaded_accounts`.
- Removes `last_modification_slot` from return value of `TransactionProcessingCallback::get_account_shared_data()`.