### PR TITLE
WIP: implementation of additive FFT Reed-Solomon encoding for shreds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "additive-fft-reed-solomon"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a52212a3f225892782b55adf22d2c03ce62043ebe138c0a2fb349218cb29cc"
+dependencies = [
+ "additive-fft-reed-solomon-gf2p8",
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "additive-fft-reed-solomon-gf2p8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52bd08bc1cbd6f99f6afe7de6be4f818f79a93365f97c2986f8a9162d74a8b2"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +46,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -78,10 +94,10 @@ dependencies = [
  "bitvec",
  "criterion",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "solana-bls-signatures",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-signer-store",
  "thiserror 2.0.20",
  "wincode",
@@ -103,7 +119,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "log",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
  "qualifier_attr",
  "rayon",
  "smallvec",
@@ -112,13 +128,13 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-runtime",
@@ -140,11 +156,11 @@ dependencies = [
 name = "agave-feature-set"
 version = "4.4.0-alpha.2"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-pubkey 4.3.0",
  "solana-sha256-hasher",
@@ -159,7 +175,7 @@ dependencies = [
  "io-uring",
  "libc",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "slab",
  "smallvec",
  "tempfile",
@@ -174,7 +190,7 @@ dependencies = [
  "log",
  "solana-bls-signatures",
  "solana-clock",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
  "solana-signature",
  "solana-transaction",
@@ -188,7 +204,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-logger",
  "bzip2",
- "clap 2.33.3",
+ "clap 2.34.0",
  "console 0.16.4",
  "crossbeam-channel",
  "ctrlc",
@@ -197,10 +213,10 @@ dependencies = [
  "nix",
  "reqwest 0.12.28",
  "scopeguard",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_yaml",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sha256-hasher",
  "solana-version",
  "tar",
@@ -237,7 +253,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-math-utils",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "test-case",
 ]
 
@@ -254,7 +270,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "openssl",
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-ed25519-program",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -271,9 +287,9 @@ name = "agave-random"
 version = "4.4.0-alpha.2"
 dependencies = [
  "assert_matches",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sha256-hasher",
  "test-case",
 ]
@@ -304,7 +320,7 @@ dependencies = [
  "agave-feature-set",
  "agave-scheduler-bindings",
  "agave-transaction-view",
- "ahash 0.8.12",
+ "ahash",
  "libc",
  "nix",
  "rts-alloc",
@@ -332,13 +348,13 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "lz4",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
- "semver 1.0.28",
+ "semver",
  "solana-accounts-db",
  "solana-clock",
  "solana-genesis-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-lattice-hash",
  "solana-measure",
  "solana-metrics",
@@ -355,7 +371,7 @@ dependencies = [
 name = "agave-store-histogram"
 version = "4.4.0-alpha.2"
 dependencies = [
- "clap 2.33.3",
+ "clap 2.34.0",
  "solana-version",
 ]
 
@@ -366,9 +382,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83adf0eb2a269e96090deb451df68e72ed03bc3005bd8222dd82bdf33f8fbd08"
 dependencies = [
  "bytes",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
  "solana-short-vec",
@@ -394,7 +410,7 @@ dependencies = [
  "bytesize",
  "caps",
  "chrono",
- "clap 2.33.3",
+ "clap 2.34.0",
  "console 0.16.4",
  "crossbeam-channel",
  "fd-lock",
@@ -410,13 +426,13 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "scopeguard",
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-clap-utils",
@@ -432,7 +448,7 @@ dependencies = [
  "solana-genesis-utils",
  "solana-geyser-plugin-manager",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-inflation",
  "solana-keypair",
  "solana-ledger",
@@ -489,8 +505,8 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.15.0",
  "log",
- "parking_lot 0.12.3",
- "rand 0.9.4",
+ "parking_lot 0.12.5",
+ "rand 0.9.5",
  "serde",
  "serde_bytes",
  "smallvec",
@@ -500,7 +516,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -543,7 +559,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-leader-schedule",
  "solana-pubkey 4.3.0",
  "solana-short-vec",
@@ -579,13 +595,13 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-feature-set",
  "agave-logger",
- "clap 2.33.3",
+ "clap 2.34.0",
  "humantime",
  "log",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-metrics",
  "solana-native-token",
  "solana-notifier",
@@ -625,17 +641,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -649,33 +654,24 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "alloc-no-stdlib"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -691,15 +687,15 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -712,27 +708,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -748,15 +729,6 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-parse"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
@@ -766,21 +738,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -809,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "archery"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+checksum = "33ca55ee147b1926dbea904f50fe4902494e97bc742205abbbf10c709e43815f"
 
 [[package]]
 name = "ark-bn254"
@@ -830,14 +803,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "ark-std",
  "educe 0.6.0",
  "fnv",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -872,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -885,7 +858,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -894,13 +867,13 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "ark-ff",
  "ark-serialize",
  "ark-std",
  "educe 0.6.0",
  "fnv",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -924,7 +897,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -934,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -962,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
- "bstr 1.4.0",
+ "bstr",
  "libc",
  "predicates",
  "predicates-core",
@@ -984,14 +957,12 @@ checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "async-compression"
-version = "0.4.1"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+checksum = "515a1f282e33d55983c499d7e9e87082e81cbc32974825bf9032f928392d5844"
 dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
+ "compression-codecs",
+ "compression-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -1015,7 +986,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1053,15 +1024,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autotools"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
 dependencies = [
  "cc",
 ]
@@ -1076,7 +1047,7 @@ dependencies = [
  "assert_matches",
  "aya-obj",
  "bitflags 2.13.1",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "libc",
  "log",
  "nix",
@@ -1094,8 +1065,8 @@ checksum = "609b414caa508f04d2dbbc9481ad6869f43ab9ab1dc9abd237fca27c0818f663"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "rustc_version 0.4.1",
- "which 8.0.4",
+ "rustc_version",
+ "which 8.0.6",
 ]
 
 [[package]]
@@ -1139,7 +1110,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1180,9 +1151,9 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bencher"
@@ -1213,8 +1184,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1223,8 +1194,8 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.100",
- "rand 0.8.6",
+ "bitcoin_hashes 0.14.101",
+ "rand 0.8.8",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -1262,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "hex-conservative",
 ]
@@ -1322,8 +1293,8 @@ dependencies = [
  "cc",
  "cfg-if 1.0.4",
  "constant_time_eq",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1346,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1392,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1403,28 +1374,28 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+checksum = "12cdfe656708a01f89b451a7d36466e6fe6c414de0aa18fc54f864f6f9ca9f56"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "boxcar"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bb12751a83493ef4b8da1120451a262554e216a247f14b48cb5e8fe7ed8bdf"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1433,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1453,30 +1424,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "bstr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
-dependencies = [
- "memchr",
- "once_cell",
- "regex-automata 0.1.10",
- "serde",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bv"
@@ -1511,7 +1472,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1555,20 +1516,19 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -1600,7 +1560,7 @@ checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -1614,21 +1574,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1653,9 +1607,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cfg_eval"
@@ -1665,17 +1619,17 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1704,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -1715,15 +1669,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -1735,15 +1689,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -1751,35 +1705,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
- "unicode-width 0.1.9",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
- "textwrap 0.16.0",
+ "textwrap 0.16.2",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1787,26 +1741,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
- "clap_lex 0.7.7",
+ "clap_lex 1.1.0",
  "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1820,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
@@ -1832,9 +1786,9 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1851,22 +1805,31 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "compression-codecs"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+checksum = "2fe67f2944eef52fc7b106b8c9450d243a88701a0c065f7f57235e76abaed7df"
 dependencies = [
- "crossbeam-utils",
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
 ]
+
+[[package]]
+name = "compression-core"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8ccc4ea9f6acc32d102c0f6d471d11d913ad15f20c04de743374861fa1d414"
 
 [[package]]
 name = "console"
@@ -1877,7 +1840,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1889,8 +1852,8 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
- "windows-sys 0.61.0",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1943,19 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1978,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1996,15 +1949,15 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if 1.0.4",
 ]
@@ -2019,7 +1972,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.31",
+ "clap 4.6.6",
  "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
@@ -2055,11 +2008,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
- "cfg-if 1.0.4",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -2089,9 +2041,9 @@ checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -2107,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -2118,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2149,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -2173,14 +2125,14 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -2210,7 +2162,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rand_core 0.6.4",
- "rustc_version 0.4.1",
+ "rustc_version",
  "serde",
  "subtle",
  "zeroize",
@@ -2224,7 +2176,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2247,7 +2199,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2258,7 +2210,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2274,19 +2226,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if 1.0.4",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.12",
  "rayon",
  "serde",
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.3.2"
+name = "dashmap"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.12",
+ "serde",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "der"
@@ -2300,12 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derivation-path"
@@ -2332,31 +2327,31 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.16"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.3.3",
- "syn 1.0.109",
+ "rustc_version",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2377,8 +2372,8 @@ dependencies = [
  "convert_case 0.10.0",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
- "syn 2.0.117",
+ "rustc_version",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -2423,18 +2418,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2461,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
@@ -2473,13 +2468,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2510,11 +2505,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature 1.4.0",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2534,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519 1.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
@@ -2577,7 +2572,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2589,14 +2584,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -2632,7 +2627,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2652,27 +2647,27 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2691,7 +2686,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
@@ -2706,30 +2701,29 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -2737,21 +2731,21 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.4",
- "siphasher 1.0.2",
+ "portable-atomic",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fd-lock"
@@ -2789,9 +2783,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed3d8a5e20435ff00469e51a0d82049bae66504b5c429920dadf9bb54d47b3f"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
@@ -2800,21 +2794,19 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.15"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall 0.2.10",
- "winapi",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "five8"
@@ -2854,12 +2846,13 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2915,9 +2908,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -2993,7 +2989,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3060,16 +3056,17 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -3106,14 +3103,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3124,11 +3121,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
- "js-sys",
  "libc",
- "r-efi 5.2.0",
+ "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3138,28 +3133,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
- "aho-corasick 0.7.18",
- "bstr 0.2.17",
- "fnv",
+ "aho-corasick",
+ "bstr",
  "log",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3186,7 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rand_core 0.6.4",
  "rand_xorshift 0.3.0",
  "subtle",
@@ -3194,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3204,7 +3201,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util 0.7.19",
@@ -3213,9 +3210,14 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hash32"
@@ -3231,25 +3233,18 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3269,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3292,9 +3287,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -3304,24 +3299,24 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+checksum = "db3fef046dca3ca91ee1408a8c1b80ab777e80a4d308d1bf4e7adb3fcb047e08"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "hidapi"
-version = "2.6.6"
+version = "2.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+checksum = "818c0e1d27887aaf76fe737042e27a66b796a7b099e6d2e1a72d106c2dff3fa6"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
  "libc",
  "pkg-config",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3375,7 +3370,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3401,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http 0.2.12",
@@ -3412,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http 1.5.0",
@@ -3422,14 +3417,14 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -3441,9 +3436,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -3459,9 +3454,9 @@ checksum = "a17b27f28a7466846baca75f0a5244e546e44178eb7f1c07a3820f413e91c6b0"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3477,7 +3472,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http-body 0.4.5",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -3491,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3501,11 +3496,10 @@ dependencies = [
  "futures-core",
  "h2",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3513,21 +3507,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http 1.5.0",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -3536,7 +3528,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3551,7 +3543,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3570,8 +3562,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.5.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http-body 1.1.0",
+ "hyper 1.11.1",
  "ipnet",
  "libc",
  "percent-encoding 2.3.2",
@@ -3584,34 +3576,47 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "winapi",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3621,96 +3626,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3743,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3777,7 +3745,7 @@ dependencies = [
  "bitmaps 3.2.1",
  "equivalent",
  "imbl-sized-chunks",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "rand_xoshiro 0.7.0",
  "rayon",
  "serde_core",
@@ -3806,12 +3774,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "rayon",
 ]
 
@@ -3823,25 +3791,25 @@ checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console 0.16.4",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.4",
 ]
@@ -3859,25 +3827,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -3917,16 +3875,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -3935,39 +3895,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.23"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if 1.0.4",
- "combine 4.6.7",
- "jni-sys 0.3.1",
+ "combine 4.6.8",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.20",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3986,25 +3961,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if 1.0.4",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -4024,7 +4001,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
- "derive_more 0.99.16",
+ "derive_more 0.99.20",
  "futures 0.3.34",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -4191,11 +4168,11 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy-lru"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b031495510a5a17bfb14e9f1fc00f6efdebfaa9ab04a876a4e153b042a3fe06"
+checksum = "a35523c6dfa972e1fd19132ef647eff4360a6546c6271807e1327ca6e8797f96"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4206,9 +4183,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -4252,9 +4229,18 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -4282,7 +4268,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.6",
+ "rand 0.8.8",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -4331,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4354,9 +4340,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4366,17 +4352,16 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -4388,20 +4373,11 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
-dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4443,9 +4419,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -4514,15 +4490,15 @@ dependencies = [
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4530,13 +4506,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.61.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4562,7 +4538,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4583,7 +4559,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4593,28 +4569,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
+name = "multimap"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.37"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -4645,13 +4626,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
- "version_check",
 ]
 
 [[package]]
@@ -4662,9 +4642,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4672,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4684,7 +4664,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4695,14 +4675,14 @@ checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -4743,17 +4723,17 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -4771,28 +4751,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.17.0",
- "indexmap 2.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.1",
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -4816,20 +4802,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
@@ -4868,9 +4854,9 @@ checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "owo-colors"
@@ -4925,44 +4911,44 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
+ "parking_lot_core 0.9.12",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.4",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -5019,22 +5005,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
 ]
 
 [[package]]
@@ -5044,8 +5021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
- "hashbrown 0.15.1",
- "indexmap 2.14.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.1",
 ]
 
 [[package]]
@@ -5065,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.6",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -5078,7 +5055,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5087,7 +5064,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -5117,20 +5094,14 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -5144,15 +5115,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -5163,15 +5134,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -5190,17 +5161,26 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -5211,9 +5191,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -5237,9 +5220,9 @@ checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -5278,7 +5261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5292,18 +5275,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5316,7 +5299,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
 ]
 
@@ -5330,7 +5313,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -5370,7 +5353,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap",
+ "multimap 0.8.3",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -5390,7 +5373,7 @@ dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
- "multimap",
+ "multimap 0.10.1",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
  "prost 0.14.4",
@@ -5398,7 +5381,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -5425,7 +5408,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5494,9 +5477,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
@@ -5505,9 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+checksum = "ab1ad36992cead65f02aa399a373a42730922f1525d988172634fdefdecb8a60"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -5529,7 +5512,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5560,15 +5543,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5583,31 +5567,32 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -5636,9 +5621,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5647,12 +5632,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5693,7 +5678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5711,14 +5696,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -5748,6 +5733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5762,7 +5756,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5780,7 +5774,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -5809,45 +5803,31 @@ version = "4.4.0-alpha.2"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
- "redox_syscall 0.2.10",
-]
-
-[[package]]
-name = "reed-solomon-erasure"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
-dependencies = [
- "cc",
- "libc",
- "libm",
- "lru 0.7.8",
- "parking_lot 0.11.2",
- "smallvec",
- "spin",
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5856,25 +5836,19 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "memchr",
- "regex-automata 0.4.16",
+ "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "regex-automata"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "memchr",
  "regex-syntax",
 ]
@@ -5897,9 +5871,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5923,14 +5897,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5938,9 +5912,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -5996,7 +5970,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if 1.0.4",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -6034,17 +6008,17 @@ checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.1"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6054,7 +6028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a7239c091a5c3e96677bb7ad465b4ffe87f6c4a8b4db6a260f16863b57cff63"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6069,24 +6043,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -6094,20 +6059,20 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6120,7 +6085,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6140,21 +6105,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6162,11 +6127,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -6175,10 +6140,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6200,15 +6165,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -6218,9 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -6242,12 +6207,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "lazy_static",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6278,25 +6242,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6314,15 +6265,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
@@ -6332,21 +6274,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "seqlock"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
 dependencies = [
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -6395,7 +6328,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6442,7 +6375,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6451,7 +6384,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde",
@@ -6468,7 +6401,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
  "serial_test_derive",
 ]
 
@@ -6480,14 +6413,14 @@ checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
@@ -6525,8 +6458,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6537,9 +6470,9 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -6552,29 +6485,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "409fbc30bb3899d634b1414fd42d946f1f980faf3e2cd209a564b45c189f82f8"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shuttle"
@@ -6587,9 +6526,9 @@ dependencies = [
  "generator",
  "hex",
  "owo-colors",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rand_core 0.6.4",
- "rand_pcg",
+ "rand_pcg 0.3.1",
  "scoped-tls",
  "smallvec",
  "tracing",
@@ -6607,18 +6546,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -6632,9 +6572,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simpl"
@@ -6650,9 +6606,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sized-chunks"
@@ -6681,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -6721,7 +6677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6735,7 +6691,7 @@ dependencies = [
  "futures 0.3.34",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.8.8",
  "sha1",
 ]
 
@@ -6754,9 +6710,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c83d346056532a7ef16177dbb799abf73da080e93eae3de6a901c726ce47fb0"
+checksum = "981155967c57428348ca75b2296e079688d09bf16c5751502eaa49f65da83cb1"
 dependencies = [
  "bincode",
  "serde",
@@ -6785,14 +6741,14 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-config-interface",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-loader-v3-interface",
  "solana-nonce",
@@ -6826,7 +6782,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-pubkey 4.3.0",
  "zstd",
 ]
@@ -6849,9 +6805,9 @@ name = "solana-accounts-cluster-bench"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-logger",
- "clap 2.33.3",
+ "clap 2.34.0",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "solana-accounts-db",
  "solana-clap-utils",
@@ -6862,7 +6818,7 @@ dependencies = [
  "solana-core",
  "solana-faucet",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-local-cluster",
@@ -6895,27 +6851,27 @@ dependencies = [
  "agave-fs",
  "agave-logger",
  "agave-reserved-account-keys",
- "ahash 0.8.12",
+ "ahash",
  "assert_matches",
  "bincode",
  "blake3",
  "bv",
  "criterion",
- "dashmap",
+ "dashmap 5.5.3",
  "itertools 0.15.0",
  "log",
  "memoffset",
  "modular-bitfield",
  "num_cpus",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
  "seqlock",
  "serde",
  "serde_bytes",
  "smallvec",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
@@ -6924,7 +6880,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-lattice-hash",
@@ -6985,7 +6941,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "five8",
  "five8_const",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_derive",
  "sha2-const-stable",
@@ -7025,7 +6981,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
 dependencies = [
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -7034,12 +6990,12 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "borsh",
  "futures 0.3.34",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-banks-interface",
  "solana-banks-server",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
  "solana-program-pack",
  "solana-pubkey 4.3.0",
@@ -7064,10 +7020,10 @@ name = "solana-banks-interface"
 version = "4.4.0-alpha.2"
 dependencies = [
  "serde",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
  "solana-pubkey 4.3.0",
  "solana-signature",
@@ -7084,11 +7040,11 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "futures 0.3.34",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
  "solana-pubkey 4.3.0",
  "solana-runtime",
@@ -7130,7 +7086,7 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -7140,12 +7096,12 @@ dependencies = [
  "bencher",
  "bv",
  "fnv",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "solana-bloom",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sanitize",
  "solana-sha256-hasher",
  "solana-signature",
@@ -7167,7 +7123,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rayon",
  "serde",
  "serde_json",
@@ -7227,9 +7183,9 @@ dependencies = [
  "bincode",
  "criterion",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "shuttle",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -7239,7 +7195,7 @@ dependencies = [
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -7266,7 +7222,7 @@ dependencies = [
  "agave-feature-set",
  "assert_matches",
  "bincode",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-instruction",
@@ -7286,14 +7242,14 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.4.0-alpha.2"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bv",
  "bytemuck",
  "bytemuck_derive",
  "memmap2 0.9.11",
  "modular-bitfield",
  "num_enum",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "solana-bucket-map",
  "solana-clock",
@@ -7309,7 +7265,7 @@ dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
@@ -7324,7 +7280,7 @@ name = "solana-builtins-default-costs"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-feature-set",
- "ahash 0.8.12",
+ "ahash",
  "qualifier_attr",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
@@ -7339,7 +7295,7 @@ dependencies = [
  "bip39",
  "bs58",
  "chrono",
- "clap 2.33.3",
+ "clap 2.34.0",
  "rpassword",
  "solana-bls-signatures",
  "solana-cli-config",
@@ -7347,7 +7303,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -7371,7 +7327,7 @@ dependencies = [
  "assert_matches",
  "bip39",
  "chrono",
- "clap 3.2.23",
+ "clap 3.2.25",
  "five8",
  "rpassword",
  "solana-clap-v3-utils",
@@ -7380,7 +7336,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-commitment-config",
  "solana-derivation-path",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
@@ -7411,7 +7367,7 @@ dependencies = [
  "bincode",
  "bip39",
  "bs58",
- "clap 2.33.3",
+ "clap 2.34.0",
  "console 0.16.4",
  "const_format",
  "hex",
@@ -7422,7 +7378,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-bls-signatures",
@@ -7441,7 +7397,7 @@ dependencies = [
  "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-fee-structure",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -7451,7 +7407,7 @@ dependencies = [
  "solana-nonce",
  "solana-nonce-account",
  "solana-offchain-message",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-presigner",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
@@ -7512,15 +7468,15 @@ dependencies = [
  "base64 0.23.1",
  "bitvec",
  "chrono",
- "clap 2.33.3",
+ "clap 2.34.0",
  "console 0.16.4",
  "humantime",
  "indicatif",
  "pretty-hex",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-bls-signatures",
@@ -7529,11 +7485,11 @@ dependencies = [
  "solana-clock",
  "solana-epoch-info",
  "solana-epoch-schedule",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-native-token",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-rpc-client-api",
  "solana-sdk-ids",
@@ -7558,13 +7514,13 @@ dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 5.5.3",
  "futures-util",
  "indicatif",
  "log",
  "solana-commitment-config",
  "solana-connection-cache",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-measure",
  "solana-message",
@@ -7605,7 +7561,7 @@ dependencies = [
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-pubsub-client",
  "solana-rpc",
@@ -7631,10 +7587,10 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0255645cb08e00df08f889d593581d569a8f347072d77946abea320c48f1a80f"
 dependencies = [
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-commitment-config",
  "solana-epoch-info",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -7669,7 +7625,7 @@ checksum = "b0cb69036cd1ac8b8a2c644115535396794b057976de2a1033635c25aba333d5"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -7697,13 +7653,13 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "criterion",
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-borsh",
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -7772,9 +7728,9 @@ dependencies = [
  "agave-logger",
  "async-trait",
  "crossbeam-channel",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "solana-keypair",
  "solana-measure",
@@ -7805,7 +7761,7 @@ dependencies = [
  "agave-votor-messages",
  "agave-votor-transport",
  "agave-xdp",
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "arc-swap",
  "arrayvec",
@@ -7817,7 +7773,7 @@ dependencies = [
  "chrono",
  "criterion",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 5.5.3",
  "futures 0.3.34",
  "histogram",
  "itertools 0.15.0",
@@ -7828,7 +7784,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
  "rolling-file",
@@ -7841,7 +7797,7 @@ dependencies = [
  "signal-hook",
  "slab",
  "smallvec",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -7868,7 +7824,7 @@ dependencies = [
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -7881,7 +7837,7 @@ dependencies = [
  "solana-net-utils",
  "solana-nonce",
  "solana-nonce-account",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-poh",
  "solana-poh-config",
@@ -7948,7 +7904,7 @@ dependencies = [
  "agave-feature-set",
  "agave-logger",
  "agave-reserved-account-keys",
- "ahash 0.8.12",
+ "ahash",
  "itertools 0.15.0",
  "log",
  "solana-bincode",
@@ -7957,11 +7913,11 @@ dependencies = [
  "solana-cost-model",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
  "solana-sdk-ids",
@@ -8006,12 +7962,6 @@ dependencies = [
 
 [[package]]
 name = "solana-define-syscall"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
-
-[[package]]
-name = "solana-define-syscall"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
@@ -8052,14 +8002,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff4c7caf3fe3d70815869a5838ee45b4d2b009eaacea1790ef3cd9b3c89edbbd"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
- "digest 0.11.2",
+ "digest 0.11.3",
  "ed25519 2.2.3",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.5",
  "rand 0.10.2",
  "rand_core 0.10.1",
- "rustc_version 0.4.1",
+ "rustc_version",
  "sha2 0.11.0",
  "subtle",
  "zeroize",
@@ -8082,7 +8032,7 @@ name = "solana-ed25519-program-tests"
 version = "4.4.0-alpha.2"
 dependencies = [
  "assert_matches",
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-ed25519-program",
  "solana-instruction",
  "solana-keypair",
@@ -8108,7 +8058,7 @@ dependencies = [
  "log",
  "num_cpus",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "smallvec",
  "solana-address 2.7.0",
@@ -8116,12 +8066,12 @@ dependencies = [
  "solana-clock",
  "solana-cost-model",
  "solana-entry",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-measure",
  "solana-merkle-tree",
  "solana-message",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
@@ -8155,7 +8105,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-get-sysvar",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -8170,7 +8120,7 @@ checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
  "solana-address 2.7.0",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -8193,12 +8143,12 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-stake"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc6693d0ea833b880514b9b88d95afb80b42762dca98b0712465d1fcbbcb89e"
+checksum = "027e6d0b9e7daac5b2ac7c3f9ca1b727861121d9ef05084cf435ff736051e7c2"
 dependencies = [
- "solana-define-syscall 3.0.0",
- "solana-pubkey 3.0.0",
+ "solana-define-syscall 5.2.0",
+ "solana-pubkey 4.3.0",
 ]
 
 [[package]]
@@ -8209,7 +8159,7 @@ checksum = "0eb265ff95e28eceda117e2e3d2d2a611ecbbfe911dfeeeecd1521814540ffab"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-nonce",
  "solana-pubkey 4.3.0",
@@ -8226,13 +8176,13 @@ dependencies = [
  "log",
  "solana-cli-output",
  "solana-faucet",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-signer",
  "solana-system-interface 3.3.0",
@@ -8249,7 +8199,7 @@ name = "solana-faucet-cli"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-logger",
- "clap 2.33.3",
+ "clap 2.34.0",
  "log",
  "solana-clap-utils",
  "solana-cli-config",
@@ -8269,7 +8219,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
@@ -8320,7 +8270,7 @@ dependencies = [
  "console 0.15.11",
  "indicatif",
  "log",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -8334,12 +8284,12 @@ dependencies = [
  "bs58",
  "bv",
  "bytes",
- "dashmap",
+ "dashmap 6.2.1",
  "im",
  "imbl",
  "log",
  "memmap2 0.5.10",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "serde",
  "serde_derive",
@@ -8358,7 +8308,7 @@ checksum = "3ce2a1f17252391f44f620d4e47d1e3e0bec173f760a86ee7de2426db9ea7496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8371,12 +8321,12 @@ dependencies = [
  "base64 0.23.1",
  "bincode",
  "bs58",
- "clap 2.33.3",
+ "clap 2.34.0",
  "itertools 0.15.0",
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bls-signatures",
  "solana-borsh",
  "solana-clap-utils",
@@ -8424,12 +8374,12 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-inflation",
  "solana-keypair",
  "solana-poh-config",
@@ -8450,7 +8400,7 @@ dependencies = [
  "log",
  "solana-download-utils",
  "solana-genesis-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-rpc-client",
  "thiserror 2.0.20",
 ]
@@ -8481,13 +8431,13 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-bls-signatures",
  "solana-clock",
  "solana-entry",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-ledger",
  "solana-measure",
  "solana-message",
@@ -8518,14 +8468,14 @@ dependencies = [
  "crossbeam-channel",
  "ed25519-dalek 2.2.0",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itertools 0.15.0",
  "lazy-lru",
  "log",
  "num-traits",
  "num_cpus",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
  "serial_test",
@@ -8536,14 +8486,14 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-rayon-threadlimit",
@@ -8576,7 +8526,7 @@ name = "solana-gossip-cli"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-logger",
- "clap 2.33.3",
+ "clap 2.34.0",
  "log",
  "solana-clap-utils",
  "solana-gossip",
@@ -8600,15 +8550,6 @@ dependencies = [
 
 [[package]]
 name = "solana-hash"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
-dependencies = [
- "solana-hash 4.6.0",
-]
-
-[[package]]
-name = "solana-hash"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df9b01495ed31100aca97a7f5862d5e19ab1636d60d1a9f02391408dd9dec84"
@@ -8617,7 +8558,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "five8",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
@@ -8719,7 +8660,7 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -8729,7 +8670,7 @@ dependencies = [
  "agave-votor-messages",
  "bip39",
  "bs58",
- "clap 3.2.23",
+ "clap 3.2.25",
  "dirs-next",
  "num_cpus",
  "serde_json",
@@ -8758,7 +8699,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "five8",
  "five8_core",
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-address 2.7.0",
  "solana-derivation-path",
  "solana-seed-derivable",
@@ -8791,7 +8732,7 @@ dependencies = [
  "bs58",
  "bytemuck",
  "criterion",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "solana-lattice-hash",
 ]
@@ -8802,7 +8743,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-random",
  "itertools 0.15.0",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "solana-clock",
  "solana-pubkey 4.3.0",
@@ -8815,6 +8756,7 @@ dependencies = [
 name = "solana-ledger"
 version = "4.4.0-alpha.2"
 dependencies = [
+ "additive-fft-reed-solomon",
  "agave-feature-set",
  "agave-logger",
  "agave-reserved-account-keys",
@@ -8833,31 +8775,30 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "eager",
  "fs_extra",
  "futures 0.3.34",
  "itertools 0.15.0",
  "lazy-lru",
  "log",
- "lru 0.18.2",
+ "lru",
  "mockall",
  "num_cpus",
  "num_enum",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
  "proptest",
  "prost 0.14.4",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
- "reed-solomon-erasure",
  "rocksdb",
  "scopeguard",
  "serde",
  "shuttle",
  "smallvec",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bls-signatures",
@@ -8869,7 +8810,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-genesis-config",
  "solana-genesis-utils",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -8880,7 +8821,7 @@ dependencies = [
  "solana-native-token",
  "solana-net-utils",
  "solana-nohash-hasher",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-program-option",
  "solana-program-pack",
@@ -8979,10 +8920,10 @@ dependencies = [
  "gag",
  "itertools 0.15.0",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "serial_test",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-bls-signatures",
  "solana-client-traits",
@@ -8999,7 +8940,7 @@ dependencies = [
  "solana-genesis-utils",
  "solana-gossip",
  "solana-hard-forks",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -9007,7 +8948,7 @@ dependencies = [
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-poh-config",
  "solana-program-binaries",
@@ -9052,7 +8993,7 @@ name = "solana-merkle-tree"
 version = "4.4.0-alpha.2"
 dependencies = [
  "hex",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sha256-hasher",
 ]
 
@@ -9068,7 +9009,7 @@ dependencies = [
  "solana-address 2.7.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -9086,7 +9027,7 @@ dependencies = [
  "env_logger",
  "gethostname",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest 0.12.28",
  "serial_test",
  "solana-cluster-type",
@@ -9121,13 +9062,13 @@ dependencies = [
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
- "dashmap",
+ "dashmap 5.5.3",
  "hxdmp",
  "itertools 0.15.0",
  "log",
  "nix",
  "pcap-file",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "shuttle",
  "socket2 0.6.5",
@@ -9156,7 +9097,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-pubkey 4.3.0",
  "solana-sha256-hasher",
  "wincode",
@@ -9168,8 +9109,8 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
- "solana-account 4.6.0",
- "solana-hash 4.6.0",
+ "solana-account 4.7.0",
+ "solana-hash",
  "solana-nonce",
  "solana-sdk-ids",
 ]
@@ -9181,7 +9122,7 @@ dependencies = [
  "log",
  "reqwest 0.12.28",
  "serde_json",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -9196,27 +9137,18 @@ dependencies = [
 
 [[package]]
 name = "solana-offchain-message"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e2a1141a673f72a05cf406b99e4b2b8a457792b7c01afa07b3f00d4e2de393"
+checksum = "cb8ab5c5d46f9e080176ac2987fd81c9923def4d24c1430d82ea67095a8df131"
 dependencies = [
  "num_enum",
- "solana-hash 3.1.0",
- "solana-packet 3.0.0",
- "solana-pubkey 3.0.0",
+ "solana-hash",
+ "solana-packet",
+ "solana-pubkey 4.3.0",
  "solana-sanitize",
  "solana-sha256-hasher",
  "solana-signature",
  "solana-signer",
-]
-
-[[package]]
-name = "solana-packet"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
-dependencies = [
- "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -9244,7 +9176,7 @@ dependencies = [
  "agave-logger",
  "agave-random",
  "agave-transaction-view",
- "ahash 0.8.12",
+ "ahash",
  "arc-swap",
  "assert_matches",
  "bencher",
@@ -9255,18 +9187,18 @@ dependencies = [
  "log",
  "nix",
  "num_cpus",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
  "serde",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
@@ -9301,11 +9233,11 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "shuttle",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -9329,7 +9261,7 @@ name = "solana-poh-bench"
 version = "4.4.0-alpha.2"
 dependencies = [
  "agave-logger",
- "clap 3.2.23",
+ "clap 3.2.25",
  "num_cpus",
  "rayon",
  "solana-entry",
@@ -9397,7 +9329,7 @@ dependencies = [
  "solana-epoch-stake",
  "solana-example-mocks",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar 4.0.0",
@@ -9430,7 +9362,7 @@ name = "solana-program-binaries"
 version = "4.4.0-alpha.2"
 dependencies = [
  "bincode",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -9463,11 +9395,11 @@ dependencies = [
 
 [[package]]
 name = "solana-program-memory"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e5660c60749c7bfb30b447542529758e4dbcecd31b1e8af1fdc92e2bdde90a"
+checksum = "4068648649653c2c50546e9a7fb761791b5ab0cda054c771bb5808d3a4b9eb52"
 dependencies = [
- "solana-define-syscall 3.0.0",
+ "solana-define-syscall 4.0.1",
 ]
 
 [[package]]
@@ -9498,9 +9430,9 @@ dependencies = [
  "log",
  "openssl",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-info",
  "solana-clock",
  "solana-ed25519-program",
@@ -9509,7 +9441,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-keypair",
@@ -9559,7 +9491,7 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address 2.7.0",
@@ -9575,7 +9507,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-loader-v3-interface",
@@ -9627,7 +9559,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f71b7a414de2ced1071f015834e9be581592d013432adbd06d02e4af11eba9"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-address 2.7.0",
 ]
 
@@ -9671,7 +9603,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-quic-client",
@@ -9706,9 +9638,9 @@ dependencies = [
  "log",
  "num-derive 0.5.1",
  "num-traits",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
  "rusb",
- "semver 1.0.28",
+ "semver",
  "serde_json",
  "serial_test",
  "solana-derivation-path",
@@ -9762,7 +9694,7 @@ dependencies = [
  "base64 0.23.1",
  "bs58",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 5.5.3",
  "itertools 0.15.0",
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9777,7 +9709,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "soketto",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -9797,7 +9729,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-leader-schedule",
@@ -9875,10 +9807,10 @@ dependencies = [
  "log",
  "reqwest 0.12.28",
  "reqwest-middleware",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-bls-signatures",
@@ -9887,7 +9819,7 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-schedule",
  "solana-feature-gate-interface",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -9931,15 +9863,15 @@ name = "solana-rpc-client-nonce-utils"
 version = "4.4.0-alpha.2"
 dependencies = [
  "anyhow",
- "clap 2.33.3",
+ "clap 2.34.0",
  "futures 0.3.34",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-commitment-config",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-nonce",
@@ -9963,7 +9895,7 @@ dependencies = [
  "base64 0.23.1",
  "bs58",
  "const_format",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "solana-account-decoder-client-types",
@@ -9997,7 +9929,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-net-utils",
  "solana-pubkey 4.3.0",
@@ -10029,7 +9961,7 @@ dependencies = [
  "agave-snapshots",
  "agave-transaction-view",
  "agave-votor-messages",
- "ahash 0.8.12",
+ "ahash",
  "arc-swap",
  "arrayref",
  "assert_matches",
@@ -10042,7 +9974,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "imbl",
  "itertools 0.15.0",
  "libc",
@@ -10055,16 +9987,16 @@ dependencies = [
  "prost 0.14.4",
  "protosol",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rayon",
  "regex",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_json",
  "serde_with",
  "shuttle",
  "smallvec",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-decoder",
  "solana-account-info",
  "solana-accounts-db",
@@ -10094,7 +10026,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-genesis-config",
  "solana-hard-forks",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-inflation",
  "solana-instruction",
  "solana-instruction-error",
@@ -10108,7 +10040,7 @@ dependencies = [
  "solana-native-token",
  "solana-nonce",
  "solana-nonce-account",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-poh-config",
  "solana-precompile-error",
  "solana-program-binaries",
@@ -10171,11 +10103,11 @@ dependencies = [
  "agave-transaction-view",
  "bytes",
  "criterion",
- "rand 0.9.4",
+ "rand 0.9.5",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -10212,7 +10144,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rustc-demangle",
  "shuttle",
  "thiserror 2.0.20",
@@ -10237,7 +10169,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10308,10 +10240,10 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.15.0",
  "log",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-fee-calculator",
  "solana-genesis-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-measure",
  "solana-metrics",
@@ -10368,7 +10300,7 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.6.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -10401,7 +10333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c79722e299d957958bf33695f7cd1ef6724ff55563c60fd9e3e24487cccde2"
 dependencies = [
  "solana-hard-forks",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sha256-hasher",
 ]
 
@@ -10412,7 +10344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe45ce95700ac8045e422344b88e273843d70185873cc1cc880ba06dd9fa9002"
 dependencies = [
  "five8",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -10454,7 +10386,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-get-sysvar",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
  "wincode",
@@ -10489,8 +10421,8 @@ dependencies = [
 name = "solana-stake-accounts"
 version = "4.4.0-alpha.2"
 dependencies = [
- "clap 2.33.3",
- "solana-account 4.6.0",
+ "clap 2.34.0",
+ "solana-account 4.7.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
@@ -10579,7 +10511,7 @@ dependencies = [
  "solana-entry",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-metrics",
@@ -10611,7 +10543,7 @@ dependencies = [
  "protobuf-src",
  "serde",
  "solana-account-decoder",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.3.0",
@@ -10637,10 +10569,10 @@ dependencies = [
  "assert_matches",
  "bytes",
  "chrono",
- "clap 4.5.31",
+ "clap 4.6.6",
  "crossbeam-channel",
  "futures 0.3.34",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itertools 0.15.0",
  "libc",
  "log",
@@ -10648,7 +10580,7 @@ dependencies = [
  "num_cpus",
  "pem",
  "quinn",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "smallvec",
  "solana-keypair",
@@ -10656,7 +10588,7 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-perf",
  "solana-pubkey 4.3.0",
  "solana-signer",
@@ -10675,7 +10607,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
- "ahash 0.8.12",
+ "ahash",
  "assert_matches",
  "bincode",
  "env_logger",
@@ -10684,10 +10616,10 @@ dependencies = [
  "prost 0.14.4",
  "protosol",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "shuttle",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -10700,7 +10632,7 @@ dependencies = [
  "solana-fee-structure",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar 4.0.0",
@@ -10755,7 +10687,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.4.0-alpha.2"
 dependencies = [
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.3.0",
@@ -10791,7 +10723,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0afde938e0d3f06e87853e6e189396d67256e3b600675d867a47d066f8cebadb"
 dependencies = [
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-message",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
@@ -10804,7 +10736,7 @@ name = "solana-svm-type-overrides"
 version = "4.4.0-alpha.2"
 dependencies = [
  "futures 0.3.34",
- "rand 0.9.4",
+ "rand 0.9.5",
  "shuttle",
 ]
 
@@ -10816,7 +10748,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -10829,7 +10761,7 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-hash-512",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -10898,14 +10830,14 @@ dependencies = [
  "bincode",
  "criterion",
  "log",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bincode",
  "solana-fee-calculator",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-nonce",
  "solana-nonce-account",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -10928,7 +10860,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63f5bfbf00b68749dec8facc7c6dfe48eb42d4834b21b3fd64cd10d81f55874d"
 dependencies = [
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-message",
  "solana-pubkey 4.3.0",
@@ -10957,7 +10889,7 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-fee-calculator",
  "solana-get-sysvar",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
@@ -10997,7 +10929,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-accounts-db",
  "solana-bls-signatures",
  "solana-cli-output",
@@ -11067,11 +10999,11 @@ dependencies = [
  "assert_matches",
  "bincode",
  "chrono",
- "clap 2.33.3",
+ "clap 2.34.0",
  "console 0.16.4",
  "csv",
  "ctrlc",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "indicatif",
  "pickledb",
  "serde",
@@ -11083,7 +11015,7 @@ dependencies = [
  "solana-cli-output",
  "solana-clock",
  "solana-commitment-config",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
@@ -11149,7 +11081,7 @@ dependencies = [
  "futures-util",
  "itertools 0.15.0",
  "log",
- "lru 0.18.2",
+ "lru",
  "quinn",
  "rustls",
  "serde_json",
@@ -11160,7 +11092,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-pubsub-client",
  "solana-rpc-client",
@@ -11188,7 +11120,7 @@ dependencies = [
  "solana-address 2.7.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
@@ -11208,7 +11140,7 @@ dependencies = [
  "bincode",
  "qualifier_attr",
  "serde",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-account-info",
  "solana-instruction",
  "solana-instructions-sysvar 4.0.0",
@@ -11257,7 +11189,7 @@ dependencies = [
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-entry",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-loader-v2-interface",
  "solana-loader-v3-interface",
@@ -11325,8 +11257,8 @@ dependencies = [
  "itertools 0.15.0",
  "lazy-lru",
  "log",
- "lru 0.18.2",
- "rand 0.9.4",
+ "lru",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rayon",
  "solana-clock",
@@ -11335,7 +11267,7 @@ dependencies = [
  "solana-entry",
  "solana-genesis-config",
  "solana-gossip",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-leader-schedule",
  "solana-ledger",
@@ -11371,7 +11303,7 @@ dependencies = [
  "solana-connection-cache",
  "solana-keypair",
  "solana-net-utils",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-streamer",
  "solana-transaction-error",
 ]
@@ -11384,7 +11316,7 @@ dependencies = [
  "assert_matches",
  "bytes",
  "solana-clock",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.3.0",
@@ -11405,7 +11337,7 @@ dependencies = [
  "agave-logger",
  "assert_matches",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 5.5.3",
  "derive-where",
  "derive_more 2.1.1",
  "log",
@@ -11413,7 +11345,7 @@ dependencies = [
  "solana-clock",
  "solana-cost-model",
  "solana-entry",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-keypair",
  "solana-metrics",
  "solana-poh",
@@ -11442,8 +11374,8 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "agave-feature-set",
  "bincode",
- "rand 0.9.4",
- "semver 1.0.28",
+ "rand 0.9.5",
+ "semver",
  "serde",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -11462,18 +11394,18 @@ dependencies = [
  "bincode",
  "log",
  "qualifier_attr",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-keypair",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -11500,14 +11432,14 @@ dependencies = [
  "cfg_eval",
  "num-derive 0.4.2",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_derive",
  "serde_with",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.3.0",
@@ -11532,7 +11464,7 @@ dependencies = [
  "criterion",
  "log",
  "qualifier_attr",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -11540,9 +11472,9 @@ dependencies = [
  "solana-fee-calculator",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash 4.6.0",
+ "solana-hash",
  "solana-instruction",
- "solana-packet 4.3.0",
+ "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -11571,9 +11503,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zero-copy"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea15126ebdc7e270c50d43884369af9f51d2308156d46a18e351522a164844d"
+checksum = "bd3183a7934dd7e6490ae86732616cd70361f5ab9401b9a375ab62f7fa17b112"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -11614,7 +11546,7 @@ name = "solana-zk-elgamal-proof-program-tests"
 version = "4.4.0-alpha.2"
 dependencies = [
  "bytemuck",
- "solana-account 4.6.0",
+ "solana-account 4.7.0",
  "solana-compute-budget",
  "solana-compute-budget-interface",
  "solana-instruction",
@@ -11643,7 +11575,7 @@ dependencies = [
  "hkdf",
  "itertools 0.14.0",
  "merlin",
- "rand 0.8.6",
+ "rand 0.8.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11681,12 +11613,6 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "solana-program-runtime",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -11729,19 +11655,19 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
+checksum = "5d1dbc82ab91422345b6df40a79e2b78c7bce1ebb366da323572dd60b7076b67"
 dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.117",
+ "syn 2.0.119",
  "thiserror 1.0.69",
 ]
 
@@ -11773,7 +11699,7 @@ checksum = "821d96d034ea31c4965d182c742153c491ae0abee531331b55771086c5030d86"
 dependencies = [
  "arrayref",
  "bytemuck",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
@@ -11893,9 +11819,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -11950,7 +11876,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -11978,9 +11904,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11989,9 +11915,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12009,13 +11935,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12091,7 +12017,7 @@ checksum = "57c1932595af3b23fc8635cc23c28c54fb658622e261ad7f8f026da70e69f350"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -12101,17 +12027,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-case"
@@ -12131,7 +12057,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12142,7 +12068,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
@@ -12152,14 +12078,14 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width 0.1.9",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -12196,7 +12122,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12207,7 +12133,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12218,16 +12144,16 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
- "once_cell",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -12262,9 +12188,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -12272,9 +12198,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -12285,15 +12211,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -12311,18 +12237,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -12333,30 +12259,30 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.5",
  "tokio-macros",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -12364,9 +12290,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -12412,7 +12338,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12448,27 +12374,40 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
  "winnow",
 ]
 
@@ -12482,9 +12421,9 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.11.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding 2.3.2",
@@ -12508,7 +12447,7 @@ dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12533,7 +12472,7 @@ dependencies = [
  "prost-build 0.14.4",
  "prost-types 0.14.4",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -12546,7 +12485,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12559,9 +12498,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.13.1",
@@ -12569,15 +12508,15 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.5.0",
- "http-body 1.0.1",
+ "http-body 1.1.0",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util 0.7.19",
  "tower",
  "tower-layer",
  "tower-service",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -12594,9 +12533,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -12606,13 +12545,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12672,9 +12611,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -12687,20 +12626,20 @@ dependencies = [
  "http 1.5.0",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.20",
  "utf-8",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -12716,63 +12655,60 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -12780,7 +12716,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -12877,12 +12813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12896,9 +12826,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -12908,9 +12838,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -12920,31 +12850,29 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -12956,24 +12884,24 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -12984,21 +12912,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if 1.0.4",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13006,31 +12932,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13048,27 +12974,27 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "rustls-pki-types",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13082,14 +13008,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.39",
+ "rustix 0.38.44",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]
@@ -13122,11 +13048,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13160,27 +13086,42 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13191,11 +13132,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.1.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -13215,20 +13165,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -13237,46 +13178,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -13303,12 +13214,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -13321,12 +13226,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -13336,12 +13235,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13363,12 +13256,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -13378,12 +13265,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -13399,12 +13280,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -13417,21 +13292,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.16"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -13448,21 +13317,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -13475,13 +13338,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.14",
- "rustix 0.38.39",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -13498,11 +13360,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -13510,82 +13371,93 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -13594,20 +13466,26 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
-name = "zmij"
-version = "1.0.10"
+name = "zlib-rs"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
@@ -13620,18 +13498,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "additive-fft-reed-solomon"
-version = "0.1.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a52212a3f225892782b55adf22d2c03ce62043ebe138c0a2fb349218cb29cc"
+checksum = "e24cd70cf4280e39cfa7d9f04ec93ff9bb5dbe12a3bc1292d597885770a33fe5"
 dependencies = [
  "additive-fft-reed-solomon-gf2p8",
  "cfg-if 1.0.4",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "additive-fft-reed-solomon-gf2p8"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52bd08bc1cbd6f99f6afe7de6be4f818f79a93365f97c2986f8a9162d74a8b2"
+checksum = "cd1b3ab9b0f5c590193c7f671222f8bd3d67c85cdd5b468b096b7449425539a7"
 
 [[package]]
 name = "adler2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
+additive-fft-reed-solomon = { version = "0.1.2", default-features = false }
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
@@ -317,7 +318,6 @@ quinn = "0.11.11"
 rand = "0.9.4"
 rand_chacha = "0.9.0"
 rayon = "1.12.0"
-reed-solomon-erasure = "6.0.0"
 regex = "1.13.1"
 reqwest = { version = "0.12.28", default-features = false }
 reqwest-middleware = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-additive-fft-reed-solomon = { version = "0.1.2", default-features = false }
+additive-fft-reed-solomon = "0.2"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-additive-fft-reed-solomon = "0.2"
+additive-fft-reed-solomon = "0.2.2"
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -1,19 +1,18 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    bencher::{Bencher, benchmark_group, benchmark_main},
+    bencher::{benchmark_group, benchmark_main, Bencher},
     rand::Rng,
-    solana_entry::entry::{Entry, create_ticks},
+    solana_entry::entry::{create_ticks, Entry},
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats,
-            ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
-            get_data_shred_bytes_per_batch_typical, max_entries_per_n_shred,
-            max_ticks_per_n_shreds,
+            filter::ShredRecoveryContext, get_data_shred_bytes_per_batch_typical,
+            max_entries_per_n_shred, max_ticks_per_n_shreds, ProcessShredsStats, Shred, Shredder,
+            CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK,
         },
     },
     solana_perf::test_tx,
@@ -30,7 +29,6 @@ fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
     ShredRecoveryContext::new(
-        ReedSolomonCache::default(),
         dummy_retransmit_sender,
         root_bank,
         shreds.first().map(Shred::version).unwrap_or_default(),
@@ -61,7 +59,6 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     // ~1Mb
     let num_ticks = max_ticks_per_n_shreds(1, Some(SHRED_SIZE_TYPICAL)) * num_shreds as u64;
     let entries = create_ticks(num_ticks, 0, Hash::default());
-    let reed_solomon_cache = ReedSolomonCache::default();
     let chained_merkle_root = Hash::new_from_array(rand::rng().random());
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
@@ -72,7 +69,6 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
             chained_merkle_root,
             0,
             0,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
     })
@@ -90,7 +86,6 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
     );
     let entries = make_large_unchained_entries(txs_per_entry, num_entries);
     let chained_merkle_root = Hash::new_from_array(rand::rng().random());
-    let reed_solomon_cache = ReedSolomonCache::default();
     // 1Mb
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
@@ -101,7 +96,6 @@ fn bench_shredder_large_entries(bencher: &mut Bencher) {
             chained_merkle_root,
             0,
             0,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
     })
@@ -123,7 +117,6 @@ fn bench_deshredder(bencher: &mut Bencher) {
         chained_merkle_root,
         0,
         0,
-        &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     );
     bencher.iter(|| {
@@ -138,7 +131,6 @@ fn bench_deserialize_hdr(bencher: &mut Bencher) {
     let shredder = Shredder::new(2, 1, 0, 0).unwrap();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     let mut stats = ProcessShredsStats::default();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let mut shreds = shredder
         .make_merkle_shreds_from_entries(
             &keypair,
@@ -147,7 +139,6 @@ fn bench_deserialize_hdr(bencher: &mut Bencher) {
             merkle_root,
             1, // next_shred_index
             0, // next_code_index
-            &reed_solomon_cache,
             &mut stats,
         )
         .into_iter()
@@ -170,7 +161,6 @@ fn make_entries() -> Vec<Entry> {
 fn bench_shredder_coding(bencher: &mut Bencher) {
     let entries = make_entries();
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     bencher.iter(|| {
         let shreds = shredder.make_merkle_shreds_from_entries(
@@ -180,7 +170,6 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
             merkle_root,
             0, // next_shred_index
             0, // next_code_index
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         black_box(shreds);
@@ -190,7 +179,6 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
 fn bench_shredder_decoding(bencher: &mut Bencher) {
     let entries = make_entries();
     let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     let (_data_shreds, mut coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
         &Keypair::new(),
@@ -199,7 +187,6 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
         merkle_root,
         0, // next_shred_index
         0, // next_code_index
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     coding_shreds.truncate(CODING_SHREDS_PER_FEC_BLOCK);

--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -329,7 +329,7 @@ pub mod test {
             blockstore,
             blockstore::Blockstore,
             get_tmp_ledger_path_auto_delete,
-            shred::{ProcessShredsStats, ReedSolomonCache, Shredder, max_ticks_per_n_shreds},
+            shred::{ProcessShredsStats, Shredder, max_ticks_per_n_shreds},
         },
         solana_message::{
             Message, VersionedMessage,
@@ -658,7 +658,6 @@ pub mod test {
                     Hash::new_unique(),
                     shred_index,
                     shred_index,
-                    &ReedSolomonCache::default(),
                     &mut ProcessShredsStats::default(),
                 )
         };

--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -11,7 +11,7 @@ use {
     solana_ledger::{
         blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{Nonce, ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        shred::{Nonce, ProcessShredsStats, Shred, Shredder},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler},
     solana_signer::Signer,
@@ -33,7 +33,6 @@ pub struct MaliciousRepairHandler {
     keypair: Arc<Keypair>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     config: MaliciousRepairConfig,
-    reed_solomon_cache: ReedSolomonCache,
     standard_repair_handler: StandardRepairHandler,
 }
 
@@ -50,7 +49,6 @@ impl MaliciousRepairHandler {
             keypair,
             leader_schedule_cache,
             config,
-            reed_solomon_cache: ReedSolomonCache::default(),
         }
     }
 
@@ -123,7 +121,6 @@ impl MaliciousRepairHandler {
             chained_merkle_root,
             shred_index as u32, // next_shred_index
             0,                  // next_code_index
-            &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
 

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -269,7 +269,7 @@ mod tests {
         solana_ledger::{
             blockstore_meta::BlockLocation,
             get_tmp_ledger_path_auto_delete,
-            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+            shred::{ProcessShredsStats, Shred, Shredder},
         },
         solana_perf::packet::PacketBatchRecycler,
         std::net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -293,7 +293,6 @@ mod tests {
             chained_merkle_root,
             0, // next_shred_index
             0, // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
 

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -166,7 +166,7 @@ pub mod test {
         solana_keypair::Keypair,
         solana_ledger::{
             get_tmp_ledger_path,
-            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+            shred::{ProcessShredsStats, Shred, Shredder},
         },
         solana_runtime::bank_utils,
         trees::tr,
@@ -311,7 +311,6 @@ pub mod test {
         outstanding_repairs = HashMap::new();
         slot_meta_cache = AHashMap::default();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
 
         let completed_shreds: Vec<Shred> = [(0, 0), (2, 1), (4, 2), (6, best_overall_slot)]
             .iter()
@@ -324,7 +323,6 @@ pub mod test {
                     Hash::default(),
                     last_shred as u32,
                     last_shred as u32,
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );
                 shreds

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2022,7 +2022,7 @@ mod tests {
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             get_tmp_ledger_path_auto_delete,
             shred::{
-                ProcessShredsStats, ReedSolomonCache, Shred, Shredder, max_ticks_per_n_shreds,
+                ProcessShredsStats, Shred, Shredder, max_ticks_per_n_shreds,
                 merkle_tree::hash_as_merkle_proof_entry,
             },
         },
@@ -2563,7 +2563,6 @@ mod tests {
         assert!(rv.is_none());
         let shredder = Shredder::new(slot, slot - 1, 0, 2).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let index = 1;
         let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             &keypair,
@@ -2572,7 +2571,6 @@ mod tests {
             Hash::default(),
             index as u32,
             index as u32,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         shreds.truncate(1);
@@ -3125,7 +3123,6 @@ mod tests {
         fn new_test_data_shred(slot: Slot, index: u32) -> Shred {
             let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
             let keypair = Keypair::new();
-            let reed_solomon_cache = ReedSolomonCache::default();
             let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
                 &keypair,
                 &[],
@@ -3133,7 +3130,6 @@ mod tests {
                 Hash::default(),
                 0,
                 0,
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             );
             shreds.remove(index as usize)
@@ -3141,7 +3137,6 @@ mod tests {
         fn new_test_coding_shred(slot: Slot, index: u32) -> Shred {
             let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
             let keypair = Keypair::new();
-            let reed_solomon_cache = ReedSolomonCache::default();
             let (_, mut shreds) = shredder.entries_to_merkle_shreds_for_tests(
                 &keypair,
                 &[],
@@ -3149,7 +3144,6 @@ mod tests {
                 Hash::default(),
                 0,
                 0,
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             );
             shreds.remove(index as usize)

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -48,7 +48,7 @@ use {
         entry_notifier_service::EntryNotification,
         genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
         get_tmp_ledger_path, get_tmp_ledger_path_auto_delete,
-        shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        shred::{ProcessShredsStats, Shred, Shredder},
     },
     solana_net_utils::SocketAddrSpace,
     solana_poh::poh_recorder::create_test_recorder,
@@ -232,7 +232,6 @@ fn block_marker_shreds_with_last(
             Hash::new_unique(),
             shred_index,
             shred_index,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
 }
@@ -993,7 +992,6 @@ fn test_dead_fork_entry_deserialize_failure() {
 
         let shredder = Shredder::new(bank.slot(), bank.parent_slot(), 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
 
         shredder
             .make_shreds_from_data_slice(
@@ -1003,7 +1001,6 @@ fn test_dead_fork_entry_deserialize_failure() {
                 Hash::default(),
                 0,
                 0,
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             )
             .unwrap()

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -22,7 +22,7 @@ use {
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
         blockstore_db::{DBPinnableSlice, WriteBatch},
         blockstore_meta::BlockLocation,
-        shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
+        shred::{self, Shred, filter::ShredRecoveryContext},
     },
     solana_measure::measure::Measure,
     solana_net_utils::PinnedXdpSender,
@@ -423,7 +423,6 @@ impl WindowService {
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         retransmit_sender: EvictingSender<Vec<shred::Payload>>,
     ) -> JoinHandle<()> {
-        let reed_solomon_cache = ReedSolomonCache::default();
         Builder::new()
             .name("solWinInsert".to_string())
             .spawn(move || {
@@ -445,7 +444,6 @@ impl WindowService {
                 let mut ws_metrics = WindowServiceMetrics::default();
                 let mut last_print = Instant::now();
                 let mut shred_recovery_context = ShredRecoveryContext::new(
-                    reed_solomon_cache,
                     retransmit_sender,
                     sharable_banks.root(),
                     shred_version,
@@ -551,7 +549,6 @@ mod test {
             Hash::new_from_array(rand::rng().random()),
             0, // next_shred_index
             0, // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         data_shreds
@@ -702,7 +699,6 @@ mod test {
                     shreds,
                     false, // is_trusted
                     &mut ShredRecoveryContext::new(
-                        ReedSolomonCache::default(),
                         dummy_retransmit_sender,
                         bank_forks.read().unwrap().root_bank(),
                         0, // shred_version

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -386,7 +386,7 @@ pub(crate) mod tests {
         solana_entry::entry::Entry,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::shred::{ProcessShredsStats, Shredder},
         solana_signature::Signature,
         solana_signer::Signer,
         solana_system_transaction::transfer,
@@ -499,7 +499,6 @@ pub(crate) mod tests {
             Hash::new_from_array(rng.random()),
             next_shred_index,
             next_code_index, // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
     }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -37,7 +37,7 @@ use {
         bigtable_upload::ConfirmedBlockUploadConfig,
         blockstore::Blockstore,
         blockstore_options::AccessType,
-        shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+        shred::{ProcessShredsStats, Shred, Shredder},
     },
     solana_pubkey::Pubkey,
     solana_shred_version::compute_shred_version,
@@ -587,7 +587,6 @@ async fn shreds(
                 Hash::default(), // chained_merkle_root
                 0,               // next_shred_index
                 0,               // next_code_index
-                &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             )
             .into_iter()

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -30,6 +30,7 @@ agave-unstable-api = []
 shuttle-test = ["dep:shuttle"]
 
 [dependencies]
+additive-fft-reed-solomon = { workspace = true }
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
@@ -62,7 +63,6 @@ qualifier_attr = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-reed-solomon-erasure = { workspace = true, features = ["simd-accel"] }
 scopeguard = { workspace = true }
 serde = { workspace = true }
 shuttle = { workspace = true, optional = true }

--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -9,7 +9,8 @@ use {
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            ProcessShredsStats, ReedSolomonCache, Shred, Shredder, filter::ShredRecoveryContext,
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
+            filter::ShredRecoveryContext,
         },
     },
     solana_packet::PACKET_DATA_SIZE,
@@ -23,7 +24,10 @@ use {
 fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
     let mut genesis_config = create_genesis_config(1).genesis_config;
     let shred_slot = shreds.first().map(Shred::slot).unwrap_or_default();
-    let slots_per_epoch = shred_slot.max(MINIMUM_SLOTS_PER_EPOCH);
+    let slots_per_epoch = shred_slot
+        .saturating_add(1)
+        .saturating_mul(2)
+        .max(MINIMUM_SLOTS_PER_EPOCH);
     genesis_config.epoch_schedule = EpochSchedule::custom(slots_per_epoch, slots_per_epoch, false);
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
@@ -80,13 +84,14 @@ fn make_shreds_from_entries<R: Rng>(
     reed_solomon_cache: &ReedSolomonCache,
     stats: &mut ProcessShredsStats,
 ) -> (Vec<Shred>, Vec<Shred>) {
+    let next_shred_index = rng.random_range(0..60) * DATA_SHREDS_PER_FEC_BLOCK as u32;
     let (data, code) = shredder.entries_to_merkle_shreds_for_tests(
         keypair,
         entries,
         is_last_in_slot,
         chained_merkle_root,
-        rng.random_range(0..2_000), // next_shred_index
-        rng.random_range(0..2_000), // next_code_index
+        next_shred_index,
+        next_shred_index,
         reed_solomon_cache,
         stats,
     );
@@ -200,6 +205,7 @@ fn run_recover_shreds(
     code.sort_unstable_by_key(|shred| shred.index());
     let mut shreds = data;
     shreds.extend(code);
+
     c.bench_function(name, |b| {
         let mut shred_recovery_context = new_shred_recovery_context(&shreds);
         b.iter(|| {

--- a/ledger/benches/make_shreds_from_entries.rs
+++ b/ledger/benches/make_shreds_from_entries.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    criterion::{Criterion, criterion_group, criterion_main},
+    criterion::{criterion_group, criterion_main, Criterion},
     rand::Rng,
     solana_entry::entry::Entry,
     solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
@@ -9,8 +9,8 @@ use {
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
-            filter::ShredRecoveryContext,
+            filter::ShredRecoveryContext, ProcessShredsStats, Shred, Shredder,
+            DATA_SHREDS_PER_FEC_BLOCK,
         },
     },
     solana_packet::PACKET_DATA_SIZE,
@@ -32,7 +32,6 @@ fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
     ShredRecoveryContext::new(
-        ReedSolomonCache::default(),
         dummy_retransmit_sender,
         root_bank,
         shreds.first().map(Shred::version).unwrap_or_default(),
@@ -81,7 +80,6 @@ fn make_shreds_from_entries<R: Rng>(
     entries: &[Entry],
     is_last_in_slot: bool,
     chained_merkle_root: Hash,
-    reed_solomon_cache: &ReedSolomonCache,
     stats: &mut ProcessShredsStats,
 ) -> (Vec<Shred>, Vec<Shred>) {
     let next_shred_index = rng.random_range(0..60) * DATA_SHREDS_PER_FEC_BLOCK as u32;
@@ -92,7 +90,6 @@ fn make_shreds_from_entries<R: Rng>(
         chained_merkle_root,
         next_shred_index,
         next_shred_index,
-        reed_solomon_cache,
         stats,
     );
     (black_box(data), black_box(code))
@@ -118,7 +115,6 @@ fn run_make_shreds_from_entries(
     let data_size = num_packets * PACKET_DATA_SIZE;
     let entries = make_dummy_entries(&mut rng, data_size);
     let chained_merkle_root = make_dummy_hash(&mut rng);
-    let reed_solomon_cache = ReedSolomonCache::default();
     let mut stats = ProcessShredsStats::default();
     // Initialize the thread-pool and warm the Reed-Solomon cache.
     for _ in 0..10 {
@@ -129,7 +125,6 @@ fn run_make_shreds_from_entries(
             &entries,
             is_last_in_slot,
             chained_merkle_root,
-            &reed_solomon_cache,
             &mut stats,
         );
     }
@@ -142,7 +137,6 @@ fn run_make_shreds_from_entries(
                 &entries,
                 is_last_in_slot,
                 chained_merkle_root,
-                &reed_solomon_cache,
                 &mut stats,
             );
             black_box(data);
@@ -172,7 +166,6 @@ fn run_recover_shreds(
     let data_size = num_packets * PACKET_DATA_SIZE;
     let entries = make_dummy_entries(&mut rng, data_size);
     let chained_merkle_root = make_dummy_hash(&mut rng);
-    let reed_solomon_cache = ReedSolomonCache::default();
     let mut stats = ProcessShredsStats::default();
     let (data, code) = make_shreds_from_entries(
         &mut rng,
@@ -181,7 +174,6 @@ fn run_recover_shreds(
         &entries,
         is_last_in_slot,
         chained_merkle_root,
-        &reed_solomon_cache,
         &mut stats,
     );
     let fec_set_index = data[0].fec_set_index();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -18,8 +18,8 @@ use {
         },
         next_slots_iterator::NextSlotsIterator,
         shred::{
-            self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Payload, ProcessShredsStats,
-            ReedSolomonCache, Shred, ShredFlags, ShredId, ShredType, Shredder,
+            self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Payload, ProcessShredsStats, Shred,
+            ShredFlags, ShredId, ShredType, Shredder,
             filter::ShredRecoveryContext,
             merkle_tree::{MerkleTree, SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size},
         },
@@ -793,7 +793,6 @@ impl Blockstore {
         let mut walk = TreeWalk::from(forks);
         let mut blockhashes = HashMap::new();
         let mut merkle_roots: HashMap<Slot, Hash> = HashMap::new();
-        let reed_solomon_cache = shred::ReedSolomonCache::default();
         while let Some(visit) = walk.get() {
             let slot = *visit.node().data();
             if self.meta(slot).unwrap().is_some() && self.orphan(slot).unwrap().is_none() {
@@ -831,7 +830,6 @@ impl Blockstore {
                         chained_merkle_root,
                         0,
                         0,
-                        &reed_solomon_cache,
                         &mut ProcessShredsStats::default(),
                     )
                     .into_iter()
@@ -3882,7 +3880,6 @@ impl Blockstore {
         let mut shredder = Shredder::new(current_slot, parent_slot, 0, version).unwrap();
         let mut all_shreds = vec![];
         let mut slot_entries = vec![];
-        let reed_solomon_cache = ReedSolomonCache::default();
         let mut chained_merkle_root = self
             .get_last_shred_merkle_root(parent_slot)
             .unwrap()
@@ -3909,7 +3906,6 @@ impl Blockstore {
                         chained_merkle_root,
                         start_index, // next_shred_index
                         start_index, // next_code_index
-                        &reed_solomon_cache,
                         &mut ProcessShredsStats::default(),
                     );
                 let next_chained_merkle_root = coding_shreds
@@ -3942,7 +3938,6 @@ impl Blockstore {
                 chained_merkle_root,
                 0, // next_shred_index
                 0, // next_code_index
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             ));
         }
@@ -6522,7 +6517,6 @@ pub fn create_new_ledger(
         chained_merkle_root,
         0, // next_shred_index
         0, // next_code_index
-        &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     );
     assert!(shreds.last().unwrap().last_in_slot());
@@ -6739,7 +6733,6 @@ pub fn entries_to_test_shreds(
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             0,                                          // next_shred_index,
             0,                                          // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
         .into_iter()

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -1,23 +1,24 @@
 use {
     super::*,
     crate::{
-        genesis_utils::{GenesisConfigInfo, create_genesis_config},
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
         shred::{
-            MAX_DATA_SHREDS_PER_SLOT, ShredFlags, max_ticks_per_n_shreds,
+            max_ticks_per_n_shreds,
             merkle::finish_erasure_batch_for_tests,
             merkle_tree::{
-                SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size, hash_as_merkle_proof_entry,
-                verify_merkle_proof,
+                get_proof_size, hash_as_merkle_proof_entry, verify_merkle_proof,
+                SIZE_OF_MERKLE_PROOF_ENTRY,
             },
+            ShredFlags, MAX_DATA_SHREDS_PER_SLOT,
         },
     },
     assert_matches::assert_matches,
-    rand::{Rng, rng, seq::SliceRandom},
-    rand_chacha::{ChaChaRng, rand_core::SeedableRng},
+    rand::{rng, seq::SliceRandom, Rng},
+    rand_chacha::{rand_core::SeedableRng, ChaChaRng},
     solana_entry::entry::{
         entries_to_verification_data, entry_views_to_verification_data, next_entry_mut,
     },
-    solana_genesis_utils::{MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, open_genesis_config},
+    solana_genesis_utils::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     solana_hash::Hash,
     solana_message::{compiled_instruction::CompiledInstruction, v0::LoadedAddresses},
     solana_packet::PACKET_DATA_SIZE,
@@ -91,7 +92,6 @@ fn create_update_parent_shreds_with_shred_parent(
             Hash::new_unique(),
             shred_index,
             shred_index,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
 }
@@ -122,7 +122,6 @@ fn create_block_header_shreds_with_shred_parent(
             Hash::new_unique(),
             0,
             0,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
 }
@@ -180,7 +179,6 @@ fn create_block_footer_shreds_with_last(
             Hash::new_unique(),
             shred_index,
             shred_index,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
 }
@@ -203,7 +201,6 @@ fn create_entry_batch_shreds(
             Hash::new_unique(),
             shred_index,
             shred_index,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
 }
@@ -224,11 +221,9 @@ fn test_create_new_ledger() {
     let entries = blockstore.get_slot_entries(0, 0).unwrap();
 
     assert_eq!(ticks, entries);
-    assert!(
-        Path::new(ledger_path.path())
-            .join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL)
-            .exists()
-    );
+    assert!(Path::new(ledger_path.path())
+        .join(BLOCKSTORE_DIRECTORY_ROCKS_LEVEL)
+        .exists());
 
     assert_eq!(
         genesis_config,
@@ -685,12 +680,10 @@ fn test_data_set_completed_on_insert() {
     let shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
     let num_shreds = shreds.len();
     assert!(num_shreds > 1);
-    assert!(
-        blockstore
-            .insert_shreds(shreds[1..].to_vec(), false)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shreds(shreds[1..].to_vec(), false)
+        .unwrap()
+        .is_empty());
     assert_eq!(
         blockstore
             .insert_shreds(vec![shreds[0].clone()], false)
@@ -1328,7 +1321,7 @@ fn test_slot_range_connected_starting_slot_not_full() {
 
 #[test]
 fn test_get_slots_since() {
-    use smallvec::{SmallVec, smallvec};
+    use smallvec::{smallvec, SmallVec};
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -1716,7 +1709,6 @@ fn test_should_insert_data_shred() {
     let entries = create_ticks(2000, 1, Hash::new_unique());
     let shredder = Shredder::new(0, 0, 1, 0).unwrap();
     let keypair = Keypair::new();
-    let rsc = ReedSolomonCache::default();
     let shreds = shredder
         .entries_to_merkle_shreds_for_tests(
             &keypair,
@@ -1725,7 +1717,6 @@ fn test_should_insert_data_shred() {
             Hash::default(), // merkle_root
             0,
             0,
-            &rsc,
             &mut ProcessShredsStats::default(),
         )
         .0;
@@ -1753,7 +1744,6 @@ fn test_should_insert_data_shred() {
             Hash::default(), // merkle_root
             6,               // next_shred_index,
             6,               // next_code_index
-            &rsc,
             &mut ProcessShredsStats::default(),
         )
         .0;
@@ -1814,7 +1804,6 @@ fn test_should_insert_data_shred() {
             Hash::default(), // merkle_root
             last_idx,        // next_shred_index,
             last_idx,        // next_code_index
-            &rsc,
             &mut ProcessShredsStats::default(),
         )
         .0;
@@ -2218,7 +2207,6 @@ fn test_merkle_root_metas_data() {
 
     let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
     let keypair = Keypair::new();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let new_index = fec_set_index + 31;
     // Add a shred from different fec set
     let new_data_shred = shredder
@@ -2229,7 +2217,6 @@ fn test_merkle_root_metas_data() {
             Hash::default(),
             new_index,
             new_index,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         )
         .unwrap()
@@ -2625,7 +2612,6 @@ fn test_get_slot_entries_with_shred_count_corruption() {
 
     let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
     let keypair = Keypair::new();
-    let reed_solomon_cache = ReedSolomonCache::default();
 
     let mut shreds = shredder
         .make_shreds_from_data_slice(
@@ -2635,7 +2621,6 @@ fn test_get_slot_entries_with_shred_count_corruption() {
             Hash::default(),
             next_shred_index as u32,
             next_shred_index as u32,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         )
         .unwrap();
@@ -3046,7 +3031,6 @@ fn test_get_complete_block_with_block_markers() {
             Hash::new_unique(),
             entry_start_index,
             entry_start_index,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
         .into_iter()
@@ -3080,24 +3064,20 @@ fn test_get_complete_block_with_block_markers() {
     assert_eq!(num_shreds, u64::from(slot_end_index));
     assert!(is_full);
 
-    assert!(
-        blockstore
-            .get_entries_in_data_block(slot, 0..entry_start_index, None)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(blockstore
+        .get_entries_in_data_block(slot, 0..entry_start_index, None)
+        .unwrap()
+        .is_empty());
     assert_eq!(
         blockstore
             .get_entries_in_data_block(slot, entry_start_index..entry_end_index, None)
             .unwrap(),
         entries
     );
-    assert!(
-        blockstore
-            .get_entries_in_data_block(slot, entry_end_index..slot_end_index, None)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(blockstore
+        .get_entries_in_data_block(slot, entry_end_index..slot_end_index, None)
+        .unwrap()
+        .is_empty());
 
     let complete_block = blockstore.get_complete_block(slot, true).unwrap();
     assert_eq!(complete_block.parent_slot, parent_slot);
@@ -3115,11 +3095,8 @@ fn test_get_complete_block_with_block_markers() {
         .get_rooted_block_with_components(slot, true)
         .unwrap();
     assert_eq!(block, complete_block);
-    let [
-        ConfirmedBlockComponent::BlockMarker(header),
-        ConfirmedBlockComponent::EntryBatch(entry_summaries),
-        ConfirmedBlockComponent::BlockMarker(footer),
-    ] = components.as_slice()
+    let [ConfirmedBlockComponent::BlockMarker(header), ConfirmedBlockComponent::EntryBatch(entry_summaries), ConfirmedBlockComponent::BlockMarker(footer)] =
+        components.as_slice()
     else {
         panic!("unexpected confirmed block components");
     };
@@ -3176,12 +3153,10 @@ fn test_persist_transaction_status() {
     let cost_units_2 = Some(5678);
 
     // result not found
-    assert!(
-        transaction_status_cf
-            .get_protobuf((Signature::default(), 0))
-            .unwrap()
-            .is_none()
-    );
+    assert!(transaction_status_cf
+        .get_protobuf((Signature::default(), 0))
+        .unwrap()
+        .is_none());
 
     // insert value
     let status = TransactionStatusMeta {
@@ -3202,11 +3177,9 @@ fn test_persist_transaction_status() {
         cost_units: cost_units_1,
     }
     .into();
-    assert!(
-        transaction_status_cf
-            .put_protobuf((Signature::default(), 0), &status)
-            .is_ok()
-    );
+    assert!(transaction_status_cf
+        .put_protobuf((Signature::default(), 0), &status)
+        .is_ok());
 
     // result found
     let TransactionStatusMeta {
@@ -3260,11 +3233,9 @@ fn test_persist_transaction_status() {
         cost_units: cost_units_2,
     }
     .into();
-    assert!(
-        transaction_status_cf
-            .put_protobuf((Signature::from([2u8; 64]), 9), &status)
-            .is_ok()
-    );
+    assert!(transaction_status_cf
+        .put_protobuf((Signature::from([2u8; 64]), 9), &status)
+        .is_ok());
 
     // result found
     let TransactionStatusMeta {
@@ -4270,19 +4241,17 @@ fn test_get_confirmed_signatures_for_address2() {
     assert!(sig_infos.found_before);
     assert!(sig_infos.infos.is_empty());
 
-    assert!(
-        blockstore
-            .get_confirmed_signatures_for_address2(
-                address0,
-                highest_super_majority_root,
-                None,
-                Some(all0[0].signature),
-                2,
-            )
-            .unwrap()
-            .infos
-            .is_empty()
-    );
+    assert!(blockstore
+        .get_confirmed_signatures_for_address2(
+            address0,
+            highest_super_majority_root,
+            None,
+            Some(all0[0].signature),
+            2,
+        )
+        .unwrap()
+        .infos
+        .is_empty());
 
     // Fetch all signatures for address 0, three at a time
     assert!(all0.len().is_multiple_of(3));
@@ -4429,33 +4398,29 @@ fn test_get_confirmed_signatures_for_address2() {
         assert_eq!(results[0], all0[i], "Unexpected result for {i}");
     }
 
-    assert!(
-        blockstore
-            .get_confirmed_signatures_for_address2(
-                address0,
-                highest_confirmed_slot,
-                Some(all0[all0.len() - 1].signature),
-                None,
-                1,
-            )
-            .unwrap()
-            .infos
-            .is_empty()
-    );
+    assert!(blockstore
+        .get_confirmed_signatures_for_address2(
+            address0,
+            highest_confirmed_slot,
+            Some(all0[all0.len() - 1].signature),
+            None,
+            1,
+        )
+        .unwrap()
+        .infos
+        .is_empty());
 
-    assert!(
-        blockstore
-            .get_confirmed_signatures_for_address2(
-                address0,
-                highest_confirmed_slot,
-                None,
-                Some(all0[0].signature),
-                2,
-            )
-            .unwrap()
-            .infos
-            .is_empty()
-    );
+    assert!(blockstore
+        .get_confirmed_signatures_for_address2(
+            address0,
+            highest_confirmed_slot,
+            None,
+            Some(all0[0].signature),
+            2,
+        )
+        .unwrap()
+        .infos
+        .is_empty());
 
     // Fetch all signatures for address 0, three at a time
     assert!(all0.len() % 3 == 2);
@@ -4708,7 +4673,6 @@ fn test_recovery() {
             coding_shreds,
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
-                ReedSolomonCache::default(),
                 dummy_retransmit_sender,
                 root_bank,
                 0, // shred_version
@@ -4782,7 +4746,6 @@ fn test_skip_alt_recovery() {
             )),
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
-                ReedSolomonCache::default(),
                 dummy_retransmit_sender,
                 root_bank,
                 0, // shred_version
@@ -4794,20 +4757,16 @@ fn test_skip_alt_recovery() {
         .unwrap();
 
     assert_eq!(metrics.num_recovered, 0);
-    assert!(
-        blockstore
-            .get_index_from_location(slot, alternate_location)
-            .unwrap()
-            .unwrap()
-            .data()
-            .contains(data_shred_index)
-    );
-    assert!(
-        blockstore
-            .get_data_shred(slot, data_shred_index)
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .get_index_from_location(slot, alternate_location)
+        .unwrap()
+        .unwrap()
+        .data()
+        .contains(data_shred_index));
+    assert!(blockstore
+        .get_data_shred(slot, data_shred_index)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -4822,7 +4781,6 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
     let genesis_config = create_genesis_config(2).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
     let slot = root_bank.get_slots_in_epoch(root_bank.epoch());
-    let reed_solomon_cache = ReedSolomonCache::default();
     let (data_shreds, coding_shreds, leader_keypair) =
         setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
             slot,
@@ -4847,13 +4805,8 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
         payload.as_mut()[DATA_SHRED_FLAGS_OFFSET] |= ShredFlags::DATA_COMPLETE_SHRED.bits();
         *shred = Shred::new_from_serialized_shred(payload).unwrap();
     }
-    finish_erasure_batch_for_tests(
-        &leader_keypair,
-        &mut first_fec_set,
-        chained_merkle_root,
-        &reed_solomon_cache,
-    )
-    .unwrap();
+    finish_erasure_batch_for_tests(&leader_keypair, &mut first_fec_set, chained_merkle_root)
+        .unwrap();
 
     let (mut data_shreds, mut coding_shreds): (Vec<_>, Vec<_>) =
         first_fec_set.into_iter().partition(Shred::is_data);
@@ -4882,7 +4835,6 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
             shreds,
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
-                reed_solomon_cache,
                 dummy_retransmit_sender,
                 root_bank,
                 0, // shred_version
@@ -4908,12 +4860,10 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
         valid_data_shred.payload().as_ref(),
     );
     for shred in data_shreds {
-        assert!(
-            blockstore
-                .get_data_shred(slot, u64::from(shred.index()))
-                .unwrap()
-                .is_none()
-        );
+        assert!(blockstore
+            .get_data_shred(slot, u64::from(shred.index()))
+            .unwrap()
+            .is_none());
     }
     verify_index_integrity(&blockstore, slot);
 }
@@ -5107,7 +5057,6 @@ fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypa
         chained_merkle_root,
         fec_set_index, // next_shred_index
         fec_set_index, // next_code_index
-        &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     );
 
@@ -5152,7 +5101,6 @@ fn test_duplicate_slot() {
     let entries1 = make_slot_entries_with_transactions(1);
     let entries2 = make_slot_entries_with_transactions(1);
     let leader_keypair = Arc::new(Keypair::new());
-    let reed_solomon_cache = ReedSolomonCache::default();
     let shredder = Shredder::new(slot, 0, 0, 0).unwrap();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
@@ -5162,7 +5110,6 @@ fn test_duplicate_slot() {
         merkle_root,
         0, // next_shred_index
         0, // next_code_index,
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     let (duplicate_shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
@@ -5172,7 +5119,6 @@ fn test_duplicate_slot() {
         merkle_root,
         0, // next_shred_index
         0, // next_code_index
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     let shred = shreds[0].clone();
@@ -5194,11 +5140,9 @@ fn test_duplicate_slot() {
         blockstore.is_shred_duplicate(&duplicate_shred).as_deref(),
         Some(shred.payload().as_ref())
     );
-    assert!(
-        blockstore
-            .is_shred_duplicate(&non_duplicate_shred)
-            .is_none()
-    );
+    assert!(blockstore
+        .is_shred_duplicate(&non_duplicate_shred)
+        .is_none());
 
     // Store a duplicate shred
     blockstore
@@ -5254,12 +5198,10 @@ fn test_clear_unconfirmed_slot() {
             .as_slice(),
         &[unconfirmed_child_slot]
     );
-    assert!(
-        blockstore
-            .get_data_shred(unconfirmed_slot, 0)
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .get_data_shred(unconfirmed_slot, 0)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -5287,12 +5229,10 @@ fn test_clear_unconfirmed_slot_and_insert_again() {
     // Purge the slot
     blockstore.clear_unconfirmed_slot(unconfirmed_slot);
     assert!(!blockstore.is_dead(unconfirmed_slot));
-    assert!(
-        blockstore
-            .get_data_shred(unconfirmed_slot, 0)
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .get_data_shred(unconfirmed_slot, 0)
+        .unwrap()
+        .is_none());
 
     // Re-add unconfirmed_slot and confirm that confirmed_slot only has
     // unconfirmed_slot in next_slots once
@@ -5318,16 +5258,14 @@ fn test_update_completed_data_indexes() {
     for i in 0..10 {
         shred_index.insert(i as u64);
         let received = u64::from(i) + 1;
-        assert!(
-            update_completed_data_indexes(
-                true,
-                i,
-                received,
-                &shred_index,
-                &mut completed_data_indexes
-            )
-            .eq(std::iter::once(i..i + 1))
-        );
+        assert!(update_completed_data_indexes(
+            true,
+            i,
+            received,
+            &shred_index,
+            &mut completed_data_indexes
+        )
+        .eq(std::iter::once(i..i + 1)));
         assert!(completed_data_indexes.iter().eq(0..=i));
     }
 }
@@ -5341,54 +5279,62 @@ fn test_update_completed_data_indexes_out_of_order() {
     let received = 5;
 
     shred_index.insert(4);
-    assert!(
-        update_completed_data_indexes(
-            false,
-            4,
-            received,
-            &shred_index,
-            &mut completed_data_indexes
-        )
-        .eq([])
-    );
+    assert!(update_completed_data_indexes(
+        false,
+        4,
+        received,
+        &shred_index,
+        &mut completed_data_indexes
+    )
+    .eq([]));
     assert!(completed_data_indexes.is_empty());
 
     shred_index.insert(2);
-    assert!(
-        update_completed_data_indexes(
-            false,
-            2,
-            received,
-            &shred_index,
-            &mut completed_data_indexes
-        )
-        .eq([])
-    );
+    assert!(update_completed_data_indexes(
+        false,
+        2,
+        received,
+        &shred_index,
+        &mut completed_data_indexes
+    )
+    .eq([]));
     assert!(completed_data_indexes.is_empty());
 
     shred_index.insert(3);
-    assert!(
-        update_completed_data_indexes(true, 3, received, &shred_index, &mut completed_data_indexes)
-            .eq([])
-    );
+    assert!(update_completed_data_indexes(
+        true,
+        3,
+        received,
+        &shred_index,
+        &mut completed_data_indexes
+    )
+    .eq([]));
     assert!(completed_data_indexes.clone().iter().eq([3]));
 
     // Inserting data complete shred 1 now confirms the range of shreds [2, 3]
     // is part of the same data set
     shred_index.insert(1);
-    assert!(
-        update_completed_data_indexes(true, 1, received, &shred_index, &mut completed_data_indexes)
-            .eq(std::iter::once(2..4))
-    );
+    assert!(update_completed_data_indexes(
+        true,
+        1,
+        received,
+        &shred_index,
+        &mut completed_data_indexes
+    )
+    .eq(std::iter::once(2..4)));
     assert!(completed_data_indexes.clone().iter().eq([1, 3]));
 
     // Inserting data complete shred 0 now confirms the range of shreds [0]
     // is part of the same data set
     shred_index.insert(0);
-    assert!(
-        update_completed_data_indexes(true, 0, received, &shred_index, &mut completed_data_indexes)
-            .eq([0..1, 1..2])
-    );
+    assert!(update_completed_data_indexes(
+        true,
+        0,
+        received,
+        &shred_index,
+        &mut completed_data_indexes
+    )
+    .eq([0..1, 1..2]));
     assert!(completed_data_indexes.clone().iter().eq([0, 1, 3]));
 }
 
@@ -5534,7 +5480,6 @@ fn erasure_multiple_config() {
 
     let version = version_from_hash(&entries[0].hash);
     let shredder = Shredder::new(slot, 0, 0, version).unwrap();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     let kp = Keypair::new();
     // produce normal shreds
@@ -5545,7 +5490,6 @@ fn erasure_multiple_config() {
         merkle_root,
         0, // next_shred_index
         0, // next_code_index
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     // produce shreds with conflicting FEC set index based off different data.
@@ -5558,7 +5502,6 @@ fn erasure_multiple_config() {
         merkle_root,
         0, // next_shred_index
         1, // next_code_index (overlaps with FEC set in data1 + coding1)
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
 
@@ -5642,7 +5585,6 @@ fn setup_duplicate_last_in_slot(
 ) -> ((Vec<Shred>, Vec<Shred>), (Vec<Shred>, Vec<Shred>)) {
     let entries = make_slot_entries_with_transactions(1);
     let leader_keypair = Arc::new(Keypair::new());
-    let reed_solomon_cache = ReedSolomonCache::default();
     let shredder = Shredder::new(slot, 0, 0, 0).unwrap();
     let (shreds1, code1) = shredder.entries_to_merkle_shreds_for_tests(
         &leader_keypair,
@@ -5651,7 +5593,6 @@ fn setup_duplicate_last_in_slot(
         Hash::new_unique(), // chained_merkle_root
         0,                  // next_shred_index
         0,                  // next_code_index,
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     let last_data1 = shreds1.last().unwrap();
@@ -5664,7 +5605,6 @@ fn setup_duplicate_last_in_slot(
         last_data1.chained_merkle_root().unwrap(),
         last_data1.index() + 1, // next_shred_index
         last_code1.index() + 1, // next_code_index,
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     ((shreds1, code1), (shreds2, code2))
@@ -5776,12 +5716,10 @@ fn test_duplicate_last_index_mark_dead() {
                 shred_to_check.payload().as_ref(),
             );
         } else {
-            assert!(
-                blockstore
-                    .get_data_shred(slot, shred_index)
-                    .unwrap()
-                    .is_none()
-            );
+            assert!(blockstore
+                .get_data_shred(slot, shred_index)
+                .unwrap()
+                .is_none());
         }
     }
 
@@ -5809,12 +5747,10 @@ fn test_duplicate_last_index_mark_dead() {
                 shred_to_check.payload().as_ref(),
             );
         } else {
-            assert!(
-                blockstore
-                    .get_data_shred(slot, shred_index)
-                    .unwrap()
-                    .is_none()
-            );
+            assert!(blockstore
+                .get_data_shred(slot, shred_index)
+                .unwrap()
+                .is_none());
         }
     }
 }
@@ -5902,11 +5838,9 @@ fn test_chained_merkle_root_consistency_backwards() {
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred.clone())
+        .is_empty());
 
     let merkle_root = coding_shred.merkle_root().unwrap();
 
@@ -5920,16 +5854,12 @@ fn test_chained_merkle_root_consistency_backwards() {
     );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
+    assert!(blockstore
+        .insert_shred_return_duplicate(data_shred)
+        .is_empty());
 }
 
 #[test]
@@ -5957,18 +5887,14 @@ fn test_chained_merkle_root_consistency_forwards() {
     );
     let next_coding_shred = next_coding_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_coding_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_coding_shred)
+        .is_empty());
 
     // Insert previous FEC set
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
 }
 
 #[test]
@@ -5982,11 +5908,9 @@ fn test_chained_merkle_root_across_slots_backwards() {
     let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred = data_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(data_shred.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(data_shred.clone())
+        .is_empty());
 
     // Incorrectly chained merkle for next slot
     let merkle_root = Hash::new_unique();
@@ -6001,16 +5925,12 @@ fn test_chained_merkle_root_across_slots_backwards() {
         );
     let next_slot_data_shred = next_slot_data_shreds[0].clone();
     let next_slot_coding_shred = next_slot_coding_shreds[0].clone();
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_slot_coding_shred)
-            .is_empty()
-    );
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_slot_data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_slot_coding_shred)
+        .is_empty());
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_slot_data_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6036,18 +5956,14 @@ fn test_chained_merkle_root_across_slots_forwards() {
     );
     let next_slot_data_shred = next_slot_data_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_slot_data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_slot_data_shred)
+        .is_empty());
 
     // Insert for previous slot
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6064,11 +5980,9 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     let coding_shred_previous = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred_previous.clone())
+        .is_empty());
 
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
@@ -6090,11 +6004,9 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     );
 
     // Should not check again, even though this shred conflicts as well
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(data_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6111,11 +6023,9 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
     let coding_shred_previous = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred_previous.clone())
+        .is_empty());
 
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
@@ -6137,11 +6047,9 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
         PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(data_shred.slot())
     );
     // Should not check again, even though this shred conflicts as well
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6170,11 +6078,9 @@ fn test_chained_merkle_root_inconsistency_forwards() {
     );
     let next_data_shred = next_data_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_data_shred.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_data_shred.clone())
+        .is_empty());
 
     // Insert previous FEC set
     let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
@@ -6201,11 +6107,9 @@ fn test_chained_merkle_root_inconsistency_data_shreds_only() {
     let data_shred_previous = data_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(data_shred_previous.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(data_shred_previous.clone())
+        .is_empty());
 
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != data_shred_previous.merkle_root().unwrap());
@@ -6268,17 +6172,13 @@ fn test_chained_merkle_root_inconsistency_both() {
     );
     let next_data_shred = next_data_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(prev_coding_shred.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(prev_coding_shred.clone())
+        .is_empty());
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_data_shred.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_data_shred.clone())
+        .is_empty());
 
     // Insert data shred
     let duplicate_shreds = blockstore.insert_shred_return_duplicate(data_shred.clone());
@@ -6311,11 +6211,9 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
     let coding_shred_previous = coding_shreds[1].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone())
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred_previous.clone())
+        .is_empty());
 
     // Set the first received coding shred index to 0 and remove merkle root meta to simulate this insertion coming from an
     // older version.
@@ -6332,12 +6230,10 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
         .merkle_root_meta_cf
         .delete_range_in_batch(&mut write_batch, slot, slot);
     blockstore.write_batch(write_batch).unwrap();
-    assert!(
-        blockstore
-            .merkle_root_meta(coding_shred_previous.erasure_set())
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .merkle_root_meta(coding_shred_previous.erasure_set())
+        .unwrap()
+        .is_none());
 
     // Add an incorrectly chained merkle from the next set. Although incorrectly chained
     // we skip the duplicate check as the first received coding shred index shred is missing
@@ -6352,16 +6248,12 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
     );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
+    assert!(blockstore
+        .insert_shred_return_duplicate(data_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6390,11 +6282,9 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
     );
     let next_data_shred = next_data_shreds[0].clone();
 
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(next_data_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(next_data_shred)
+        .is_empty());
 
     // Remove the merkle root meta in order to simulate this blockstore originating from
     // an older version.
@@ -6403,20 +6293,16 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
         .merkle_root_meta_cf
         .delete_range_in_batch(&mut write_batch, slot, slot);
     blockstore.write_batch(write_batch).unwrap();
-    assert!(
-        blockstore
-            .merkle_root_meta(next_coding_shreds[0].erasure_set())
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .merkle_root_meta(next_coding_shreds[0].erasure_set())
+        .unwrap()
+        .is_none());
 
     // Insert previous FEC set, although incorrectly chained we skip the duplicate check
     // as the merkle root meta is missing.
-    assert!(
-        blockstore
-            .insert_shred_return_duplicate(coding_shred)
-            .is_empty()
-    );
+    assert!(blockstore
+        .insert_shred_return_duplicate(coding_shred)
+        .is_empty());
 }
 
 #[test]
@@ -6646,7 +6532,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     assert_eq!(double_merkle_root, expected_double_merkle_root);
     assert_eq!(double_merkle_meta.double_merkle_root, double_merkle_root);
     assert_eq!(double_merkle_meta.fec_set_count, 3); // With 200 entries, we should have 3 FEC sets
-    // Proofs are empty
+                                                     // Proofs are empty
     assert_eq!(double_merkle_meta.proofs.len(), 0);
 
     // Generate the proofs
@@ -6722,12 +6608,10 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
         .unwrap();
     assert!(insert_results.duplicate_shreds.is_empty());
 
-    assert!(
-        blockstore
-            .get_double_merkle_root(incomplete_slot, block_location)
-            .unwrap()
-            .is_none()
-    );
+    assert!(blockstore
+        .get_double_merkle_root(incomplete_slot, block_location)
+        .unwrap()
+        .is_none());
 }
 
 fn insert_test_block_at_location(
@@ -7573,12 +7457,10 @@ fn test_marker_boundary_ooo() {
     assert_eq!(meta.parent_block_id, update_parent_block_id);
     assert_eq!(meta.replay_fec_set_index, 32);
     for shred_index in [64, 96, 128] {
-        assert!(
-            blockstore
-                .get_data_shred(slot, shred_index)
-                .unwrap()
-                .is_some()
-        );
+        assert!(blockstore
+            .get_data_shred(slot, shred_index)
+            .unwrap()
+            .is_some());
     }
     assert!(!blockstore.is_dead(slot));
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2490,7 +2490,7 @@ pub mod tests {
             genesis_utils::{
                 GenesisConfigInfo, create_genesis_config, create_genesis_config_with_leader,
             },
-            shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
+            shred::{ProcessShredsStats, Shred, Shredder},
         },
         agave_transaction_view::transaction_view::SanitizedTransactionView,
         agave_votor_messages::{
@@ -5676,7 +5676,6 @@ pub mod tests {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let keypair = Arc::new(Keypair::new());
-        let reed_solomon_cache = ReedSolomonCache::default();
 
         let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
             parent_slot: 0,
@@ -5712,7 +5711,6 @@ pub mod tests {
                 Hash::default(),
                 next_shred_index,
                 0,
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             )
             .into_iter()
@@ -5731,7 +5729,6 @@ pub mod tests {
                     Hash::default(),
                     next_shred_index,
                     0,
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
                 .into_iter()
@@ -5747,7 +5744,6 @@ pub mod tests {
                     Hash::default(),
                     next_shred_index,
                     0,
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
                 .into_iter()
@@ -5765,7 +5761,6 @@ pub mod tests {
                     Hash::default(),
                     next_shred_index,
                     0,
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
                 .into_iter()
@@ -5781,7 +5776,6 @@ pub mod tests {
                     Hash::default(),
                     next_shred_index,
                     0,
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
                 .into_iter()
@@ -5949,7 +5943,7 @@ pub mod tests {
 
     #[test]
     fn test_check_chained_block_id() {
-        use crate::shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder};
+        use crate::shred::{ProcessShredsStats, Shred, Shredder};
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(
@@ -5971,7 +5965,6 @@ pub mod tests {
                         chained_merkle_root,
                         0,
                         0,
-                        &ReedSolomonCache::default(),
                         &mut ProcessShredsStats::default(),
                     )
                     .into_iter()

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -83,7 +83,7 @@ pub use {
         payload::Payload,
         stats::{ProcessShredsStats, ShredFetchStats},
     },
-    crate::shredder::{ReedSolomonCache, Shredder},
+    crate::shredder::Shredder,
 };
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {solana_keypair::Keypair, solana_perf::packet::Packet, solana_signer::Signer};
@@ -179,8 +179,6 @@ pub enum Error {
     WincodeRead(#[from] wincode::ReadError),
     #[error(transparent)]
     WincodeWrite(#[from] wincode::WriteError),
-    #[error(transparent)]
-    Erasure(#[from] reed_solomon_erasure::Error),
     #[error("Invalid data size: {size}, payload: {payload}")]
     InvalidDataSize { size: u16, payload: usize },
     #[error("Invalid deshred set")]
@@ -223,6 +221,20 @@ pub enum Error {
     UnknownProofSize,
     #[error("Empty shreds list")]
     EmptyIterator,
+    #[error("Invalid shred index")]
+    InvalidIndex,
+    #[error("Too few data shards")]
+    TooFewDataShards,
+    #[error("Too few parity shards")]
+    TooFewParityShards,
+    #[error("Too many erased shards")]
+    TooManyErasures,
+    #[error("Invalid num data shreds: {0}")]
+    InvalidNumDataShreds(u16),
+    #[error("Invalid Merkle proof node for index {0} and nodes count {1}")]
+    InvalidMerkleProofNode(usize, usize),
+    #[error("Invalid Merkle proof shape with offset {0} and nodes count {1}")]
+    InvalidMerkleProofShape(usize, usize),
 }
 
 #[repr(u8)]
@@ -842,7 +854,6 @@ pub(crate) fn make_merkle_shreds_for_tests<R: Rng>(
         is_last_in_slot,
         fec_set_index, // next_shred_index
         fec_set_index, // next_code_index
-        &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     )
 }
@@ -1140,30 +1151,26 @@ mod tests {
     #[test]
     fn test_serde_compat_shred_data() {
         // bytes of a serialized merkle data shred
-        const PAYLOAD: &str = "aX2ovF3sZRfd6HyqMow9kkrtL3MyJd52m7gvuSjcvA4qayXZ\
-        cVPhjURcs4JX86YQM8wVrKXqdneqdEUJwBWhFrxSkegDSov6NQoK89SzZi9auEXHHr35dmN\
-        4zQbxuNdPjKM2K7b7WKRWaHyoMKQfG9jDbJGcWqwVkAxBmUXZQKryHvAqyNdBuRTdWrMtPK\
-        DiJWhqVWTmokpyGNceL7mqVr3VrLby6dEuiEUCBHCkhbsXBjfpFZk4yRoSKosb7BViTWWdt\
-        pWd7NrbDSiE97sBppEU1nWTPaVQh3bu91x8dEoYk696k532MxnhRLcKeL4XzG6P2HzypAck\
-        JdXiRJDn5E3woA8aiPojqdN9ScthJ8yXq1h4HhvzTRWkRxRBpJL8HEYPBcshwuMLDZ9iBsW\
-        SFZLmj5v1xH3kDnMuNYJg6Dau6PKHnZyD15tTyFtFtMaXaBc35RqYhsM7s8JuQ9tJ1UfFwd\
-        khHa1wdrmTWGcvq9DDmALuTtejH1ccoW43GiYSs1TmByJWjRtupvLzMRifZZ7meaGbUBgHU\
-        kA6t1VN3akoZ9BhdX561KpFGABxTU4NxyFqztEy1EB5EJYtTHwtbJQb1NmNMwKFkazXkn1o\
-        uKK6drH5y19roH3mMo2JykapbvzYPDBSXUwKQWe1RqSvogapwPxm1EzSRDeXNDP6EYUJJjj\
-        TAnckNatpT5UZDz4EhpaSbUzd9b5ztqsdPp9HxeBTm412GopAXKN5iSXSPS2WvrEdnANFD7\
-        tRV3a6PM2SfwpF6eFM5J7xXGJSoPm5TWJSPBMbxttxVFUETSRrBubEsd24aymYZZePJtHr7\
-        Q8S1deygcyXH5WhhYAmR23hNPv3nUUHe8iwJfaFg73Ncjr8fQBVjwePEy9JKT5jNG5sm87q\
-        e2RrHEWEwkNKnNgUknoVMbL7y3wmGFpP8VoKTgP51EjMDz7JTxnVsZeRsSp29STteGKbq4i\
-        wiC5EmMS5K86CAJ86FYt1kXXHJBSw4D79wAMgxRDDycp5PgdowdLxAbwySgpmwdfnxnSD4h\
-        Y8mo4jLGWokP1mGdgjnPmtMbzndiQCLPjpUcbZoVc6SQrTDCufupkJhy1ewo64yA1db6T2T\
-        ASTWSHJkjzaWt7QtFfnBo8WoXQrNKw5pyKAQsmP7n6r1SVD7tASfcZAjfaFHxkVvMpKwTQF\
-        dy9WHxREeCPK3yeN7ACT75RgRuRT1shC1PRCuAu4EFGnBmr3nWuDrYNCG5WrWuW6RRoMyB3\
-        YaXqjYMXRUVuwb5h2PBP9euBb96Ntung8ihWXa2mbKMYMtmaoYCDhYYrFYszYfdgQH68JYz\
-        AXZvjFH1SxCETfiXAWGD1aYDa33rXZLcLVx637igoydr77qmzo5YozRQnuXUiJ19PScLWic\
-        8jWeVmQ6Mm7BLoGhVPyYbJBeyX5HRwh8CNeLK2ekmhFz9MypB1rM2PXUfcnr2MXS9WRK8bh\
-        sy47awNdApPdN3RxmuyPLnvmN6FsG5fUNqF8rsz9KUiJh9C4ziYf6NSZvVG2c1KFsQRyFrS\
-        BzyjqqxBrH1xereV9YNr1gNamFjhZTncpGcPQf9oAoA4LQeSAZXR1dMtfktCs1fFWVbA67F\
-        dQ1GrpZVGTsZCbuw7Tspns8WoL158AdS7";
+        const PAYLOAD: &str = "CxxG69PFdKnFjGtd34VcXR7TZ5NqYgViTUhwi1Lq5HTyPWSBUkGJnEKY8BVnjFRmYsRA\
+            MxAhH5gQKpW1kj2eMdBBHb44MUoGPiwfyXRn8eBobvNzoPUon9AyJybGo2MAdgmZcArK4PPTrbzWyfNSLo7YqR7\
+            L7g7pWq35mnvkPRaVuepvLgLWtam8nGeh1wztj6MaLuNKPFUqxLSHc29aLRSHmATRdrp9LHXJiiYuNasL5Xfm3c\
+            HGWYZw4ozYPniR127ETnkseQckBp2ZCJ9aYKNVLb4ShShZgaEjefzwwZ5fpnGWHthUMkLe6LdpUgUK8zNsSLysX\
+            L5EmDeByVqyysKxw771otRnyTLu1hxK9F9TJDJEDCDw3CRwz8i9VfjN8Y6GpbMGBp6fdf1ZphwftBo1mpn2rtYH\
+            H5Fc39gQzT7zjqFT4spuTmxeVBHzrdkojKah8pZruayABW6GkuxXLBnua5ChaaDH7EpifZpfH7CTHDF5Th5QMu1\
+            BdQt5vjaWRQNgeeF8kEk4TViyK849DZkTLz8hSKNrKNawWrxCsMf83Jo229F94apnSqssoP8mq4NNEQwUxTiJod\
+            QVNYXpSQWtPZrav4596ypbrTWz8wSxneC2rqWD8cHLPL7ZHce6y9bTehLf6qDFvi6iCbmMZGNXzWFJXqiF9gSab\
+            GTUbFoJGRJi1Z5vD2YmLN6YpBVtMeFg2is68jJMd4XBWoudMJ6yMiuw16NDStmrneuXkX62LPVCJdjRy1NfVkJB\
+            ZT6Ds6rt57ECVE1fvqiHVo4mvvFbAy1mPM9VzajLrhBeASsaGw2HfVXz16os3zxYNkkptYJrLnn5CmVLvrb48cr\
+            RsfEQqFF1aTf5NoaFrWYgERTWvgSwJx2czemFPXhq8YuT1pcqXGt4HP6kbdzGANfjry3Q2TtS9iLpnH2d2Jhw6A\
+            qhA7hnyqDnKRBEBZLdKBNmxCSgbNS5VXPmLqUyduPZeSdMsUwqAZRd5vn653Fhe7yZi5kmMBbGF9C61rhZtC7rm\
+            Qow7Kiuj3rtQhkEdPNeskqzVged2VFEpyMozpx94tDZPjpZ16M2AH3RnR9uKQDdNbErRnsHNpsAZjm9e9TEGEtA\
+            Nb6wtykpAE1kCeh5PVy7YevhaJMYP8JEX8vqzN832zqhNrbg6kz57d3s9iupvYzDNBTHuG7LrJnqNu47kFsB6g2\
+            Bc2whLqwfvkFaiFnf7ooZVPxnDsmvKx1s1pM48DLWBL7BbvNAQWmEJGCeph9pVuLJVVkVedxGk5bV2oTmfyhCtD\
+            f2SHB5Vji7Yfum6eTvqNATf87oHLT9bwh3BArTCFAtm6jXibLoqkrA3ZuuxDbN6ETVNqAtJqDNp8p2SQFNoNNfs\
+            vzGkkdbSuWN6gGAAz7Np51ZAmRSPmFzFmBS8LQxZk19SDGgXZAow6fvQ7ytXE6NNPwoQnbAr4jcXYC2HGoY168J\
+            aSW1fU6hPWfToE7oBqdQYa1fTVQJdjwXiNJ3KBL8zzt1qzkdioFZ8TpFXZUjBwHek8zbGTcLCgDbyKfC2Kn43Ya\
+            GJs6grfzPoVfV7B7C1UxcvYijvg5Jpm9t8bxv3RTqm9YejyTm9tccXSAtAuraiuAMM2drr8PFxXES3HTLbGbJBD\
+            1NC4AZkpz";
 
         let mut rng = {
             let seed = [1u8; 32];
@@ -1176,7 +1183,6 @@ mod tests {
         let keypair = keypair_from_seed(&seed).unwrap();
         let slot = 142076266;
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 42).unwrap();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let mut shred = shredder
             .make_shreds_from_data_slice(
                 &keypair,
@@ -1185,7 +1191,6 @@ mod tests {
                 Hash::default(),
                 64,
                 64,
-                &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             )
             .unwrap()
@@ -1209,30 +1214,27 @@ mod tests {
     #[test]
     fn test_serde_compat_shred_data_empty() {
         // bytes of a serialized merkle data shred
-        const PAYLOAD: &str = "HV7qJBe3jCM8aRd4HAXJnJzyDvNYDYsPjjaaK2tTFTxJU2Qj\
-        7i87e45TzCg2Vv4rrcBznfs8212svH8aXsM2WYDPst43KyDz99FesBZ8aasxhkUgHGg3Smc\
-        Pa7opSARcYBpQAG2UHRYFmoPsj3hXADsX5C8JBM3jyHLtbQ78CH11J2dh7J4ps8JxCcUsq7\
-        E7PVs7NgFku54c8gBuhBuAMykvvSyhGRjyXCL17feubvA8WQyMJz27eXk8hE6LGs98ucsV9\
-        pScMuXVbAL4rT2cW9gN77QP4mBohJ8miWbMYbi7eLxiXJ9nA6i7XZd32GKscf3Ln8PK7NFT\
-        JpKxinptw2vd3MuVQRQjNuyZLTEjJSiaxoR1mhSKet27PCTkPWRAxPfMCvLNY2mtdixnFfk\
-        BdKj1nrwHcQYqNnKHjg3axRhx58QQ7VX5LSNGRtLByZRFMq9wCy7zz7HiMKvMZzddqixHcx\
-        EFeaM6YFh2sfmW3AKz4pS9s6XL3mAD9MtFvRJUXupNK9P3XtA7BGU8Z8AyYnVi4wxfaWoSd\
-        22nhDmMuHTRNHgUDxCEPHfE5enuR3PG4q1DGpVyV9rM6678qFG3cUKdTbJw85uFAkedEhAn\
-        RsU5u7H2DUTMrZ3AsLGuRmRoLZdxcFGe9GJmWY3WYEBJsdrJUVTnQVDsgvcc7HiFCoGBmGG\
-        KPS19ncA7Ynie1iokXCjwZNaQf3fpUMksGzkqjfYiFfGQDMNTsPUdcHFAae5Nmh3p8bduG6\
-        TNHn3A4LoSMX8wwM6Sn4XL3fFLHrkWTV8CJfg67AoqpzgGiWQNdeK2HRABGRbamUxXSzWhA\
-        tJ7yEPrh9tKTX851mpPjrFHxpu68xDL3t5nd18mtALJ5n5gmTsXMwUxpt9GfGrZyHXteZfH\
-        jaMLmSqvmDAFH1xADU2SZucRDbAWsuaWUMwaPXCNtiozgJ6uRnyxmwBhikChgtxDSZmRALA\
-        uYwEnCE8uj4NWvryeVpzfy6m9tqYutCkRsbNodaGmBZ2KGtg4iaQjj4iCK9jKKAxpYVnxbr\
-        n2jtFezUTsR9dqFh94c9Aa4NdPgkr19hcqabqBZyzan3xP3Jvs78Z5uqkSUVtXP3t3b5ozd\
-        qjYRMkgwsgGpNqcmBLGANiPXrQ8SseoNsCs3Xtv6Vf7oGg1St3teXSrtWMbsouK3uF8DPgn\
-        S14yUtrs8cyXX53QMCEuY1wKcoQZwSWqL86FTvZUA3vT6SYvjVKYxAXwNP1ouKdwtePfwdH\
-        wdM37RT9SMht4BLEXutSCcBys1K3pTWWwqGB87A26apuG1TiqeEugv1FrjprEKyt84S3FgM\
-        5eJfdN5NDArvw9bBR81UoYmyZgX5pEY6gNg2xw28Gd7gH9TVe5Y31iggni2oJ3GuBj3R7Ma\
-        umdo8rE1S4tBWVGsXikv9KFDtMmT2sMmeFuAwDbUZEGsBCAfK7EQpKcYSv7KajtgLpqi6JW\
-        RP8nBR7FkKR9qv5khhiBLuRzfSxwtADXZknFRU6bh8Ba6JmLhjhqkCYETizXmZVrjvy4gLZ\
-        we5YHZW5uhbthAzfcLRxuTxnPbyW7LehgwkYde64b8PzqYepYUtxqFHuJSwddis1VuoA2Lb\
-        M3SeyTe262Q7gUiPEjwQdRXKwUAgGrxVu";
+        const PAYLOAD: &str = "75DQSUQHsJ7GdpbdTdqUsAYLtdiSxQCJ2VfP2vLmM7szi3RsSk8z2VhJgKvLeUYQmhnF\
+            dMe8HrvaybnMNXCdYEFfiLXfYFQZCYUkg8nvypTSXGby9Z27KieRR5HKd39syRtuaah4928jLLGo8zAY7fT2eue\
+            Er6ekLv4f3hP6CQgMdswVAzYVFQLrtziDbj5TaRXiHdpvFKsxi23Ej3NDFkXRwLdMb1mJFzJpHaTPag4o64sdA9\
+            L4pioThohdyerguyPSJM5EqtGrubBZUerSGWkFx5WvVsGuw9Rq6vSVkjZsNyy9XzwiFTFqppD6dK1yEtRaCR4N2\
+            uT4VouGsTEkDd8oBqFVgVTiaCUoqi1cKn95PESGXLLDabneFvZeDjgjdBNaDrCEEfs4V4rcQWLhspMGwBFmcxnV\
+            FnpapowSxL26ag7TVEmDmULorFeffJeB7oddZUE4EdUnxWhHgae76nCzSfKQPNuwk7fKF58QFdApg2cD1gkgCJy\
+            FGXLWmrYaEwtzdd3bouubUXQQmtYLa7Uc57jdgcVnmSyGwBmwTzCdZsGBCwsyMyUJcAQz43PzAbctMndkt3zDws\
+            MHpJwPb6mFhFBhcEuZMT62oyLuDn13dKubrio6tiRviBityt5XRxHvx3YcdexmYkPM6irYWNaKe8ZXXRE1HKerv\
+            worz6jyhUfCWQmGMtsjuNEQ3ENoxXXF3uboPUazazkw3k232sBRCFzN9nd6of1ehiZCenJ1HpfTq7iK87SUkhsD\
+            RPxY753ADa3eo5ocppKBQZjdumTF14onxsv5zZvAX5uNZtEv5GRdiBP3moLXoKgSA4NDJvtYaXwfq8cMKzjV4hy\
+            LXaB45cExYZjJ7n2s6kyoLXuMmdpTRFiuQrENuBb1FtyMm6oVET9cMBCFSFCaKmdYinTZw5sNQrvbmCnYwgMhSm\
+            6r2DhpVoWZ8pPJtn5JmZoUWXSZbtUAaEtFsG4uAGiosuhYzda7hDjj62Aqfdp7nK9uJCNqcKA7mr4AY2Ut3vicX\
+            NdcJ3TrqZjQU98RMLgbd68h22iFm197L1PgFqjE7BwaoBnDTcnr52ocviJ2aBj273B9UShtwtW9tdk4bGntTASU\
+            yirT9SySEWhQcZJe9nFUgPwrMWjrBqFrrexR3Qf6xrLpksL5L3Pvp88b6Y5pCf1XwnHiqLqm2iuiDS4phQsGJSJ\
+            d3AGXm2Eg3HKGhkhoLFmWjN7mQ64ktKgajGX8PJREUKpcLiVdkw4qWA8aub5v789971BgDk3JZ2LZ5UBMVKQU7u\
+            QnsFT9xHk1D463WDg1nwDKhNAgaRGowS1nkvd8Ygms3Ja4A7C5bXHGUSiXR5jvryKVP6yhk9GcBexRUqvRk9EXb\
+            HjCHbFAUBpJ6P73sME8K7wg4W7eXt1YLRU4xELAXcefkn1uShXMEqjv9MSzsEAMS3pVnBGFLcepGPNShhH6yq7c\
+            QCa3by98WSNg7PMxVtGLKcVbKWpz7f1iuhhcmx9LZLayeAEAZCfAm9TyF5yGPHSoTveGEyGKND4PtpgN7GKrmro\
+            j3d3fudjECcfKYKY73D6KZHfEvYHqtVY8SrTXRhVRxjkCmLMMJ7Df4L5nixCECY7qtLyQyzv6bA6xS78dtaL9vr\
+            Ygs2QC9Tu";
+
         let mut rng = {
             let seed = [1u8; 32];
             ChaChaRng::from_seed(seed)

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -3,8 +3,8 @@
 
 use {
     super::{
-        DATA_SHREDS_PER_FEC_BLOCK, Error, Payload, ReedSolomonCache, Shred, ShredFetchStats,
-        ShredFlags, ShredType, ShredVariant, layout, merkle,
+        DATA_SHREDS_PER_FEC_BLOCK, Error, Payload, Shred, ShredFetchStats, ShredFlags, ShredType,
+        ShredVariant, layout, merkle,
     },
     crate::blockstore,
     solana_clock::Slot,
@@ -450,8 +450,6 @@ fn check_last_data_shred_index(index: u32) -> bool {
 
 /// Holds the context to perform filtering on shred recovery
 pub struct ShredRecoveryContext {
-    /// Used to perform RS erasure code recovery
-    pub reed_solomon_cache: ReedSolomonCache,
     /// Sender to retransmit the recovered shreds
     retransmit_sender: EvictingSender<Vec<Payload>>,
     /// Used for filtering recovered shreds
@@ -460,14 +458,12 @@ pub struct ShredRecoveryContext {
 
 impl ShredRecoveryContext {
     pub fn new(
-        reed_solomon_cache: ReedSolomonCache,
         retransmit_sender: EvictingSender<Vec<Payload>>,
         root_bank: Arc<Bank>,
         shred_version: u16,
     ) -> Self {
         let shred_filter_ctx = ShredFilterContext::new(root_bank, shred_version);
         Self {
-            reed_solomon_cache,
             retransmit_sender,
             shred_filter_ctx,
         }
@@ -505,7 +501,7 @@ impl ShredRecoveryContext {
         // The same signature also verifies for recovered shreds because when
         // reconstructing the Merkle tree for the erasure batch, we will obtain the
         // same Merkle root.
-        let shreds = merkle::recover(shreds, &self.reed_solomon_cache)?;
+        let shreds = merkle::recover(shreds)?;
         shreds
             .filter_map(|shred| shred.ok())
             .filter(|shred| !self.should_discard_shred(shred))
@@ -774,7 +770,6 @@ mod tests {
         let max_code_shreds_per_slot = coding_shreds[0].index();
         let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
         let mut shred_recovery_context = ShredRecoveryContext::new(
-            ReedSolomonCache::default(),
             dummy_retransmit_sender,
             new_test_bank(0),
             shred_version,
@@ -797,9 +792,7 @@ mod tests {
                 &mut recovered_shreds,
                 &mut recovered_data_shreds,
             ),
-            Err(Error::Erasure(
-                reed_solomon_erasure::Error::TooFewParityShards
-            ))
+            Err(Error::TooFewParityShards)
         );
         assert!(recovered_shreds.is_empty());
         assert!(recovered_data_shreds.is_empty());

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1,23 +1,18 @@
 use {
-    crate::{
-        shred::{
-            self, CODING_SHREDS_PER_FEC_BLOCK, CodingShredHeader, DATA_SHREDS_PER_FEC_BLOCK,
-            DataShredHeader, Error, ProcessShredsStats, SHREDS_PER_FEC_BLOCK,
-            SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_NONCE,
-            SIZE_OF_SIGNATURE, Shred, ShredCommonHeader, ShredFlags, ShredVariant,
-            common::impl_shred_common,
-            merkle_tree::*,
-            payload::{Payload, PayloadMutGuard},
-            shred_code, shred_data,
-            traits::{
-                Shred as ShredTrait, ShredCode as ShredCodeTrait, ShredData as ShredDataTrait,
-            },
-        },
-        shredder::ReedSolomonCache,
+    crate::shred::{
+        self, CODING_SHREDS_PER_FEC_BLOCK, CodingShredHeader, DATA_SHREDS_PER_FEC_BLOCK,
+        DataShredHeader, Error, ProcessShredsStats, SHREDS_PER_FEC_BLOCK,
+        SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_NONCE, SIZE_OF_SIGNATURE,
+        Shred, ShredCommonHeader, ShredFlags, ShredVariant,
+        common::impl_shred_common,
+        merkle_tree::*,
+        payload::{Payload, PayloadMutGuard},
+        shred_code, shred_data,
+        traits::{Shred as ShredTrait, ShredCode as ShredCodeTrait, ShredData as ShredDataTrait},
     },
+    additive_fft_reed_solomon::{Gf2p8_11d, Rs},
     assert_matches::debug_assert_matches,
     itertools::Itertools,
-    reed_solomon_erasure::Error::{InvalidIndex, TooFewParityShards},
     solana_clock::Slot,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -26,7 +21,7 @@ use {
     solana_signer::Signer,
     static_assertions::const_assert_eq,
     std::{
-        cmp::Ordering,
+        cell::RefCell,
         io::{Cursor, Write},
         ops::Range,
         time::Instant,
@@ -35,6 +30,26 @@ use {
 
 const_assert_eq!(ShredData::SIZE_OF_PAYLOAD, 1203);
 const_assert_eq!(ShredCode::SIZE_OF_PAYLOAD, 1228);
+
+thread_local! {
+    static RS_ENCODE_WORKSPACE: RefCell<Vec<Gf2p8_11d>> = RefCell::new(Vec::new());
+}
+
+thread_local! {
+    static RS_RECOVER_WORKSPACE: RefCell<Vec<Gf2p8_11d>> = RefCell::new(Vec::new());
+}
+
+thread_local! {
+    static RS_MESSAGE: RefCell<Vec<Gf2p8_11d>> = RefCell::new(Vec::new());
+}
+
+thread_local! {
+    static RS_PARITY: RefCell<Vec<Gf2p8_11d>> = RefCell::new(Vec::new());
+}
+
+thread_local! {
+    static RS_RECEIVED: RefCell<Vec<Gf2p8_11d>> = RefCell::new(Vec::new());
+}
 
 // Layout: {common, data} headers | data buffer
 //     | [Merkle root of the previous erasure batch if chained]
@@ -588,42 +603,47 @@ fn get_merkle_node(shred: &[u8], offsets: Range<usize>) -> Result<Hash, Error> {
 }
 
 pub(super) fn recover(
-    mut shreds: Vec<Shred>,
-    reed_solomon_cache: &ReedSolomonCache,
+    shreds: Vec<Shred>,
 ) -> Result<impl Iterator<Item = Result<Shred, Error>> + use<>, Error> {
-    // Sort shreds by their erasure shard index.
-    // In particular this places all data shreds before coding shreds.
-    let is_sorted = |(a, b)| cmp_shred_erasure_shard_index(a, b).is_le();
-    if !shreds.iter().tuple_windows().all(is_sorted) {
-        shreds.sort_unstable_by(cmp_shred_erasure_shard_index);
-    }
-    // Grab {common, coding} headers from the last coding shred.
+    // Grab {common, coding} headers from the first coding shred.
     // Incoming shreds are resigned immediately after signature verification,
     // so we can just grab the retransmitter signature from one of the
     // available shreds and attach it to the recovered shreds.
-    let (common_header, coding_header, merkle_root, chained_merkle_root, retransmitter_signature) = {
-        // The last shred must be a coding shred by the above sorting logic.
-        let Some(Shred::ShredCode(shred)) = shreds.last() else {
-            return Err(Error::from(TooFewParityShards));
+    let (
+        common_header,
+        coding_header,
+        merkle_root,
+        chained_merkle_root,
+        retransmitter_signature,
+        shard_len,
+    ) = {
+        let Some(shred) = shreds.iter().find_map(|shred| match shred {
+            Shred::ShredCode(shred) => Some(shred),
+            Shred::ShredData(_) => None,
+        }) else {
+            return Err(Error::TooFewParityShards);
         };
         let position = u32::from(shred.coding_header.position);
         let index = shred.common_header.index.checked_sub(position);
         let common_header = ShredCommonHeader {
-            index: index.ok_or(Error::from(InvalidIndex))?,
+            index: index.ok_or(Error::InvalidIndex)?,
             ..shred.common_header
         };
         let coding_header = CodingShredHeader {
             position: 0u16,
             ..shred.coding_header
         };
+        let shard_len = shred.erasure_shard()?.len();
         (
             common_header,
             coding_header,
             shred.merkle_root()?,
             shred.chained_merkle_root().ok(),
             shred.retransmitter_signature().ok(),
+            shard_len,
         )
     };
+
     debug_assert_matches!(common_header.shred_variant, ShredVariant::MerkleCode { .. });
     let (proof_size, resigned) = match common_header.shred_variant {
         ShredVariant::MerkleCode {
@@ -673,140 +693,174 @@ pub(super) fn recover(
                 }
             }
     }));
-    let num_data_shreds = usize::from(coding_header.num_data_shreds);
-    let num_coding_shreds = usize::from(coding_header.num_coding_shreds);
-    let num_shards = num_data_shreds + num_coding_shreds;
-    // Identify which shreds are missing and create stub shreds in their place.
-    let mut mask = vec![false; num_shards];
-    let mut shreds = {
-        let make_stub_shred = |erasure_shard_index| {
-            make_stub_shred(
-                erasure_shard_index,
-                &common_header,
-                &coding_header,
-                &chained_merkle_root,
-                &retransmitter_signature,
-            )
-        };
-        let mut batch = Vec::with_capacity(num_shards);
-        // By the sorting logic earlier above, this visits shreds in the order
-        // of their erasure shard index.
-        for shred in shreds {
+
+    // Batch sizes declared in the shreds, casted to usize. Subject to sanity checks below.
+    let num_data_shreds = coding_header.num_data_shreds as usize;
+    let num_coding_shreds = coding_header.num_coding_shreds as usize;
+    if num_data_shreds == 0 || num_data_shreds > DATA_SHREDS_PER_FEC_BLOCK {
+        return Err(Error::InvalidNumDataShreds(coding_header.num_data_shreds));
+    }
+    if num_coding_shreds == 0 || num_coding_shreds > CODING_SHREDS_PER_FEC_BLOCK {
+        return Err(Error::InvalidNumCodingShreds(
+            coding_header.num_coding_shreds,
+        ));
+    }
+
+    // Merkle leaf count.
+    let num_shreds = num_data_shreds + num_coding_shreds;
+
+    let make_stub_shred = |erasure_shard_index| {
+        make_stub_shred(
+            erasure_shard_index,
+            &common_header,
+            &coding_header,
+            &chained_merkle_root,
+            &retransmitter_signature,
+        )
+    };
+
+    // Codec shard index derived from shred batch metadata. Parity-first.
+    let codec_shard_index = |shred_index: usize| -> usize {
+        debug_assert!(shred_index < num_shreds);
+        if shred_index < num_data_shreds {
+            CODING_SHREDS_PER_FEC_BLOCK + shred_index
+        } else {
+            shred_index - num_data_shreds
+        }
+    };
+
+    // Merkle tree nodes. Only the first `num_shred` elements are accessed.
+    let mut nodes: [Option<Hash>; SHREDS_PER_FEC_BLOCK] = [None; SHREDS_PER_FEC_BLOCK];
+
+    let recovered = RS_RECEIVED.with_borrow_mut(|mut rec| {
+        rec.resize(SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+
+        // Ones for the given shreds and zeros for erasures. Codec ordering: parity shard indices
+        // are less than message shard indices.
+        let mut mask: u64 = 0;
+
+        for mut shred in shreds {
             // The leader signs the Merkle root and shreds in the same erasure
             // batch have the same Merkle root. So the signatures are the same
             // or shreds are not from the same erasure batch.
             if shred.signature() != &common_header.signature {
                 return Err(Error::InvalidMerkleRoot);
             }
-            let erasure_shard_index = shred.erasure_shard_index()?;
-            if !(batch.len()..num_shards).contains(&erasure_shard_index) {
-                return Err(Error::from(InvalidIndex));
+
+            let shred_index = shred.erasure_shard_index()?;
+
+            // Convert the shard index to codec ordering.
+            let shard_index = codec_shard_index(shred_index);
+            // Check for duplicates.
+            if mask & (1 << shard_index) != 0 {
+                return Err(Error::InvalidIndex);
             }
-            // Push stub shreds as placeholder for the missing shreds in
-            // between.
-            while batch.len() < erasure_shard_index {
-                batch.push(make_stub_shred(batch.len())?);
-            }
-            mask[erasure_shard_index] = true;
-            batch.push(shred);
+
+            nodes[shred_index] = Some(shred.merkle_node()?);
+
+            let src: &[Gf2p8_11d] = unsafe {
+                std::slice::from_raw_parts(
+                    shred.erasure_shard_mut()?.as_ptr() as *const Gf2p8_11d,
+                    shard_len,
+                )
+            };
+            rec[shard_index * shard_len..(shard_index + 1) * shard_len].copy_from_slice(src);
+            mask |= 1 << shard_index;
         }
-        // Push stub shreds as placeholder for the missing shreds at the end.
-        while batch.len() < num_shards {
-            batch.push(make_stub_shred(batch.len())?);
+
+        // Zero the erased and given zero shards.
+        for i in (0..SHREDS_PER_FEC_BLOCK).filter(|i| mask & (1 << i) == 0) {
+            rec[i * shard_len..(i + 1) * shard_len].fill(0u8.into());
         }
-        batch
-    };
-    // Obtain erasure encoded shards from the shreds and reconstruct shreds.
-    let mut shards = shreds
-        .iter_mut()
-        .zip(&mask)
-        .map(|(shred, &mask)| Ok((shred.erasure_shard_mut()?, mask)))
-        .collect::<Result<Vec<_>, Error>>()?;
-    reed_solomon_cache
-        .get(num_data_shreds, num_coding_shreds)?
-        .reconstruct(&mut shards)?;
-    // Drop the mut guards to allow further mutation below.
-    drop(shards);
-    // Verify and sanitize recovered shreds, re-compute the Merkle tree and set
-    // the merkle proof on the recovered shreds.
-    let nodes = shreds
-        .iter_mut()
-        .zip(&mask)
-        .enumerate()
-        .map(|(index, (shred, mask))| {
-            if !mask {
-                if index < num_data_shreds {
-                    let Shred::ShredData(shred) = shred else {
-                        return Err(Error::InvalidRecoveredShred);
-                    };
-                    let (common_header, data_header) = wincode::deserialize(&shred.payload[..])?;
-                    if shred.common_header != common_header {
-                        return Err(Error::InvalidRecoveredShred);
-                    }
-                    shred.data_header = data_header;
-                } else if !matches!(shred, Shred::ShredCode(_)) {
+
+        // Message shards past num_data_shreds are given zeros that were not transmitted. They are
+        // not erasures.
+        for i in CODING_SHREDS_PER_FEC_BLOCK + num_data_shreds..SHREDS_PER_FEC_BLOCK {
+            mask |= 1 << i;
+        }
+
+        let mut remaining_erasures = !mask;
+        let mut erasure_positions = Vec::with_capacity(remaining_erasures.count_ones() as usize);
+        while remaining_erasures != 0 {
+            erasure_positions.push(remaining_erasures.trailing_zeros() as u8);
+            // Clear the lowest set bit.
+            remaining_erasures &= remaining_erasures - 1;
+        }
+
+        if !erasure_positions.is_empty() {
+            RS_RECOVER_WORKSPACE.with_borrow_mut(|mut ws| {
+                let rs = Rs::<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>::default();
+                ws.resize(SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+                if !rs.recover_erasure_shards(&mut rec, &mut ws, shard_len, &erasure_positions) {
+                    return Err(Error::TooManyErasures);
+                }
+                Ok(())
+            })?;
+        }
+
+        // Collect, verify and sanitize recovered shreds, re-compute the Merkle tree and set
+        // the merkle proof on the recovered shreds.
+        let mut recovered = Vec::new();
+        for (shred_index, node) in nodes
+            .iter_mut()
+            .take(num_shreds)
+            .enumerate()
+            .filter(|(_, n)| n.is_none())
+        {
+            let shard_index = codec_shard_index(shred_index);
+            let mut shred = make_stub_shred(shred_index)?;
+            let src: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    rec[shard_index * shard_len..(shard_index + 1) * shard_len].as_ptr()
+                        as *const u8,
+                    shard_len,
+                )
+            };
+            shred.erasure_shard_mut()?.copy_from_slice(src);
+            if shred_index < num_data_shreds {
+                let Shred::ShredData(shred) = &mut shred else {
+                    return Err(Error::InvalidRecoveredShred);
+                };
+                let (common_header, data_header) = wincode::deserialize(&shred.payload[..])?;
+                if shred.common_header != common_header {
                     return Err(Error::InvalidRecoveredShred);
                 }
-                shred.sanitize()?;
+                shred.data_header = data_header;
+            } else if !matches!(shred, Shred::ShredCode(_)) {
+                return Err(Error::InvalidRecoveredShred);
             }
-            shred.merkle_node()
-        });
-    let tree = MerkleTree::try_new(nodes)?;
+            shred.sanitize()?;
+            *node = Some(shred.merkle_node()?);
+            recovered.push((shred_index, shred));
+        }
+        Ok(recovered)
+    })?;
+
+    debug_assert!(nodes[..num_shreds].iter().all(Option::is_some));
+    let tree = MerkleTree::try_new(
+        nodes[..num_shreds]
+            .iter()
+            .map(|node| node.ok_or(Error::InvalidRecoveredShred)),
+    )?;
+
     // The attached signature verifies only if we obtain the same Merkle root.
     // Because shreds obtained from turbine or repair are sig-verified, this
     // also means that we don't need to verify signatures for recovered shreds.
     if tree.root() != &merkle_root {
         return Err(Error::InvalidMerkleRoot);
     }
-    let set_merkle_proof = move |(index, (mut shred, mask)): (_, (Shred, _))| {
-        if mask {
-            debug_assert!({
-                let proof = tree.make_merkle_proof(index, num_shards);
-                shred.merkle_proof()?.map(Some).eq(proof.map(Result::ok))
-            });
-            Ok(None)
-        } else {
-            let proof = tree.make_merkle_proof(index, num_shards);
-            shred.set_merkle_proof(proof)?;
-            // Already sanitized after reconstruct.
-            debug_assert_matches!(shred.sanitize(), Ok(()));
-            // Assert that shred payload is fully populated.
-            debug_assert_eq!(shred, {
-                let shred = shred.payload().clone();
-                Shred::from_payload(shred).unwrap()
-            });
-            Ok(Some(shred))
-        }
-    };
-    Ok(shreds
-        .into_iter()
-        .zip(mask)
-        .enumerate()
-        .map(set_merkle_proof)
-        .filter_map(Result::transpose))
-}
 
-// Compares shreds of the same erasure batch by their erasure shard index
-// within the erasure batch.
-#[inline]
-fn cmp_shred_erasure_shard_index(a: &Shred, b: &Shred) -> Ordering {
-    debug_assert_eq!(
-        a.common_header().fec_set_index,
-        b.common_header().fec_set_index
-    );
-    // Ordering by erasure shard index is equivalent to:
-    //   * ShredType::Data < ShredType::Code.
-    //   * Tie break by shred index.
-    match (a, b) {
-        (Shred::ShredCode(_), Shred::ShredData(_)) => Ordering::Greater,
-        (Shred::ShredData(_), Shred::ShredCode(_)) => Ordering::Less,
-        (Shred::ShredCode(a), Shred::ShredCode(b)) => {
-            a.common_header.index.cmp(&b.common_header.index)
-        }
-        (Shred::ShredData(a), Shred::ShredData(b)) => {
-            a.common_header.index.cmp(&b.common_header.index)
-        }
-    }
+    Ok(recovered.into_iter().map(move |(shred_index, mut shred)| {
+        shred.set_merkle_proof(tree.make_merkle_proof(shred_index, num_shreds))?;
+        // Already sanitized after reconstruct.
+        debug_assert_matches!(shred.sanitize(), Ok(()));
+        // Assert that shred payload is fully populated.
+        debug_assert_eq!(shred, {
+            let shred = shred.payload().clone();
+            Shred::from_payload(shred).unwrap()
+        });
+        Ok(shred)
+    }))
 }
 
 // Creates a minimally populated shred which will be a placeholder for a
@@ -822,7 +876,7 @@ fn make_stub_shred(
 ) -> Result<Shred, Error> {
     let num_data_shreds = usize::from(coding_header.num_data_shreds);
     let mut shred = if let Some(position) = erasure_shard_index.checked_sub(num_data_shreds) {
-        let position = u16::try_from(position).map_err(|_| Error::from(InvalidIndex))?;
+        let position = u16::try_from(position).map_err(|_| Error::InvalidIndex)?;
         let common_header = ShredCommonHeader {
             index: common_header.index + u32::from(position),
             ..*common_header
@@ -849,7 +903,7 @@ fn make_stub_shred(
             resigned: retransmitter_signature.is_some(),
         };
         let index = common_header.fec_set_index
-            + u32::try_from(erasure_shard_index).map_err(|_| InvalidIndex)?;
+            + u32::try_from(erasure_shard_index).map_err(|_| Error::InvalidIndex)?;
         let common_header = ShredCommonHeader {
             shred_variant,
             index,
@@ -947,7 +1001,6 @@ pub(crate) fn make_shreds_from_data(
     is_last_in_slot: bool,
     next_shred_index: u32,
     next_code_index: u32,
-    reed_solomon_cache: &ReedSolomonCache,
     stats: &mut ProcessShredsStats,
 ) -> Result<Vec<Shred>, Error> {
     let now = Instant::now();
@@ -1110,7 +1163,7 @@ pub(crate) fn make_shreds_from_data(
     // (and so the signature) cannot be computed without the Merkle root of
     // the previous erasure batch.
     batches.try_fold(chained_merkle_root, |chained_merkle_root, batch| {
-        finish_erasure_batch(keypair, batch, chained_merkle_root, reed_solomon_cache)
+        finish_erasure_batch(keypair, batch, chained_merkle_root)
     })?;
     stats.gen_coding_elapsed += now.elapsed().as_micros() as u64;
     Ok(shreds)
@@ -1161,7 +1214,6 @@ fn finish_erasure_batch(
     shreds: &mut [Shred],
     // The Merkle root of the previous erasure batch if chained.
     chained_merkle_root: Hash,
-    reed_solomon_cache: &ReedSolomonCache,
 ) -> Result<Hash, Error> {
     debug_assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
     // Write common and {data,coding} headers into shreds' payload.
@@ -1186,21 +1238,61 @@ fn finish_erasure_batch(
     } = {
         // Last shred in the erasure batch should be a coding shred.
         let Some(Shred::ShredCode(shred)) = shreds.last() else {
-            return Err(Error::from(TooFewParityShards));
+            return Err(Error::TooFewParityShards);
         };
         shred.coding_header
     };
     let num_data_shreds = usize::from(num_data_shreds);
     let num_coding_shreds = usize::from(num_coding_shreds);
     let erasure_batch_size = num_data_shreds + num_coding_shreds;
-    reed_solomon_cache
-        .get(num_data_shreds, num_coding_shreds)?
-        .encode(
-            shreds
-                .iter_mut()
-                .map(Shred::erasure_shard_mut)
-                .collect::<Result<Vec<_>, _>>()?,
-        )?;
+
+    // FIXME: temporary trigger to reveal callers violating the requirement of Rs<_, _>
+    debug_assert_eq!(num_data_shreds, DATA_SHREDS_PER_FEC_BLOCK);
+    debug_assert_eq!(num_coding_shreds, CODING_SHREDS_PER_FEC_BLOCK);
+
+    let shard_len = shreds[0].erasure_shard_mut()?.len();
+    RS_MESSAGE.with(|msg| {
+        let mut msg = msg.borrow_mut();
+        msg.resize(DATA_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+
+        for (i, shred) in shreds.iter_mut().take(num_data_shreds).enumerate() {
+            let shard = shred.erasure_shard_mut()?;
+            let src: &[Gf2p8_11d] = unsafe {
+                std::slice::from_raw_parts(shard.as_ptr() as *const Gf2p8_11d, shard_len)
+            };
+            msg[i * shard_len..(i + 1) * shard_len].copy_from_slice(src);
+        }
+
+        RS_PARITY.with(|par| {
+            let mut par = par.borrow_mut();
+            // Set the length to the number of parity shards and fill with zeros.
+            par.clear();
+            par.resize(CODING_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+
+            RS_ENCODE_WORKSPACE.with(|ws| {
+                let mut ws = ws.borrow_mut();
+                ws.resize(CODING_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+                let rs = Rs::<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>::default();
+                rs.encode_systematic_sharded(&msg, &mut par, &mut ws, shard_len);
+            });
+
+            // Due to the scatter-gather payload, the parity shards need to be copied back. By the
+            // existing Agave convention, parity shards are appended after the message shards, even
+            // though this order is reversed in Rs.
+            for i in 0..CODING_SHREDS_PER_FEC_BLOCK {
+                let shard = &par[i * shard_len..(i + 1) * shard_len];
+                let src: &[u8] =
+                    unsafe { std::slice::from_raw_parts(shard.as_ptr() as *const u8, shard_len) };
+                let mut dst = shreds[num_data_shreds + i].erasure_shard_mut()?;
+                dst.copy_from_slice(src);
+            }
+
+            Ok::<(), Error>(())
+        })?;
+
+        Ok::<(), Error>(())
+    })?;
+
     // Set the chained_merkle_root for each shred.
     for shred in shreds.iter_mut() {
         shred.set_chained_merkle_root(&chained_merkle_root)?;
@@ -1232,9 +1324,8 @@ pub(crate) fn finish_erasure_batch_for_tests(
     keypair: &Keypair,
     shreds: &mut [Shred],
     chained_merkle_root: Hash,
-    reed_solomon_cache: &ReedSolomonCache,
 ) -> Result<Hash, Error> {
-    finish_erasure_batch(keypair, shreds, chained_merkle_root, reed_solomon_cache)
+    finish_erasure_batch(keypair, shreds, chained_merkle_root)
 }
 
 #[cfg(test)]
@@ -1244,12 +1335,11 @@ mod test {
         crate::shred::{ShredFlags, ShredId, ShredType},
         assert_matches::assert_matches,
         itertools::Itertools,
-        rand::{Rng, seq::SliceRandom},
-        reed_solomon_erasure::Error::TooFewShardsPresent,
+        rand::{CryptoRng, Rng, seq::SliceRandom},
         solana_keypair::Keypair,
         solana_packet::PACKET_DATA_SIZE,
         solana_signer::Signer,
-        std::{cmp::Ordering, collections::HashMap, iter::repeat_with},
+        std::{cmp::Ordering, collections::HashMap},
         test_case::{test_case, test_matrix},
     };
 
@@ -1313,36 +1403,214 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_merkle_proof_entry_from_hash() {
-        let mut rng = rand::rng();
-        let bytes: [u8; 32] = rng.random();
-        let hash = Hash::from(bytes);
-        let entry = &hash.as_ref()[..SIZE_OF_MERKLE_PROOF_ENTRY];
-        let entry = MerkleProofEntry::try_from(entry).unwrap();
-        assert_eq!(entry, &bytes[..SIZE_OF_MERKLE_PROOF_ENTRY]);
+    fn make_common_header<R: Rng + CryptoRng>(
+        rng: &mut R,
+        shred_variant: ShredVariant,
+    ) -> ShredCommonHeader {
+        ShredCommonHeader {
+            signature: Signature::default(),
+            shred_variant,
+            slot: 145_865_705,
+            index: 1835,
+            version: rng.random(),
+            fec_set_index: 1835,
+        }
     }
 
-    #[test]
-    fn test_make_merkle_proof_error() {
+    #[test_case(19, false)]
+    #[test_case(19, true)]
+    #[test_case(31, false)]
+    #[test_case(31, true)]
+    #[test_case(32, false)]
+    #[test_case(32, true)]
+    #[test_case(33, false)]
+    #[test_case(33, true)]
+    #[test_case(37, false)]
+    #[test_case(37, true)]
+    #[test_case(64, false)]
+    #[test_case(64, true)]
+    #[test_case(73, false)]
+    #[test_case(73, true)]
+    fn test_recover_merkle_shreds(num_shreds: usize, resigned: bool) {
         let mut rng = rand::rng();
-        let nodes = repeat_with(|| rng.random::<[u8; 32]>()).map(Hash::from);
-        let nodes: Vec<_> = nodes.take(5).collect();
-        let size = nodes.len();
-        let tree = MerkleTree::try_new(nodes.into_iter().map(Ok)).unwrap();
-        for index in size..size + 3 {
+        for num_data_shreds in 1..num_shreds {
+            let num_coding_shreds = num_shreds - num_data_shreds;
+            // Batch shapes outside Rs<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>
+            // cannot be encoded. Verify that recover rejects them.
+            if num_data_shreds > DATA_SHREDS_PER_FEC_BLOCK
+                || num_coding_shreds > CODING_SHREDS_PER_FEC_BLOCK
+            {
+                run_recover_rejects_oversized(
+                    &mut rng,
+                    resigned,
+                    num_data_shreds,
+                    num_coding_shreds,
+                );
+            } else {
+                run_recover_merkle_shreds(&mut rng, resigned, num_data_shreds, num_coding_shreds);
+            }
+        }
+    }
+
+    fn run_recover_rejects_oversized<R: Rng + CryptoRng>(
+        rng: &mut R,
+        resigned: bool,
+        num_data_shreds: usize,
+        num_coding_shreds: usize,
+    ) {
+        let num_shreds = num_data_shreds + num_coding_shreds;
+        let proof_size = get_proof_size(num_shreds);
+        let common_header = make_common_header(
+            rng,
+            ShredVariant::MerkleCode {
+                proof_size,
+                resigned,
+            },
+        );
+        let coding_header = CodingShredHeader {
+            num_data_shreds: num_data_shreds as u16,
+            num_coding_shreds: num_coding_shreds as u16,
+            position: 0,
+        };
+        let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
+        wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
+        let shreds = vec![Shred::ShredCode(ShredCode {
+            common_header,
+            coding_header,
+            payload: Payload::from(payload),
+        })];
+        if num_data_shreds > DATA_SHREDS_PER_FEC_BLOCK {
             assert_matches!(
-                tree.make_merkle_proof(index, size).next(),
-                Some(Err(Error::InvalidMerkleProof))
+                recover(shreds).err(),
+                Some(Error::InvalidNumDataShreds(n)) if n as usize == num_data_shreds
+            );
+        } else if num_coding_shreds > CODING_SHREDS_PER_FEC_BLOCK {
+            assert_matches!(
+                recover(shreds).err(),
+                Some(Error::InvalidNumCodingShreds(n)) if n as usize == num_coding_shreds
             );
         }
     }
 
-    fn verify_erasure_recovery<R: Rng>(
+    fn run_recover_merkle_shreds<R: Rng + CryptoRng>(
         rng: &mut R,
-        shreds: &[Shred],
-        reed_solomon_cache: &ReedSolomonCache,
+        resigned: bool,
+        num_data_shreds: usize,
+        num_coding_shreds: usize,
     ) {
+        let keypair = Keypair::new();
+        let num_shreds = num_data_shreds + num_coding_shreds;
+        let proof_size = get_proof_size(num_shreds);
+        let capacity = ShredData::capacity(proof_size, resigned).unwrap();
+        let common_header = make_common_header(
+            rng,
+            ShredVariant::MerkleData {
+                proof_size,
+                resigned,
+            },
+        );
+        let data_header = {
+            let reference_tick = rng.random_range(0..0x40);
+            DataShredHeader {
+                parent_offset: rng.random::<u16>().max(1),
+                flags: ShredFlags::from_bits_retain(reference_tick),
+                size: 0,
+            }
+        };
+        let coding_header = CodingShredHeader {
+            num_data_shreds: num_data_shreds as u16,
+            num_coding_shreds: num_coding_shreds as u16,
+            position: 0,
+        };
+        let mut shreds = Vec::with_capacity(num_shreds);
+        for i in 0..num_data_shreds {
+            let common_header = ShredCommonHeader {
+                index: common_header.index + i as u32,
+                ..common_header
+            };
+            let size = ShredData::SIZE_OF_HEADERS + rng.random_range(0..capacity);
+            let data_header = DataShredHeader {
+                size: size as u16,
+                ..data_header
+            };
+            let mut payload = vec![0u8; ShredData::SIZE_OF_PAYLOAD];
+            wincode::serialize_into(&mut payload[..], &(&common_header, &data_header)).unwrap();
+            rng.fill(&mut payload[ShredData::SIZE_OF_HEADERS..size]);
+            let shred = ShredData {
+                common_header,
+                data_header,
+                payload: Payload::from(payload),
+            };
+            shreds.push(Shred::ShredData(shred));
+        }
+        let data: Vec<_> = shreds
+            .iter_mut()
+            .map(Shred::erasure_shard_mut)
+            .collect::<Result<_, _>>()
+            .unwrap();
+        let shard_len = data[0].len();
+
+        let mut message: Vec<Gf2p8_11d> = Vec::with_capacity(DATA_SHREDS_PER_FEC_BLOCK * shard_len);
+        for shard in data {
+            let src: &[Gf2p8_11d] = unsafe {
+                std::slice::from_raw_parts(shard.as_ptr() as *const Gf2p8_11d, shard_len)
+            };
+            message.extend_from_slice(src);
+        }
+        // Zero any remaining message shards.
+        message.resize(DATA_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+
+        let mut parity = vec![0u8.into(); CODING_SHREDS_PER_FEC_BLOCK * shard_len];
+
+        RS_ENCODE_WORKSPACE.with_borrow_mut(|mut ws| {
+            let rs = Rs::<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>::default();
+            ws.resize(CODING_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
+            rs.encode_systematic_sharded(&message, &mut parity, &mut ws, shard_len);
+        });
+
+        for (i, shard) in parity.chunks(shard_len).take(num_coding_shreds).enumerate() {
+            let code: &[u8] =
+                unsafe { std::slice::from_raw_parts(shard.as_ptr() as *const u8, shard_len) };
+
+            let common_header = ShredCommonHeader {
+                shred_variant: ShredVariant::MerkleCode {
+                    proof_size,
+                    resigned,
+                },
+                index: common_header.index + i as u32 + 7,
+                ..common_header
+            };
+            let coding_header = CodingShredHeader {
+                position: i as u16,
+                ..coding_header
+            };
+            let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
+            wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
+
+            payload[ShredCode::SIZE_OF_HEADERS..ShredCode::SIZE_OF_HEADERS + code.len()]
+                .copy_from_slice(code);
+            let shred = ShredCode {
+                common_header,
+                coding_header,
+                payload: Payload::from(payload),
+            };
+            shreds.push(Shred::ShredCode(shred));
+        }
+        let nodes = shreds.iter().map(Shred::merkle_node);
+        let tree = MerkleTree::try_new(nodes).unwrap();
+        for (index, shred) in shreds.iter_mut().enumerate() {
+            let proof = tree.make_merkle_proof(index, num_shreds);
+            shred.set_merkle_proof(proof).unwrap();
+            let data = shred.signed_data().unwrap();
+            let signature = keypair.sign_message(data.as_ref());
+            shred.set_signature(signature);
+            assert!(shred.verify(&keypair.pubkey()));
+            assert_matches!(shred.sanitize(), Ok(()));
+        }
+        verify_erasure_recovery(rng, &shreds);
+    }
+
+    fn verify_erasure_recovery<R: Rng>(rng: &mut R, shreds: &[Shred]) {
         assert_eq!(shreds.iter().map(Shred::signature).dedup().count(), 1);
         assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
         let num_shreds = shreds.len();
@@ -1361,23 +1629,14 @@ mod test {
                     ShredVariant::MerkleData { .. }
                 )
             }) {
-                assert_matches!(
-                    recover(shreds, reed_solomon_cache).err(),
-                    Some(Error::Erasure(TooFewParityShards))
-                );
+                assert_matches!(recover(shreds).err(), Some(Error::TooFewParityShards));
                 continue;
             }
             if shreds.len() < num_data_shreds {
-                assert_matches!(
-                    recover(shreds, reed_solomon_cache).err(),
-                    Some(Error::Erasure(TooFewShardsPresent))
-                );
+                assert_matches!(recover(shreds).err(), Some(Error::TooManyErasures));
                 continue;
             }
-            let recovered_shreds: Vec<_> = recover(shreds, reed_solomon_cache)
-                .unwrap()
-                .map(Result::unwrap)
-                .collect();
+            let recovered_shreds: Vec<_> = recover(shreds).unwrap().map(Result::unwrap).collect();
             assert_eq!(size + recovered_shreds.len(), num_shreds);
             assert_eq!(recovered_shreds.len(), removed_shreds.len());
             removed_shreds.sort_by(|a, b| {
@@ -1400,9 +1659,8 @@ mod test {
     fn test_make_shreds_from_data(data_size: usize, is_last_in_slot: bool) {
         let mut rng = rand::rng();
         let data_size = data_size.saturating_sub(16);
-        let reed_solomon_cache = ReedSolomonCache::default();
         for data_size in data_size..data_size + 32 {
-            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot, &reed_solomon_cache);
+            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot);
         }
     }
 
@@ -1410,10 +1668,9 @@ mod test {
     #[test_case(false)]
     fn test_make_shreds_from_data_rand(is_last_in_slot: bool) {
         let mut rng = rand::rng();
-        let reed_solomon_cache = ReedSolomonCache::default();
         for _ in 0..32 {
             let data_size = rng.random_range(0..31200 * 7);
-            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot, &reed_solomon_cache);
+            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot);
         }
     }
 
@@ -1422,18 +1679,12 @@ mod test {
     #[test_case(false)]
     fn test_make_shreds_from_data_paranoid(is_last_in_slot: bool) {
         let mut rng = rand::rng();
-        let reed_solomon_cache = ReedSolomonCache::default();
         for data_size in 0..=PACKET_DATA_SIZE * 4 * 64 {
-            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot, &reed_solomon_cache);
+            run_make_shreds_from_data(&mut rng, data_size, is_last_in_slot);
         }
     }
 
-    fn run_make_shreds_from_data<R: Rng>(
-        rng: &mut R,
-        data_size: usize,
-        is_last_in_slot: bool,
-        reed_solomon_cache: &ReedSolomonCache,
-    ) {
+    fn run_make_shreds_from_data<R: Rng>(rng: &mut R, data_size: usize, is_last_in_slot: bool) {
         let keypair = Keypair::new();
         let chained_merkle_root = Hash::new_from_array(rng.random());
         let slot = 149_745_689;
@@ -1455,7 +1706,6 @@ mod test {
             is_last_in_slot,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         )
         .unwrap();
@@ -1636,11 +1886,7 @@ mod test {
             })
             .chunk_by(|shred| shred.common_header().fec_set_index)
             .into_iter()
-            .flat_map(|(_, shreds)| {
-                recover(shreds.collect(), reed_solomon_cache)
-                    .unwrap()
-                    .map(Result::unwrap)
-            })
+            .flat_map(|(_, shreds)| recover(shreds.collect()).unwrap().map(Result::unwrap))
             .collect();
         assert_eq!(recovered_data_shreds.len(), data_shreds.len());
 
@@ -1656,7 +1902,7 @@ mod test {
             .into_group_map_by(Shred::fec_set_index)
             .values()
         {
-            verify_erasure_recovery(rng, shreds, reed_solomon_cache);
+            verify_erasure_recovery(rng, shreds);
         }
     }
 }

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1335,11 +1335,11 @@ mod test {
         crate::shred::{ShredFlags, ShredId, ShredType},
         assert_matches::assert_matches,
         itertools::Itertools,
-        rand::{CryptoRng, Rng, seq::SliceRandom},
+        rand::{Rng, seq::SliceRandom},
         solana_keypair::Keypair,
         solana_packet::PACKET_DATA_SIZE,
         solana_signer::Signer,
-        std::{cmp::Ordering, collections::HashMap},
+        std::{cmp::Ordering, collections::HashMap, iter::repeat_with},
         test_case::{test_case, test_matrix},
     };
 
@@ -1403,211 +1403,29 @@ mod test {
         }
     }
 
-    fn make_common_header<R: Rng + CryptoRng>(
-        rng: &mut R,
-        shred_variant: ShredVariant,
-    ) -> ShredCommonHeader {
-        ShredCommonHeader {
-            signature: Signature::default(),
-            shred_variant,
-            slot: 145_865_705,
-            index: 1835,
-            version: rng.random(),
-            fec_set_index: 1835,
-        }
-    }
-
-    #[test_case(19, false)]
-    #[test_case(19, true)]
-    #[test_case(31, false)]
-    #[test_case(31, true)]
-    #[test_case(32, false)]
-    #[test_case(32, true)]
-    #[test_case(33, false)]
-    #[test_case(33, true)]
-    #[test_case(37, false)]
-    #[test_case(37, true)]
-    #[test_case(64, false)]
-    #[test_case(64, true)]
-    #[test_case(73, false)]
-    #[test_case(73, true)]
-    fn test_recover_merkle_shreds(num_shreds: usize, resigned: bool) {
+    #[test]
+    fn test_merkle_proof_entry_from_hash() {
         let mut rng = rand::rng();
-        for num_data_shreds in 1..num_shreds {
-            let num_coding_shreds = num_shreds - num_data_shreds;
-            // Batch shapes outside Rs<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>
-            // cannot be encoded. Verify that recover rejects them.
-            if num_data_shreds > DATA_SHREDS_PER_FEC_BLOCK
-                || num_coding_shreds > CODING_SHREDS_PER_FEC_BLOCK
-            {
-                run_recover_rejects_oversized(
-                    &mut rng,
-                    resigned,
-                    num_data_shreds,
-                    num_coding_shreds,
-                );
-            } else {
-                run_recover_merkle_shreds(&mut rng, resigned, num_data_shreds, num_coding_shreds);
-            }
-        }
+        let bytes: [u8; 32] = rng.random();
+        let hash = Hash::from(bytes);
+        let entry = &hash.as_ref()[..SIZE_OF_MERKLE_PROOF_ENTRY];
+        let entry = MerkleProofEntry::try_from(entry).unwrap();
+        assert_eq!(entry, &bytes[..SIZE_OF_MERKLE_PROOF_ENTRY]);
     }
 
-    fn run_recover_rejects_oversized<R: Rng + CryptoRng>(
-        rng: &mut R,
-        resigned: bool,
-        num_data_shreds: usize,
-        num_coding_shreds: usize,
-    ) {
-        let num_shreds = num_data_shreds + num_coding_shreds;
-        let proof_size = get_proof_size(num_shreds);
-        let common_header = make_common_header(
-            rng,
-            ShredVariant::MerkleCode {
-                proof_size,
-                resigned,
-            },
-        );
-        let coding_header = CodingShredHeader {
-            num_data_shreds: num_data_shreds as u16,
-            num_coding_shreds: num_coding_shreds as u16,
-            position: 0,
-        };
-        let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-        wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
-        let shreds = vec![Shred::ShredCode(ShredCode {
-            common_header,
-            coding_header,
-            payload: Payload::from(payload),
-        })];
-        if num_data_shreds > DATA_SHREDS_PER_FEC_BLOCK {
+    #[test]
+    fn test_make_merkle_proof_error() {
+        let mut rng = rand::rng();
+        let nodes = repeat_with(|| rng.random::<[u8; 32]>()).map(Hash::from);
+        let nodes: Vec<_> = nodes.take(5).collect();
+        let size = nodes.len();
+        let tree = MerkleTree::try_new(nodes.into_iter().map(Ok)).unwrap();
+        for index in size..size + 3 {
             assert_matches!(
-                recover(shreds).err(),
-                Some(Error::InvalidNumDataShreds(n)) if n as usize == num_data_shreds
-            );
-        } else if num_coding_shreds > CODING_SHREDS_PER_FEC_BLOCK {
-            assert_matches!(
-                recover(shreds).err(),
-                Some(Error::InvalidNumCodingShreds(n)) if n as usize == num_coding_shreds
+                tree.make_merkle_proof(index, size).next(),
+                Some(Err(Error::InvalidMerkleProofShape(_, _)))
             );
         }
-    }
-
-    fn run_recover_merkle_shreds<R: Rng + CryptoRng>(
-        rng: &mut R,
-        resigned: bool,
-        num_data_shreds: usize,
-        num_coding_shreds: usize,
-    ) {
-        let keypair = Keypair::new();
-        let num_shreds = num_data_shreds + num_coding_shreds;
-        let proof_size = get_proof_size(num_shreds);
-        let capacity = ShredData::capacity(proof_size, resigned).unwrap();
-        let common_header = make_common_header(
-            rng,
-            ShredVariant::MerkleData {
-                proof_size,
-                resigned,
-            },
-        );
-        let data_header = {
-            let reference_tick = rng.random_range(0..0x40);
-            DataShredHeader {
-                parent_offset: rng.random::<u16>().max(1),
-                flags: ShredFlags::from_bits_retain(reference_tick),
-                size: 0,
-            }
-        };
-        let coding_header = CodingShredHeader {
-            num_data_shreds: num_data_shreds as u16,
-            num_coding_shreds: num_coding_shreds as u16,
-            position: 0,
-        };
-        let mut shreds = Vec::with_capacity(num_shreds);
-        for i in 0..num_data_shreds {
-            let common_header = ShredCommonHeader {
-                index: common_header.index + i as u32,
-                ..common_header
-            };
-            let size = ShredData::SIZE_OF_HEADERS + rng.random_range(0..capacity);
-            let data_header = DataShredHeader {
-                size: size as u16,
-                ..data_header
-            };
-            let mut payload = vec![0u8; ShredData::SIZE_OF_PAYLOAD];
-            wincode::serialize_into(&mut payload[..], &(&common_header, &data_header)).unwrap();
-            rng.fill(&mut payload[ShredData::SIZE_OF_HEADERS..size]);
-            let shred = ShredData {
-                common_header,
-                data_header,
-                payload: Payload::from(payload),
-            };
-            shreds.push(Shred::ShredData(shred));
-        }
-        let data: Vec<_> = shreds
-            .iter_mut()
-            .map(Shred::erasure_shard_mut)
-            .collect::<Result<_, _>>()
-            .unwrap();
-        let shard_len = data[0].len();
-
-        let mut message: Vec<Gf2p8_11d> = Vec::with_capacity(DATA_SHREDS_PER_FEC_BLOCK * shard_len);
-        for shard in data {
-            let src: &[Gf2p8_11d] = unsafe {
-                std::slice::from_raw_parts(shard.as_ptr() as *const Gf2p8_11d, shard_len)
-            };
-            message.extend_from_slice(src);
-        }
-        // Zero any remaining message shards.
-        message.resize(DATA_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
-
-        let mut parity = vec![0u8.into(); CODING_SHREDS_PER_FEC_BLOCK * shard_len];
-
-        RS_ENCODE_WORKSPACE.with_borrow_mut(|mut ws| {
-            let rs = Rs::<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>::default();
-            ws.resize(CODING_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
-            rs.encode_systematic_sharded(&message, &mut parity, &mut ws, shard_len);
-        });
-
-        for (i, shard) in parity.chunks(shard_len).take(num_coding_shreds).enumerate() {
-            let code: &[u8] =
-                unsafe { std::slice::from_raw_parts(shard.as_ptr() as *const u8, shard_len) };
-
-            let common_header = ShredCommonHeader {
-                shred_variant: ShredVariant::MerkleCode {
-                    proof_size,
-                    resigned,
-                },
-                index: common_header.index + i as u32 + 7,
-                ..common_header
-            };
-            let coding_header = CodingShredHeader {
-                position: i as u16,
-                ..coding_header
-            };
-            let mut payload = vec![0u8; ShredCode::SIZE_OF_PAYLOAD];
-            wincode::serialize_into(&mut payload[..], &(&common_header, &coding_header)).unwrap();
-
-            payload[ShredCode::SIZE_OF_HEADERS..ShredCode::SIZE_OF_HEADERS + code.len()]
-                .copy_from_slice(code);
-            let shred = ShredCode {
-                common_header,
-                coding_header,
-                payload: Payload::from(payload),
-            };
-            shreds.push(Shred::ShredCode(shred));
-        }
-        let nodes = shreds.iter().map(Shred::merkle_node);
-        let tree = MerkleTree::try_new(nodes).unwrap();
-        for (index, shred) in shreds.iter_mut().enumerate() {
-            let proof = tree.make_merkle_proof(index, num_shreds);
-            shred.set_merkle_proof(proof).unwrap();
-            let data = shred.signed_data().unwrap();
-            let signature = keypair.sign_message(data.as_ref());
-            shred.set_signature(signature);
-            assert!(shred.verify(&keypair.pubkey()));
-            assert_matches!(shred.sanitize(), Ok(()));
-        }
-        verify_erasure_recovery(rng, &shreds);
     }
 
     fn verify_erasure_recovery<R: Rng>(rng: &mut R, shreds: &[Shred]) {

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -791,7 +791,7 @@ pub(super) fn recover(
             RS_RECOVER_WORKSPACE.with_borrow_mut(|mut ws| {
                 let rs = Rs::<SHREDS_PER_FEC_BLOCK, CODING_SHREDS_PER_FEC_BLOCK>::default();
                 ws.resize(SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
-                if !rs.recover_erasure_shards(&mut rec, &mut ws, shard_len, &erasure_positions) {
+                if !rs.recover_erasures_sharded(&mut rec, &mut ws, shard_len, &erasure_positions) {
                     return Err(Error::TooManyErasures);
                 }
                 Ok(())
@@ -1251,8 +1251,7 @@ fn finish_erasure_batch(
     debug_assert_eq!(num_coding_shreds, CODING_SHREDS_PER_FEC_BLOCK);
 
     let shard_len = shreds[0].erasure_shard_mut()?.len();
-    RS_MESSAGE.with(|msg| {
-        let mut msg = msg.borrow_mut();
+    RS_MESSAGE.with_borrow_mut(|msg| {
         msg.resize(DATA_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
 
         for (i, shred) in shreds.iter_mut().take(num_data_shreds).enumerate() {
@@ -1263,10 +1262,7 @@ fn finish_erasure_batch(
             msg[i * shard_len..(i + 1) * shard_len].copy_from_slice(src);
         }
 
-        RS_PARITY.with(|par| {
-            let mut par = par.borrow_mut();
-            // Set the length to the number of parity shards and fill with zeros.
-            par.clear();
+        RS_PARITY.with_borrow_mut(|mut par| {
             par.resize(CODING_SHREDS_PER_FEC_BLOCK * shard_len, 0u8.into());
 
             RS_ENCODE_WORKSPACE.with(|ws| {

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -91,8 +91,12 @@ impl MerkleTree {
         }
         std::iter::from_fn(move || {
             if size > 1 {
-                let Some(node) = self.nodes.get(offset + (index ^ 1).min(size - 1)) else {
-                    return Some(Err(Error::InvalidMerkleProof));
+                let node_index = offset + (index ^ 1).min(size - 1);
+                let Some(node) = self.nodes.get(node_index) else {
+                    return Some(Err(Error::InvalidMerkleProofNode(
+                        node_index,
+                        self.nodes.len(),
+                    )));
                 };
                 offset += size;
                 size = (size + 1) >> 1;
@@ -101,7 +105,10 @@ impl MerkleTree {
             } else if offset + 1 == self.nodes.len() {
                 None
             } else {
-                Some(Err(Error::InvalidMerkleProof))
+                Some(Err(Error::InvalidMerkleProofShape(
+                    offset,
+                    self.nodes.len(),
+                )))
             }
         })
     }
@@ -245,7 +252,7 @@ mod tests {
         for index in size..size + 3 {
             assert_matches!(
                 tree.make_merkle_proof(index, size).next(),
-                Some(Err(Error::InvalidMerkleProof))
+                Some(Err(Error::InvalidMerkleProofShape(..)))
             );
         }
     }

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -1,7 +1,7 @@
 #[cfg(any(test, feature = "dev-context-only-utils"))]
 use {
     crate::shred::Nonce,
-    solana_perf::packet::{BytesPacket, Meta, Packet, bytes::BufMut},
+    solana_perf::packet::{bytes::BufMut, BytesPacket, Meta, Packet},
 };
 use {
     bytes::{Bytes, BytesMut},
@@ -256,11 +256,8 @@ mod test {
     #[test]
     fn test_to_bytes_packet_nonce_endianness() {
         use {
-            crate::shredder::{ReedSolomonCache, Shredder},
-            solana_entry::entry::Entry,
-            solana_hash::Hash,
-            solana_keypair::Keypair,
-            solana_perf::packet::PacketFlags,
+            crate::shredder::Shredder, solana_entry::entry::Entry, solana_hash::Hash,
+            solana_keypair::Keypair, solana_perf::packet::PacketFlags,
         };
 
         // Build a valid shred payload using the shredder helper.
@@ -275,7 +272,6 @@ mod test {
             Hash::default(),
             0,
             0,
-            &ReedSolomonCache::default(),
             &mut stats,
         );
         let shred = &shreds[0];

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -1,30 +1,11 @@
 use {
-    crate::shred::{
-        self, DATA_SHREDS_PER_FEC_BLOCK, Error, ProcessShredsStats, Shred, ShredData, ShredFlags,
-    },
-    lazy_lru::LruCache,
-    reed_solomon_erasure::{Error::TooFewDataShards, galois_8::ReedSolomon},
+    crate::shred::{self, Error, ProcessShredsStats, Shred, ShredData, ShredFlags},
     solana_clock::Slot,
     solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    std::{
-        fmt::Debug,
-        sync::{Arc, OnceLock, RwLock},
-        time::Instant,
-    },
+    std::{fmt::Debug, time::Instant},
 };
-
-// Arc<...> wrapper so that cache entries can be initialized without locking
-// the entire cache.
-type LruCacheOnce<K, V> = RwLock<LruCache<K, Arc<OnceLock<V>>>>;
-
-pub struct ReedSolomonCache(
-    LruCacheOnce<
-        (usize, usize), // number of {data,parity} shards
-        Result<Arc<ReedSolomon>, reed_solomon_erasure::Error>,
-    >,
-);
 
 #[derive(Debug)]
 pub struct Shredder {
@@ -62,7 +43,6 @@ impl Shredder {
         chained_merkle_root: Hash,
         next_shred_index: u32,
         next_code_index: u32,
-        reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
         let now = Instant::now();
@@ -76,7 +56,6 @@ impl Shredder {
             chained_merkle_root,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             stats,
         )
         .unwrap()
@@ -91,7 +70,6 @@ impl Shredder {
         chained_merkle_root: Hash,
         next_shred_index: u32,
         next_code_index: u32,
-        reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> Vec<Shred> {
         stats.num_entries += entries.len();
@@ -106,7 +84,6 @@ impl Shredder {
             chained_merkle_root,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             stats,
         )
         .unwrap()
@@ -121,7 +98,6 @@ impl Shredder {
         chained_merkle_root: Hash,
         next_shred_index: u32,
         next_code_index: u32,
-        reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> Result<Vec<Shred>, Error> {
         shred::merkle::make_shreds_from_data(
@@ -135,7 +111,6 @@ impl Shredder {
             is_last_in_slot,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             stats,
         )
     }
@@ -148,7 +123,6 @@ impl Shredder {
         chained_merkle_root: Hash,
         next_shred_index: u32,
         next_code_index: u32,
-        reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> (
         Vec<Shred>, // data shreds
@@ -161,7 +135,6 @@ impl Shredder {
             chained_merkle_root,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             stats,
         )
         .into_iter()
@@ -176,7 +149,6 @@ impl Shredder {
         chained_merkle_root: Hash,
         next_shred_index: u32,
         next_code_index: u32,
-        reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
     ) -> (
         Vec<Shred>, // data shreds
@@ -189,7 +161,6 @@ impl Shredder {
             chained_merkle_root,
             next_shred_index,
             next_code_index,
-            reed_solomon_cache,
             stats,
         )
         .into_iter()
@@ -218,7 +189,7 @@ impl Shredder {
                 if let Some(prev) = prev
                     && prev.checked_add(1) != index
                 {
-                    return Err(Error::from(TooFewDataShards));
+                    return Err(Error::TooFewDataShards);
                 }
                 data.extend_from_slice(shred::layout::get_data(shred)?);
                 let flags = shred::layout::get_flags(shred)?;
@@ -228,7 +199,7 @@ impl Shredder {
         )?;
         // The last shred should be DATA_COMPLETE_SHRED.
         if !data_complete {
-            return Err(Error::from(TooFewDataShards));
+            return Err(Error::TooFewDataShards);
         }
         if data.is_empty() {
             // For backward compatibility. This is needed when the data shred
@@ -246,7 +217,6 @@ impl Shredder {
     #[cfg(feature = "dev-context-only-utils")]
     pub fn single_shred_for_tests(slot: Slot, keypair: &Keypair) -> Shred {
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 42).unwrap();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             keypair,
             &[],
@@ -254,43 +224,9 @@ impl Shredder {
             Hash::default(),
             0,
             0,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         shreds.pop().unwrap()
-    }
-}
-
-impl ReedSolomonCache {
-    const CAPACITY: usize = 4 * DATA_SHREDS_PER_FEC_BLOCK;
-
-    pub(crate) fn get(
-        &self,
-        data_shards: usize,
-        parity_shards: usize,
-    ) -> Result<Arc<ReedSolomon>, reed_solomon_erasure::Error> {
-        let key = (data_shards, parity_shards);
-        // Read from the cache with a shared lock.
-        let entry = self.0.read().unwrap().get(&key).cloned();
-        // Fall back to exclusive lock if there is a cache miss.
-        let entry: Arc<OnceLock<Result<_, _>>> = entry.unwrap_or_else(|| {
-            let mut cache = self.0.write().unwrap();
-            cache.get(&key).cloned().unwrap_or_else(|| {
-                let entry = Arc::<OnceLock<Result<_, _>>>::default();
-                cache.put(key, Arc::clone(&entry));
-                entry
-            })
-        });
-        // Initialize if needed by only a single thread outside locks.
-        entry
-            .get_or_init(|| ReedSolomon::new(data_shards, parity_shards).map(Arc::new))
-            .clone()
-    }
-}
-
-impl Default for ReedSolomonCache {
-    fn default() -> Self {
-        Self(RwLock::new(LruCache::new(Self::CAPACITY)))
     }
 }
 
@@ -299,7 +235,8 @@ mod tests {
     use {
         super::*,
         crate::shred::{
-            CODING_SHREDS_PER_FEC_BLOCK, ShredType, max_ticks_per_n_shreds, verify_test_data_shred,
+            CODING_SHREDS_PER_FEC_BLOCK, DATA_SHREDS_PER_FEC_BLOCK, ShredType,
+            max_ticks_per_n_shreds, verify_test_data_shred,
         },
         assert_matches::assert_matches,
         itertools::Itertools,
@@ -357,7 +294,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             start_index,                                // next_shred_index
             start_index,                                // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         let next_index = data_shreds.last().unwrap().index() + 1;
@@ -443,7 +379,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             369,                                        // next_shred_index
             776,                                        // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         for shred in [data_shreds, coding_shreds].into_iter().flatten() {
@@ -475,7 +410,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             0,                                          // next_shred_index
             0,                                          // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         data_shreds.iter().for_each(|s| {
@@ -511,7 +445,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             0,                                          // next_shred_index
             0,                                          // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         data_shreds.iter().for_each(|s| {
@@ -554,7 +487,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             0,                                          // next_shred_index
             0,                                          // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         for (i, s) in data_shreds.iter().enumerate() {
@@ -604,7 +536,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             0,                                          // next_shred_index
             0,                                          // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         assert!(
@@ -643,7 +574,6 @@ mod tests {
                 chained_merkle_root,
                 next_shred_index,
                 next_code_index,
-                &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             );
 
@@ -657,7 +587,6 @@ mod tests {
                 chained_merkle_root,
                 next_shred_index,
                 next_code_index,
-                &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             );
 
@@ -705,7 +634,6 @@ mod tests {
             Hash::new_from_array(rand::rng().random()), // chained_merkle_root
             start_index,                                // next_shred_index
             start_index,                                // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         const MIN_CHUNK_SIZE: usize = DATA_SHREDS_PER_FEC_BLOCK;

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -95,7 +95,7 @@ mod tests {
         super::*,
         crate::{
             shred::{ProcessShredsStats, Shred},
-            shredder::{ReedSolomonCache, Shredder},
+            shredder::Shredder,
         },
         assert_matches::assert_matches,
         itertools::Itertools,
@@ -140,7 +140,6 @@ mod tests {
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
         let keypair = Keypair::new();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let (mut shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             &keypair,
             &[],
@@ -148,7 +147,6 @@ mod tests {
             Hash::default(),
             0,
             0,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         let shred = shreds.pop().unwrap();
@@ -291,7 +289,6 @@ mod tests {
     fn make_packet_batch(keypair: &Keypair, slot: u64) -> PacketBatch {
         let mut batch = RecycledPacketBatch::default();
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             keypair,
             &[],
@@ -299,7 +296,6 @@ mod tests {
             Hash::default(),
             0,
             0,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         batch.resize(shreds.len(), Packet::default());
@@ -350,7 +346,6 @@ mod tests {
         is_last_in_slot: bool,
         keypairs: &HashMap<Slot, Keypair>,
     ) -> Vec<Shred> {
-        let reed_solomon_cache = ReedSolomonCache::default();
         let mut shreds: Vec<_> = keypairs
             .iter()
             .flat_map(|(&slot, keypair)| {
@@ -370,7 +365,6 @@ mod tests {
                     Hash::new_from_array(rng.random()), // chained_merkle_root
                     rng.random_range(0..2671),          // next_shred_index
                     rng.random_range(0..2781),          // next_code_index
-                    &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
                 .into_iter()

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -9,8 +9,8 @@ use {
     solana_ledger::{
         genesis_utils::create_genesis_config,
         shred::{
-            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, ShredData,
-            Shredder, filter::ShredRecoveryContext, max_entries_per_n_shred,
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, Shred, ShredData, Shredder,
+            filter::ShredRecoveryContext, max_entries_per_n_shred,
             max_entries_per_n_shred_last_or_not, verify_test_data_shred,
         },
     },
@@ -45,7 +45,6 @@ fn new_shred_recovery_context(shreds: &[Shred]) -> ShredRecoveryContext {
     ));
     let (dummy_retransmit_sender, _) = EvictingSender::new_bounded(0);
     ShredRecoveryContext::new(
-        ReedSolomonCache::default(),
         dummy_retransmit_sender,
         root_bank,
         shreds.first().map(Shred::version).unwrap_or_default(),
@@ -77,7 +76,6 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
         })
         .collect();
 
-    let reed_solomon_cache = ReedSolomonCache::default();
     let serialized_entries = wincode::serialize(&entries).unwrap();
 
     let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
@@ -87,7 +85,6 @@ fn test_multi_fec_block_coding(is_last_in_slot: bool) {
         Hash::default(), // chained_merkle_root
         0,               // next_shred_index
         0,               // next_code_index
-        &reed_solomon_cache,
         &mut ProcessShredsStats::default(),
     );
     let next_index = data_shreds.last().unwrap().index() + 1;
@@ -263,7 +260,6 @@ fn setup_different_sized_fec_blocks(
     let mut coding_slot_and_index = HashSet::new();
 
     let total_num_data_shreds: usize = 2 * num_shreds_per_iter;
-    let reed_solomon_cache = ReedSolomonCache::default();
     for i in 0..2 {
         let is_last = i == 1;
 
@@ -274,7 +270,6 @@ fn setup_different_sized_fec_blocks(
             chained_merkle_root,
             next_shred_index,
             next_code_index,
-            &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
         for shred in &data_shreds {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -48,7 +48,7 @@ use {
         blockstore_processor::{self, ProcessOptions},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{
-            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
+            DATA_SHREDS_PER_FEC_BLOCK, ProcessShredsStats, Shred, Shredder,
             filter::{TurbineMode, TurbineModeKind},
         },
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
@@ -5796,7 +5796,6 @@ fn test_invalid_forks_persisted_on_restart() {
                 Hash::default(), // chained_merkle_root
                 0,               // next_shred_index,
                 0,               // next_code_index
-                &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             )
             .0;

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -8,7 +8,7 @@ use {
     solana_ledger::{
         genesis_utils::{GenesisConfigInfo, create_genesis_config},
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        shred::{ProcessShredsStats, Shredder},
     },
     solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
     solana_pubkey as pubkey,
@@ -60,7 +60,6 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
         Hash::default(), // chained_merkle_root
         0,               // next_shred_index
         0,               // next_code_index
-        &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     );
     shreds.truncate(NUM_SHREDS);

--- a/turbine/benches/cluster_nodes.rs
+++ b/turbine/benches/cluster_nodes.rs
@@ -6,7 +6,7 @@ use {
     solana_gossip::contact_info::ContactInfo,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+    solana_ledger::shred::{ProcessShredsStats, Shredder},
     solana_net_utils::SocketAddrSpace,
     solana_pubkey::Pubkey,
     solana_turbine::{
@@ -37,7 +37,6 @@ fn get_retransmit_peers_deterministic(
     slot_leader: &Pubkey,
 ) {
     let keypair = Keypair::new();
-    let reed_solomon_cache = ReedSolomonCache::default();
     let mut stats = ProcessShredsStats::default();
     let parent_slot = if slot > 0 { slot - 1 } else { 0 };
     let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
@@ -49,7 +48,6 @@ fn get_retransmit_peers_deterministic(
         Hash::default(), // chained_merkle_root
         0,               // next_shred_index
         0,               // next_code_index
-        &reed_solomon_cache,
         &mut stats,
     );
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -659,7 +659,7 @@ pub mod test {
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             get_tmp_ledger_path_auto_delete,
             leader_schedule_cache::LeaderScheduleCache,
-            shred::{ProcessShredsStats, ReedSolomonCache, Shredder, max_ticks_per_n_shreds},
+            shred::{ProcessShredsStats, Shredder, max_ticks_per_n_shreds},
         },
         solana_runtime::bank::Bank,
         solana_signer::Signer,
@@ -696,7 +696,6 @@ pub mod test {
             Hash::new_from_array(rand::rng().random()),
             0, // next_shred_index,
             0, // next_code_index
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         (

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -8,7 +8,7 @@ use {
     solana_entry::{block_component::BlockComponent, entry::Entry},
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, ShredId, Shredder},
+    solana_ledger::shred::{ProcessShredsStats, ShredId, Shredder},
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
@@ -58,7 +58,6 @@ pub(super) struct BroadcastDuplicatesRun {
     cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
     original_last_data_shreds: Arc<Mutex<HashSet<DuplicateShredKey>>>,
     partition_last_data_shreds: Arc<Mutex<HashSet<DuplicateShredKey>>>,
-    reed_solomon_cache: Arc<ReedSolomonCache>,
     migration_status: Arc<MigrationStatus>,
     votor_event_sender: VotorEventSender,
 }
@@ -88,7 +87,6 @@ impl BroadcastDuplicatesRun {
             cluster_nodes_cache,
             original_last_data_shreds: Arc::<Mutex<HashSet<DuplicateShredKey>>>::default(),
             partition_last_data_shreds: Arc::<Mutex<HashSet<DuplicateShredKey>>>::default(),
-            reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
             migration_status,
             votor_event_sender,
         }
@@ -211,7 +209,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             self.chained_merkle_root,
             self.next_shred_index,
             self.next_code_index,
-            &self.reed_solomon_cache,
             &mut stats,
         );
         if let Some(shred) = data_shreds.iter().max_by_key(|shred| shred.index()) {
@@ -230,7 +227,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     self.chained_merkle_root,
                     self.next_shred_index,
                     self.next_code_index,
-                    &self.reed_solomon_cache,
                     &mut stats,
                 );
                 // Don't mark the last shred as last so that validators won't
@@ -243,7 +239,6 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     self.chained_merkle_root,
                     self.next_shred_index,
                     self.next_code_index,
-                    &self.reed_solomon_cache,
                     &mut stats,
                 );
                 let sigs: Vec<_> = partition_last_data_shred
@@ -481,7 +476,6 @@ mod tests {
     fn test_special_shred_key_distinguishes_shreds_with_shared_signature() {
         let keypair = Keypair::new();
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-        let reed_solomon_cache = ReedSolomonCache::default();
         let mut stats = ProcessShredsStats::default();
         let (data_shreds, _) = shredder.component_to_merkle_shreds_for_tests(
             &keypair,
@@ -490,7 +484,6 @@ mod tests {
             Hash::default(),
             0,
             0,
-            &reed_solomon_cache,
             &mut stats,
         );
         let (duplicate_data_shreds, _) = shredder.component_to_merkle_shreds_for_tests(
@@ -500,7 +493,6 @@ mod tests {
             Hash::default(),
             0,
             0,
-            &reed_solomon_cache,
             &mut stats,
         );
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -16,10 +16,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{
-            ProcessShredsStats, ReedSolomonCache, Shred, ShredType, Shredder,
-            merkle_tree::MerkleTree,
-        },
+        shred::{ProcessShredsStats, Shred, ShredType, Shredder, merkle_tree::MerkleTree},
     },
     solana_runtime::bank::Bank,
     solana_sha256_hasher::hashv,
@@ -59,7 +56,6 @@ pub struct StandardBroadcastRun {
     num_batches: usize,
     cluster_nodes_cache: Arc<ClusterNodesCache<BroadcastStage>>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
-    reed_solomon_cache: Arc<ReedSolomonCache>,
     migration_status: Arc<MigrationStatus>,
     votor_event_sender: VotorEventSender,
     max_data_shreds_per_slot: u32,
@@ -106,7 +102,6 @@ impl StandardBroadcastRun {
             num_batches: 0,
             cluster_nodes_cache,
             leader_schedule_cache,
-            reed_solomon_cache: Arc::<ReedSolomonCache>::default(),
             migration_status,
             votor_event_sender,
             max_data_shreds_per_slot: DEFAULT_MAX_DATA_SHREDS_PER_SLOT,
@@ -207,7 +202,6 @@ impl StandardBroadcastRun {
                 self.chained_merkle_root,
                 self.next_shred_index,
                 self.next_code_index,
-                &self.reed_solomon_cache,
                 &mut self.process_shreds_stats,
             );
         // These shreds will finish the slot so no need to update
@@ -241,7 +235,6 @@ impl StandardBroadcastRun {
                     self.chained_merkle_root,
                     self.next_shred_index,
                     self.next_code_index,
-                    &self.reed_solomon_cache,
                     process_stats,
                 );
         shreds.iter().for_each(|shred| {

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -724,7 +724,7 @@ mod tests {
         itertools::Itertools,
         rand::prelude::IndexedRandom as _,
         solana_hash::Hash as SolanaHash,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::shred::{ProcessShredsStats, Shredder},
         std::{collections::VecDeque, fmt::Debug, hash::Hash},
         test_case::test_case,
     };
@@ -757,7 +757,6 @@ mod tests {
                 SolanaHash::default(),
                 0,
                 0,
-                &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             )
             .0

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -953,7 +953,7 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::shred::{ProcessShredsStats, Shredder},
     };
 
     fn get_keypair() -> Keypair {
@@ -971,7 +971,6 @@ mod tests {
     fn test_shred_deduper() {
         let keypair = get_keypair();
         let entries = create_ticks(10, 1, Hash::new_unique());
-        let rsc = ReedSolomonCache::default();
         let make_shreds_for_slot = |slot, parent, code_index| {
             let shredder = Shredder::new(slot, parent, 1, 0).unwrap();
             shredder.entries_to_merkle_shreds_for_tests(
@@ -982,7 +981,6 @@ mod tests {
                 Hash::new_from_array(rand::rng().random()),
                 0,
                 code_index,
-                &rsc,
                 &mut ProcessShredsStats::default(),
             )
         };

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -6,7 +6,7 @@ use {
     agave_feature_set as feature_set,
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
     itertools::{Either, Itertools},
-    rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
+    rayon::{prelude::*, ThreadPool, ThreadPoolBuilder},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -18,7 +18,7 @@ use {
             layout::{get_shred, resign_packet},
             wire::is_retransmitter_signed_variant,
         },
-        sigverify_shreds::{LruCache, SlotPubkeys, par_verify_shreds},
+        sigverify_shreds::{par_verify_shreds, LruCache, SlotPubkeys},
     },
     solana_perf::{
         self,
@@ -32,8 +32,8 @@ use {
     std::{
         num::NonZeroUsize,
         sync::{
-            Arc, RwLock,
             atomic::{AtomicUsize, Ordering},
+            Arc, RwLock,
         },
         thread::{Builder, JoinHandle},
         time::{Duration, Instant},
@@ -594,13 +594,13 @@ mod tests {
     use {
         super::*,
         rand::Rng,
-        solana_entry::entry::{Entry, create_ticks},
+        solana_entry::entry::{create_ticks, Entry},
         solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::{
             genesis_utils::create_genesis_config_with_leader,
-            shred::{Nonce, ProcessShredsStats, ReedSolomonCache, Shredder},
+            shred::{Nonce, ProcessShredsStats, Shredder},
         },
         solana_net_utils::SocketAddrSpace,
         solana_perf::packet::{Packet, PacketFlags, RecycledPacketBatch},
@@ -634,7 +634,6 @@ mod tests {
             Hash::new_unique(),
             0,
             0,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
         let (shreds_data_wrong, _shreds_code_wrong) = shredder.entries_to_merkle_shreds_for_tests(
@@ -644,7 +643,6 @@ mod tests {
             Hash::new_unique(),
             0,
             0,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
 
@@ -705,7 +703,6 @@ mod tests {
             chained_merkle_root,
             0,
             0,
-            &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
 


### PR DESCRIPTION
#### Problem

`reed-solomon-erasure` is slow and cannot be sped up in a meaningful way due to algorithmic complexity reasons. Earlier, Firedancer introduced an additive FFT codec with effective acceleration on AVX512-GFNI machines. It is implemented here now. The GFNI acceleration is enabled by building Agave on a GFNI machine. Without GFNI, a generic implementation based on LUTs will be used.

The branch includes the fix #15035 allowing to actually run the ledger benches to see the performance difference.

#### Summary of Changes

- [X] Drop-in replacement of `reed-solomon-erasure` with `additive-fft-reed-solomon`. This produces parity shreds that are incompatible with the old encoding.
- [ ] Upgrade path allowing to version shreds and recover shred erasures depending on the version.

All items need to be implemented in order for this PR to fix #9495.

#### Testing

This branch allows to measure the performance of Agave with the old `reed-solomon-erasure` crate replaced with the new FFT codec on an AVX512-GFNI machine. Benches in `ledger` are the best place to look at. There are also a few benches in `core` that run faster with the FFT codec.

To measure the performance of `reed-solomon-erasure` without the FFT codec, run the benches in #15035 directly.