### PR TITLE
fixed slot and shred indices to allow the recover bench to run

### DIFF
--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -9,7 +9,8 @@ use {
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            ProcessShredsStats, ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
+            filter::ShredRecoveryContext,
         },
     },
     solana_packet::PACKET_DATA_SIZE,
@@ -23,7 +24,10 @@ use {
 fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
     let mut genesis_config = create_genesis_config(1).genesis_config;
     let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
-    let slots_per_epoch = shred_slot.max(MINIMUM_SLOTS_PER_EPOCH);
+    let slots_per_epoch = shred_slot
+        .saturating_add(1)
+        .saturating_mul(2)
+        .max(MINIMUM_SLOTS_PER_EPOCH);
     genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
@@ -80,13 +84,14 @@ fn make_shreds_from_entries<R: Rng>(
     reed_solomon_cache: &ReedSolomonCache,
     stats: &mut ProcessShredsStats,
 ) -> (Vec<Shred>, Vec<Shred>) {
+    let next_shred_index = rng.random_range(0..60) * DATA_SHREDS_PER_FEC_BLOCK as u32;
     let (data, code) = shredder.entries_to_merkle_shreds_for_tests(
         keypair,
         entries,
         is_last_in_slot,
         chained_merkle_root,
-        rng.random_range(0..2_000), // next_shred_index
-        rng.random_range(0..2_000), // next_code_index
+        next_shred_index,
+        next_shred_index,
         reed_solomon_cache,
         stats,
     );
@@ -200,6 +205,7 @@ fn run_recover_shreds(
     code.sort_unstable_by_key(|shred| shred.index());
     let mut shreds = data;
     shreds.extend(code);
+
     c.bench_function(name, |b| {
         let mut shred_recovery_context = new_shred_recovery_context(&shreds);
         b.iter(|| {

--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -3,14 +3,12 @@ use {
     criterion::{Criterion, criterion_group, criterion_main},
     rand::Rng,
     solana_entry::entry::Entry,
-    solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
-            filter::ShredRecoveryContext,
+            ProcessShredsStats, ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
         },
     },
     solana_packet::PACKET_DATA_SIZE,
@@ -22,13 +20,7 @@ use {
 };
 
 fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
-    let mut genesis_config = create_genesis_config(1).genesis_config;
-    let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
-    let slots_per_epoch = shred_slot
-        .saturating_add(1)
-        .saturating_mul(2)
-        .max(MINIMUM_SLOTS_PER_EPOCH);
-    genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
+    let genesis_config = create_genesis_config(1).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
     ShredRecoveryContext::new(
@@ -74,8 +66,7 @@ fn make_dummy_entries<R: Rng>(rng: &mut R, data_size: usize) -> Vec<Entry> {
         .collect()
 }
 
-fn make_shreds_from_entries<R: Rng>(
-    rng: &mut R,
+fn make_shreds_from_entries(
     shredder: &Shredder,
     keypair: &Keypair,
     entries: &[Entry],
@@ -84,14 +75,13 @@ fn make_shreds_from_entries<R: Rng>(
     reed_solomon_cache: &ReedSolomonCache,
     stats: &mut ProcessShredsStats,
 ) -> (Vec<Shred>, Vec<Shred>) {
-    let next_shred_index = rng.random_range(0..60) * DATA_SHREDS_PER_FEC_BLOCK as u32;
     let (data, code) = shredder.entries_to_merkle_shreds_for_tests(
         keypair,
         entries,
         is_last_in_slot,
         chained_merkle_root,
-        next_shred_index,
-        next_shred_index,
+        0,
+        0,
         reed_solomon_cache,
         stats,
     );
@@ -105,13 +95,13 @@ fn run_make_shreds_from_entries(
     is_last_in_slot: bool,
 ) {
     let mut rng = rand::rng();
-    let slot = 315_892_061 + rng.random_range(0..=100_000);
-    let parent_offset = rng.random_range(1..=u16::MAX);
+    let slot = rng.random_range(1..=100_000);
+    let parent_offset = 1;
     let shredder = Shredder::new(
         slot,
-        slot - u64::from(parent_offset), // parent_slot
-        rng.random_range(0..64),         // reference_tick
-        rng.random(),                    // shred_version
+        slot - parent_offset,    // parent_slot
+        rng.random_range(0..64), // reference_tick
+        rng.random(),            // shred_version
     )
     .unwrap();
     let keypair = Keypair::new();
@@ -123,7 +113,6 @@ fn run_make_shreds_from_entries(
     // Initialize the thread-pool and warm the Reed-Solomon cache.
     for _ in 0..10 {
         make_shreds_from_entries(
-            &mut rng,
             &shredder,
             &keypair,
             &entries,
@@ -136,7 +125,6 @@ fn run_make_shreds_from_entries(
     c.bench_function(name, |b| {
         b.iter(|| {
             let (data, code) = make_shreds_from_entries(
-                &mut rng,
                 &shredder,
                 &keypair,
                 &entries,
@@ -175,7 +163,6 @@ fn run_recover_shreds(
     let reed_solomon_cache = ReedSolomonCache::default();
     let mut stats = ProcessShredsStats::default();
     let (data, code) = make_shreds_from_entries(
-        &mut rng,
         &shredder,
         &keypair,
         &entries,
@@ -205,7 +192,6 @@ fn run_recover_shreds(
     code.sort_unstable_by_key(|shred| shred.index());
     let mut shreds = data;
     shreds.extend(code);
-
     c.bench_function(name, |b| {
         let mut shred_recovery_context = new_shred_recovery_context(&shreds);
         b.iter(|| {

--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -95,7 +95,7 @@ fn run_make_shreds_from_entries(
     is_last_in_slot: bool,
 ) {
     let mut rng = rand::rng();
-    let slot = rng.random_range(1..=100_000);
+    let slot = rng.random_range(1..=400);
     let parent_offset = 1;
     let shredder = Shredder::new(
         slot,
@@ -147,13 +147,13 @@ fn run_recover_shreds(
     is_last_in_slot: bool,
 ) {
     let mut rng = rand::rng();
-    let slot = 315_892_061 + rng.random_range(0..=100_000);
-    let parent_offset = rng.random_range(1..=u16::MAX);
+    let slot = rng.random_range(1..=400);
+    let parent_offset = 1;
     let shredder = Shredder::new(
         slot,
-        slot - u64::from(parent_offset), // parent_slot
-        rng.random_range(0..64),         // reference_tick
-        rng.random(),                    // shred_version
+        slot - parent_offset,    // parent_slot
+        rng.random_range(0..64), // reference_tick
+        rng.random(),            // shred_version
     )
     .unwrap();
     let keypair = Keypair::new();


### PR DESCRIPTION
#### Problem

The shred erasure `recover` bench stopped working likely quite some time ago due to bounds checks that were introduced.

#### Summary of Changes

In the bench setup, I adjusted `slots_per_epoch` to pass the check and aligned the FEC set index to be a multiple of 32 and be the same for both data and coding shreds.

#### Testing

The `bench_recover_shreds_*` can now be run.

Fixes #
