### PR TITLE
fix(rpc): reject base58 encoding for transaction version 1+

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1329,6 +1329,10 @@ impl JsonRpcRequestProcessor {
             .map(|config| config.convert_to_current())
             .unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Json);
+        validate_max_supported_transaction_version_for_encoding(
+            encoding,
+            config.max_supported_transaction_version,
+        )?;
         let encoding_options = BlockEncodingOptions {
             transaction_details: config.transaction_details.unwrap_or_default(),
             show_rewards: config.rewards.unwrap_or(true),
@@ -1782,6 +1786,10 @@ impl JsonRpcRequestProcessor {
             .unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Json);
         let max_supported_transaction_version = config.max_supported_transaction_version;
+        validate_max_supported_transaction_version_for_encoding(
+            encoding,
+            max_supported_transaction_version,
+        )?;
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
 
@@ -2551,6 +2559,23 @@ pub(crate) fn check_is_at_least_confirmed(commitment: CommitmentConfig) -> Resul
     if !commitment.is_at_least_confirmed() {
         return Err(Error::invalid_params(
             "Method does not support commitment below `confirmed`",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_max_supported_transaction_version_for_encoding(
+    encoding: UiTransactionEncoding,
+    max_supported_transaction_version: Option<u8>,
+) -> Result<()> {
+    // `binary` is the legacy alias for base58 transaction encoding.
+    if matches!(
+        encoding,
+        UiTransactionEncoding::Binary | UiTransactionEncoding::Base58
+    ) && max_supported_transaction_version.is_some_and(|version| version >= 1)
+    {
+        return Err(Error::invalid_params(
+            "base58 encoding is not supported with maxSupportedTransactionVersion >= 1",
         ));
     }
     Ok(())
@@ -7457,6 +7482,54 @@ pub mod tests {
             ),
         );
         assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn test_base58_transaction_encoding_rejects_version_1_or_higher() {
+        let rpc = RpcHandler::start();
+        let signature = rpc.create_test_transactions_and_populate_blockstore()[0].to_string();
+        let expected = (
+            ErrorCode::InvalidParams.code(),
+            String::from(
+                "base58 encoding is not supported with maxSupportedTransactionVersion >= 1",
+            ),
+        );
+
+        for max_supported_transaction_version in [1, u8::MAX] {
+            for encoding in ["base58", "binary"] {
+                let config = json!({
+                    "encoding": encoding,
+                    "maxSupportedTransactionVersion": max_supported_transaction_version,
+                });
+                for request in [
+                    create_test_request("getBlock", Some(json!([0u64, config.clone()]))),
+                    create_test_request(
+                        "getTransaction",
+                        Some(json!([signature.clone(), config.clone()])),
+                    ),
+                ] {
+                    assert_eq!(
+                        parse_failure_response(rpc.handle_request_sync(request)),
+                        expected
+                    );
+                }
+            }
+        }
+
+        for encoding in ["base58", "binary"] {
+            let config = json!({
+                "encoding": encoding,
+                "maxSupportedTransactionVersion": 0,
+            });
+            let _: Value = parse_success_result(rpc.handle_request_sync(create_test_request(
+                "getBlock",
+                Some(json!([0u64, config.clone()])),
+            )));
+            let _: Value = parse_success_result(rpc.handle_request_sync(create_test_request(
+                "getTransaction",
+                Some(json!([signature.clone(), config])),
+            )));
+        }
     }
 
     #[test]

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -3,7 +3,10 @@
 use crate::{rpc_pubsub_service, rpc_subscriptions::RpcSubscriptions};
 use {
     crate::{
-        rpc::{check_is_at_least_confirmed, optimize_filters, verify_filters},
+        rpc::{
+            check_is_at_least_confirmed, optimize_filters,
+            validate_max_supported_transaction_version_for_encoding, verify_filters,
+        },
         rpc_pubsub_service::PubSubConfig,
         rpc_subscription_tracker::{
             AccountSubscriptionParams, BlockSubscriptionKind, BlockSubscriptionParams,
@@ -551,11 +554,16 @@ impl RpcSolPubSubInternal for RpcSolPubSubImpl {
             return Err(Error::new(jsonrpc_core::ErrorCode::MethodNotFound));
         }
         let config = config.unwrap_or_default();
+        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base64);
+        validate_max_supported_transaction_version_for_encoding(
+            encoding,
+            config.max_supported_transaction_version,
+        )?;
         let commitment = config.commitment.unwrap_or_default();
         check_is_at_least_confirmed(commitment)?;
         let params = BlockSubscriptionParams {
             commitment: config.commitment.unwrap_or_default(),
-            encoding: config.encoding.unwrap_or(UiTransactionEncoding::Base64),
+            encoding,
             kind: match filter {
                 RpcBlockSubscribeFilter::All => BlockSubscriptionKind::All,
                 RpcBlockSubscribeFilter::MentionsAccountOrProgram(key) => {
@@ -683,6 +691,39 @@ mod tests {
         };
         subscriptions.notify_subscribers(commitment_slots);
         Ok(())
+    }
+
+    #[test]
+    fn test_block_subscribe_rejects_base58_transaction_version_1_or_higher() {
+        let bank = Bank::new_for_tests(&create_genesis_config(10_000).genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
+            Arc::new(AtomicU64::default()),
+            bank_forks,
+        ));
+        let (rpc, _receiver) = rpc_pubsub_service::test_connection(&subscriptions);
+
+        for max_supported_transaction_version in [1, u8::MAX] {
+            for encoding in [UiTransactionEncoding::Base58, UiTransactionEncoding::Binary] {
+                let error = rpc
+                    .block_subscribe(
+                        RpcBlockSubscribeFilter::All,
+                        Some(RpcBlockSubscribeConfig {
+                            encoding: Some(encoding),
+                            max_supported_transaction_version: Some(
+                                max_supported_transaction_version,
+                            ),
+                            ..RpcBlockSubscribeConfig::default()
+                        }),
+                    )
+                    .unwrap_err();
+                assert_eq!(error.code, ErrorCode::InvalidParams);
+                assert_eq!(
+                    error.message,
+                    "base58 encoding is not supported with maxSupportedTransactionVersion >= 1"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- base58 is deprecated and should have been removed long ago
- we shouldn't support getting blocks/transactions with txv1 if base58 is requested

#### Summary of Changes
- getBlock and getTransaction immediately return if the max version >= 1 and encoding is base58

#### Testing
- Added test for the rejection

Fixes #
