### PR TITLE
removes `ProcessedVotes::merge`

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -1206,20 +1206,23 @@ mod tests {
 
         ctx.verifier.verify_and_send_datagrams(packets).unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 1);
-        let total_votes_verified = batches
+        assert_eq!(batches.len(), 2);
+        let (total_aggregates, total_votes_verified) = batches
             .into_iter()
             .map(|batch| match batch {
                 SigVerifiedBatch::Votes(aggregates) => {
-                    assert_eq!(aggregates.len(), 2);
-                    aggregates
+                    let total_votes = aggregates
                         .iter()
                         .map(|aggregate| aggregate.num_votes())
-                        .sum::<usize>()
+                        .sum::<usize>();
+                    (aggregates.len(), total_votes)
                 }
                 rest => panic!("unexpected type: {rest:?}"),
             })
-            .sum::<usize>();
+            .fold((0, 0), |(num_aggregates, num_votes), batch| {
+                (num_aggregates + batch.0, num_votes + batch.1)
+            });
+        assert_eq!(total_aggregates, 2);
         assert_eq!(total_votes_verified, num_votes);
         assert_eq!(
             ctx.verifier.stats.vote_stats.distinct_votes_stats.count(),
@@ -1287,12 +1290,11 @@ mod tests {
 
         ctx.verifier.verify_and_send_datagrams(packets).unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 1);
-        let total_votes_verified = batches
+        assert_eq!(batches.len(), 2);
+        let (total_aggregates, total_votes_verified) = batches
             .into_iter()
             .map(|batch| match batch {
                 SigVerifiedBatch::Votes(aggregates) => {
-                    assert_eq!(aggregates.len(), 3);
                     for aggregate in &aggregates {
                         if aggregate.vote() == &vote2
                             && *aggregate.ranks().get(invalid_rank as usize).unwrap()
@@ -1300,11 +1302,15 @@ mod tests {
                             panic!("invalid vote verified");
                         }
                     }
-                    aggregates.iter().map(|v| v.num_votes()).sum::<usize>()
+                    let total_votes = aggregates.iter().map(|v| v.num_votes()).sum::<usize>();
+                    (aggregates.len(), total_votes)
                 }
                 rest => panic!("unexpected type: {rest:?}"),
             })
-            .sum::<usize>();
+            .fold((0, 0), |(num_aggregates, num_votes), batch| {
+                (num_aggregates + batch.0, num_votes + batch.1)
+            });
+        assert_eq!(total_aggregates, 3);
         assert_eq!(total_votes_verified, num_votes - 1);
     }
 
@@ -2225,16 +2231,21 @@ mod tests {
 
         assert_eq!(ctx.verifier.stats.vote_too_far_in_future.0, 2);
         assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 2);
-        let SigVerifiedBatch::Votes(aggregates) = ctx.pool_receiver.try_recv().unwrap() else {
-            panic!("expected a vote batch");
-        };
+        let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(batches.len(), 2);
+        let aggregates = batches
+            .into_iter()
+            .flat_map(|batch| match batch {
+                SigVerifiedBatch::Votes(aggregates) => aggregates,
+                rest => panic!("unexpected type: {rest:?}"),
+            })
+            .collect::<Vec<_>>();
         assert_eq!(aggregates.len(), 2);
         assert!(
             aggregates
                 .iter()
                 .all(|aggregate| aggregate.vote().is_genesis_vote())
         );
-        expect_no_receive(&ctx.pool_receiver);
         expect_no_receive(&ctx.repair_receiver);
     }
 

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -38,11 +38,7 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, epoch_stakes::BLSPubkeyToRankMap},
-    std::{
-        collections::{HashMap, hash_map::Entry},
-        num::NonZero,
-        sync::Arc,
-    },
+    std::{collections::HashMap, num::NonZero, sync::Arc},
 };
 
 #[derive(Default)]
@@ -51,29 +47,6 @@ struct ProcessedVotes {
     repair_msg: HashMap<Slot, Vec<Pubkey>>,
     vote_aggregates_for_pool: Vec<VoteAggregate>,
     metrics_msg: Vec<ConsensusMetricsEvent>,
-}
-
-impl ProcessedVotes {
-    fn merge(&mut self, other: Self) {
-        let Self {
-            mut reward_msg,
-            repair_msg,
-            mut vote_aggregates_for_pool,
-            mut metrics_msg,
-        } = other;
-        self.reward_msg.append(&mut reward_msg);
-        for (pubkey, mut slots) in repair_msg {
-            match self.repair_msg.entry(pubkey) {
-                Entry::Vacant(e) => {
-                    e.insert(slots);
-                }
-                Entry::Occupied(e) => e.into_mut().append(&mut slots),
-            }
-        }
-        self.vote_aggregates_for_pool
-            .append(&mut vote_aggregates_for_pool);
-        self.metrics_msg.append(&mut metrics_msg);
-    }
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -176,13 +149,7 @@ pub(super) fn verify_and_send_votes(
         unverified_votes
             .into_par_iter()
             .fold(
-                || {
-                    (
-                        0u64,
-                        VoteVerificationStats::default(),
-                        ProcessedVotes::default(),
-                    )
-                },
+                || (0u64, VoteVerificationStats::default(), vec![]),
                 |(mut acc_total_votes, mut acc_verification_stats, mut acc_processed_votes),
                  (vote_payload_to_sign, unverified_votes)| {
                     let (unverified_votes_len, vote_verification_stats, processed_votes) =
@@ -198,22 +165,16 @@ pub(super) fn verify_and_send_votes(
                         );
                     acc_total_votes = acc_total_votes.saturating_add(unverified_votes_len);
                     acc_verification_stats.merge(vote_verification_stats);
-                    acc_processed_votes.merge(processed_votes);
+                    acc_processed_votes.push(processed_votes);
                     (acc_total_votes, acc_verification_stats, acc_processed_votes)
                 },
             )
             .reduce(
-                || {
-                    (
-                        0,
-                        VoteVerificationStats::default(),
-                        ProcessedVotes::default(),
-                    )
-                },
-                |mut left, right| {
+                || (0, VoteVerificationStats::default(), vec![]),
+                |mut left, mut right| {
                     left.0 = left.0.saturating_add(right.0);
                     left.1.merge(right.1);
-                    left.2.merge(right.2);
+                    left.2.append(&mut right.2);
                     left
                 },
             )
@@ -301,33 +262,35 @@ fn process_verified_votes(
 fn send_msgs(
     my_pubkey: &Pubkey,
     channels: &SigVerifierChannels,
-    processed_votes: ProcessedVotes,
+    processed_votes: Vec<ProcessedVotes>,
 ) -> Result<VoteSenderStats, SigVerifyVoteError> {
     let mut sender_stats = VoteSenderStats::default();
-    send_sig_verified_batch_to_pool(
-        my_pubkey,
-        SigVerifiedBatch::Votes(processed_votes.vote_aggregates_for_pool),
-        &channels.channel_to_pool,
-        &mut sender_stats,
-    )?;
-    send_votes_to_repair(
-        my_pubkey,
-        processed_votes.repair_msg,
-        &channels.channel_to_repair,
-        &mut sender_stats,
-    );
-    send_votes_to_rewards(
-        my_pubkey,
-        processed_votes.reward_msg,
-        &channels.channel_to_reward,
-        &mut sender_stats,
-    );
-    send_votes_to_metrics(
-        my_pubkey,
-        processed_votes.metrics_msg,
-        &channels.channel_to_metrics,
-        &mut sender_stats,
-    );
+    for vote in processed_votes {
+        send_sig_verified_batch_to_pool(
+            my_pubkey,
+            SigVerifiedBatch::Votes(vote.vote_aggregates_for_pool),
+            &channels.channel_to_pool,
+            &mut sender_stats,
+        )?;
+        send_votes_to_repair(
+            my_pubkey,
+            vote.repair_msg,
+            &channels.channel_to_repair,
+            &mut sender_stats,
+        );
+        send_votes_to_rewards(
+            my_pubkey,
+            vote.reward_msg,
+            &channels.channel_to_reward,
+            &mut sender_stats,
+        );
+        send_votes_to_metrics(
+            my_pubkey,
+            vote.metrics_msg,
+            &channels.channel_to_metrics,
+            &mut sender_stats,
+        );
+    }
     Ok(sender_stats)
 }
 


### PR DESCRIPTION
#### Problem

`merge()` aggregates separate messages into a single message so that we have to send fewer messages to downstream services.

However, this is causing a lot of memory reallocations in the bls thread pool.

In particular, on master, we see:
<img width="642" height="634" alt="Screenshot from 2026-09-02 21-10-53" src="https://github.com/user-attachments/assets/7415b4ed-bf7c-42a0-9756-324d4906ab8a" />



#### Summary of Changes

Removes `merge()` and instead we are sending more msgs on the downstream channels.  With this change we see:

<img width="643" height="711" alt="Screenshot from 2026-09-02 21-11-08" src="https://github.com/user-attachments/assets/be5d1c68-1702-4ac3-a5ab-0aef857c9fa9" />

the bls thread pool is busier and spending less time "sleeping".  This is because it is doing fewer memory operations.

I also validated that the downstream services seem to be keeping up.  The bls-sigverify threads never block or drop messages when sending to downstream services.


#### Testing

No new tests added