### PR TITLE
Make clean_root non optional

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1145,7 +1145,7 @@ impl AccountsDb {
     fn collect_reclaims(
         &self,
         pubkey: &Pubkey,
-        max_clean_root_inclusive: Option<Slot>,
+        max_clean_root_inclusive: Slot,
     ) -> ReclaimsWithNewestSlot<AccountInfo> {
         let mut clean_rooted = Measure::start("clean_old_root-ms");
         let mut reclaims = ReclaimsWithNewestSlot::new();
@@ -1342,14 +1342,12 @@ impl AccountsDb {
     /// Collect all the uncleaned slots, up to a max slot
     ///
     /// Search through the uncleaned Pubkeys and return all the slots, up to a maximum slot.
-    fn collect_uncleaned_slots_up_to_slot(&self, max_slot_inclusive: Option<Slot>) -> Vec<Slot> {
+    fn collect_uncleaned_slots_up_to_slot(&self, max_slot_inclusive: Slot) -> Vec<Slot> {
         self.uncleaned_pubkeys
             .iter()
             .filter_map(|entry| {
                 let slot = *entry.key();
-                max_slot_inclusive
-                    .is_none_or(|max_slot_inclusive| slot <= max_slot_inclusive)
-                    .then_some(slot)
+                (slot <= max_slot_inclusive).then_some(slot)
             })
             .collect()
     }
@@ -1359,7 +1357,7 @@ impl AccountsDb {
     /// pubkeys to `candidates` for cleaning.
     fn remove_uncleaned_slots_up_to_slot_and_move_pubkeys(
         &self,
-        max_slot_inclusive: Option<Slot>,
+        max_slot_inclusive: Slot,
         candidates: &[RwLock<CleaningCandidatesBin>],
     ) {
         let uncleaned_slots = self.collect_uncleaned_slots_up_to_slot(max_slot_inclusive);
@@ -1398,7 +1396,7 @@ impl AccountsDb {
     /// - uncleaned_pubkeys -- the delta set of updated pubkeys in rooted slots from the last clean
     fn construct_candidate_clean_keys(
         &self,
-        max_clean_root_inclusive: Option<Slot>,
+        max_clean_root_inclusive: Slot,
         timings: &mut CleanKeyTimings,
     ) -> CleaningCandidates {
         let num_bins = self.accounts_index.bins();
@@ -1484,15 +1482,13 @@ impl AccountsDb {
     /// this is very slow
     /// this function will call Rayon par_iter, so you will want to have thread pool installed if
     /// you want to call this without consuming all the cores on the CPU.
-    fn verify_index(&self, max_slot_inclusive: Option<Slot>) {
-        info!("verifying index as of slot: {max_slot_inclusive:?}");
+    fn verify_index(&self, max_slot_inclusive: Slot) {
+        info!("verifying index as of slot: {max_slot_inclusive}");
         let pubkey_slot_lists = DashMap::<Pubkey, Vec<Slot>, PubkeyHasherBuilder>::default();
         let mut storages = self.storage.all_storages();
-        // Flush is not running while we verify, so storages are stable. With no slot bound we
-        // verify every storage; otherwise we drop storages newer than the bound.
-        if let Some(max_slot_inclusive) = max_slot_inclusive {
-            storages.retain(|s| s.slot() <= max_slot_inclusive);
-        }
+        // Flush is not running while we verify, so storages are stable. Drop storages newer
+        // than the bound.
+        storages.retain(|s| s.slot() <= max_slot_inclusive);
         // populate
         storages.par_iter().for_each_init(
             || Box::new(append_vec::new_scan_accounts_reader()),
@@ -1548,11 +1544,7 @@ impl AccountsDb {
                             let mut index_slots = slot_list
                                 .iter()
                                 .map(|(slot, _)| *slot)
-                                .filter(|slot| {
-                                    max_slot_inclusive.is_none_or(|max_slot_inclusive| {
-                                        *slot <= max_slot_inclusive
-                                    })
-                                })
+                                .filter(|slot| *slot <= max_slot_inclusive)
                                 .collect::<Vec<_>>();
                             index_slots.sort_unstable();
 
@@ -1579,7 +1571,7 @@ impl AccountsDb {
     // collection
     // Only remove those accounts where the entire rooted history of the account
     // can be purged because there are no live append vecs in the ancestors
-    pub fn clean_accounts(&self, max_clean_root_inclusive: Option<Slot>, is_startup: bool) {
+    pub fn clean_accounts(&self, max_clean_root_inclusive: Slot, is_startup: bool) {
         if self.verify_index {
             //at startup use all cores to verify the index
             if is_startup {
@@ -1596,7 +1588,9 @@ impl AccountsDb {
         let purges_old_accounts_count = AtomicU64::default();
 
         let mut measure_all = Measure::start("clean_accounts");
-        let max_clean_root_inclusive = self.max_clean_root(max_clean_root_inclusive);
+        let max_clean_root_inclusive = self
+            .max_clean_root(Some(max_clean_root_inclusive))
+            .expect("max_clean_root_inclusive must be Some");
 
         self.report_store_stats();
 
@@ -1644,7 +1638,7 @@ impl AccountsDb {
                                 let index_in_slot_list = self.accounts_index.latest_slot(
                                     None,
                                     slot_list,
-                                    max_clean_root_inclusive,
+                                    Some(max_clean_root_inclusive),
                                 );
 
                                 match index_in_slot_list {
@@ -1663,9 +1657,7 @@ impl AccountsDb {
 
                                         // If this candidate has multiple rooted slot list entries,
                                         // we should reclaim the older ones.
-                                        if slot_list.len() > 1
-                                            && *slot
-                                                <= max_clean_root_inclusive.unwrap_or(Slot::MAX)
+                                        if slot_list.len() > 1 && *slot <= max_clean_root_inclusive
                                         {
                                             should_collect_reclaims = true;
                                             purges_old_accounts_local += 1;
@@ -1734,14 +1726,18 @@ impl AccountsDb {
         self.clean_accounts_stats.report();
         datapoint_info!(
             "clean_accounts",
-            ("max_clean_root", max_clean_root_inclusive, Option<i64>),
+            ("max_clean_root", max_clean_root_inclusive, i64),
             ("total_us", measure_all.as_us(), i64),
             (
                 "collect_delta_keys_us",
                 key_timings.collect_delta_keys_us,
                 i64
             ),
-            ("construct_candidates_us", measure_construct_candidates.as_us(), i64),
+            (
+                "construct_candidates_us",
+                measure_construct_candidates.as_us(),
+                i64
+            ),
             (
                 "handle_pubkeys_removed_from_cache_us",
                 handle_pubkeys_removed_from_cache_us,
@@ -1754,7 +1750,11 @@ impl AccountsDb {
                 key_timings.zero_lamport_single_ref_slots_added_to_shrink_count,
                 i64
             ),
-            ("zero_lamport_sweep_us", key_timings.zero_lamport_sweep_us, i64),
+            (
+                "zero_lamport_sweep_us",
+                key_timings.zero_lamport_sweep_us,
+                i64
+            ),
             ("useful_keys", useful_accum.load(Ordering::Relaxed), i64),
             ("total_keys_count", num_candidates, i64),
             (
@@ -1831,7 +1831,8 @@ impl AccountsDb {
             ),
             (
                 "max_distance_to_min_scan_slot",
-                self.scan_tracker.max_distance_to_min_scan_slot
+                self.scan_tracker
+                    .max_distance_to_min_scan_slot
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
@@ -5762,8 +5763,15 @@ impl AccountsDb {
     }
 
     /// Call clean_accounts() with the common parameters that tests/benches use.
+    /// Clean covers storages, so cleaning through the newest one covers everything.
     pub fn clean_accounts_for_tests(&self) {
-        self.clean_accounts(None, false)
+        let max_storage_slot = self
+            .storage
+            .iter()
+            .map(|(slot, _storage)| slot)
+            .max()
+            .unwrap_or_default();
+        self.clean_accounts(max_storage_slot, false)
     }
 
     pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5764,7 +5764,6 @@ impl AccountsDb {
 
     /// Call clean_accounts() with the common parameters that tests/benches use.
     pub fn clean_accounts_for_tests(&self) {
-
         // Find the largest storage, to pass it into clean so all
         // storages are cleaned
         let max_storage_slot = self

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5763,8 +5763,10 @@ impl AccountsDb {
     }
 
     /// Call clean_accounts() with the common parameters that tests/benches use.
-    /// Clean covers storages, so cleaning through the newest one covers everything.
     pub fn clean_accounts_for_tests(&self) {
+
+        // Find the largest storage, to pass it into clean so all
+        // storages are cleaned
         let max_storage_slot = self
             .storage
             .iter()

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1549,7 +1549,7 @@ fn test_fully_tombstoned_storage_reclaim() {
     // Shrink routes the fully-dead slot to clean; clean retains the storage because the latest full
     // snapshot is older than the slot, so the slot is not yet eligible for shrink.
     accounts_db.shrink_slot_forced(slot);
-    accounts_db.clean_accounts(Some(slot), false);
+    accounts_db.clean_accounts(slot, false);
     assert!(accounts_db.storage.get_slot_storage_entry(slot).is_some());
     // Verify that the slot is not queued for shrink at this time
     assert!(
@@ -1563,7 +1563,7 @@ fn test_fully_tombstoned_storage_reclaim() {
     // Advance the latest full snapshot past the slot so its tombstones become purgeable. Clean then
     // cleans the storage and it is reclaimed.
     accounts_db.set_latest_full_snapshot_slot(slot + 1);
-    accounts_db.clean_accounts(Some(slot + 1), false);
+    accounts_db.clean_accounts(slot + 1, false);
     assert!(accounts_db.storage.get_slot_storage_entry(slot).is_none());
 }
 
@@ -2030,7 +2030,7 @@ fn test_clean_max_slot_zero_lamport_account() {
 
     accounts.set_latest_full_snapshot_slot(2);
     // Now the account can be cleaned up
-    accounts.clean_accounts(Some(1), false);
+    accounts.clean_accounts(1, false);
     assert_eq!(accounts.alive_account_count_in_slot(0), 0);
     assert_eq!(accounts.alive_account_count_in_slot(1), 0);
 
@@ -2593,7 +2593,7 @@ fn test_verify_index_small_dataset_detects_mismatch() {
         (false, ())
     });
 
-    accounts.verify_index(Some(slot + 1));
+    accounts.verify_index(slot + 1);
 }
 
 #[test]
@@ -3222,7 +3222,7 @@ fn test_clean_does_not_tombstone_zero_lamport_above_clean_root() {
     db.flush_rooted_accounts_cache_without_clean();
 
     // Only clean zero lamport accounts up to slot 1
-    db.clean_accounts(Some(1), false);
+    db.clean_accounts(1, false);
 
     // The slot 2 entry is above the clean root: still indexed, no tombstone, loadable
     assert!(db.accounts_index.contains(&account_key));
@@ -3233,7 +3233,7 @@ fn test_clean_does_not_tombstone_zero_lamport_above_clean_root() {
     );
 
     // Once the clean root passes slot 2, the classic zero-lamport purge path removes it
-    db.clean_accounts(Some(2), false);
+    db.clean_accounts(2, false);
     assert!(!db.accounts_index.contains(&account_key));
     assert_eq!(
         db.do_load_for_tests(&Ancestors::default(), &account_key),
@@ -4265,7 +4265,7 @@ fn test_zero_lamport_single_ref_resweep_respects_last_swept(set_last_swept: bool
     // The sweep range is (0, 4] when not set, queueing both slot 2 and slot 3.
     // The sweep range is (2, 4] when set, queueing only slot 3.
     db.set_latest_full_snapshot_slot(full_snapshot_slot);
-    db.clean_accounts(Some(full_snapshot_slot), false);
+    db.clean_accounts(full_snapshot_slot, false);
 
     let queued = db.shrink_candidate_slots.lock().unwrap();
     assert_eq!(queued.contains(&slot_at_last_swept), !set_last_swept);
@@ -4683,7 +4683,7 @@ fn test_shrink_unref() {
     db.flush_rooted_accounts_cache_without_clean();
 
     // Clean to remove outdated entry from slot 0
-    db.clean_accounts(Some(1), false);
+    db.clean_accounts(1, false);
 
     // Shrink Slot 0
     {
@@ -4701,7 +4701,7 @@ fn test_shrink_unref() {
 
     // Should be one store before clean for slot 0
     db.get_and_assert_single_storage(0);
-    db.clean_accounts(Some(2), false);
+    db.clean_accounts(2, false);
 
     // No stores should exist for slot 0 after clean
     assert_no_storages_at_slot(&db, 0);
@@ -4733,7 +4733,7 @@ fn test_clean_drop_dead_zero_lamport_single_ref_accounts() {
     accounts_db.flush_accounts_cache(true, None);
 
     // run clean
-    accounts_db.clean_accounts(Some(1), false);
+    accounts_db.clean_accounts(1, false);
 
     // After clean, both slot0 and slot1 should be marked dead and dropped
     // from the store map.
@@ -4763,7 +4763,7 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
 
     // account_key1's zero-lamport write in slot 1 was deleted from the index and tombstoned at
     // flush, leaving its slot 0 version dead. Clean drops the now-empty slot 0.
-    db.clean_accounts(Some(1), false);
+    db.clean_accounts(1, false);
 
     // Assert that after clean, slot 0 is dropped.
     assert!(db.storage.get_slot_storage_entry(0).is_none());
@@ -4811,7 +4811,7 @@ fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
 
     // Clean reclaims the outdated slot 0 entries, removing them from the slot lists at
     // reclaim. That leaves each zero-lamport update as its account's only slot list entry.
-    db.clean_accounts(Some(3), false);
+    db.clean_accounts(3, false);
 
     // The reclaim leaves account_key1 zero-lamport single-ref, so it is tombstoned:
     // removed from the index, and slot 1's storage, now holding only the tombstone and
@@ -4829,7 +4829,7 @@ fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
     // Once the full snapshot advances past slot 3, clean drops the tombstone-only
     // storage.
     db.set_latest_full_snapshot_slot(3);
-    db.clean_accounts(Some(3), false);
+    db.clean_accounts(3, false);
     assert_no_storages_at_slot(&db, 3);
 
     // Slot 0 still holds the live account_key2; the other records there are obsolete.
@@ -4842,7 +4842,7 @@ fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
     // Flushes all roots
     db.flush_accounts_cache(true, None);
 
-    db.clean_accounts(Some(4), false);
+    db.clean_accounts(4, false);
 
     // No stores should exist for slot 0. Slot 0 stores are cleaned when
     // slot 4 is flushed; the older accounts are marked obsolete.
@@ -5161,9 +5161,9 @@ fn test_collect_uncleaned_slots_up_to_slot() {
     db.uncleaned_pubkeys.insert(slot2, vec![pubkey2]);
     db.uncleaned_pubkeys.insert(slot3, vec![pubkey3]);
 
-    let mut uncleaned_slots1 = db.collect_uncleaned_slots_up_to_slot(Some(slot1));
-    let mut uncleaned_slots2 = db.collect_uncleaned_slots_up_to_slot(Some(slot2));
-    let mut uncleaned_slots3 = db.collect_uncleaned_slots_up_to_slot(Some(slot3));
+    let mut uncleaned_slots1 = db.collect_uncleaned_slots_up_to_slot(slot1);
+    let mut uncleaned_slots2 = db.collect_uncleaned_slots_up_to_slot(slot2);
+    let mut uncleaned_slots3 = db.collect_uncleaned_slots_up_to_slot(slot3);
 
     uncleaned_slots1.sort_unstable();
     uncleaned_slots2.sort_unstable();
@@ -5207,7 +5207,7 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
         iter::repeat_with(|| RwLock::new(CleaningCandidatesBin::default()))
             .take(num_bins)
             .collect();
-    db.remove_uncleaned_slots_up_to_slot_and_move_pubkeys(Some(slot3), &candidates);
+    db.remove_uncleaned_slots_up_to_slot_and_move_pubkeys(slot3, &candidates);
 
     let candidates_contain = |pubkey: &Pubkey| {
         candidates
@@ -5604,15 +5604,15 @@ fn test_clean_accounts_with_latest_full_snapshot_slot() {
     accounts_db.add_root_and_flush_write_cache(slot3);
 
     accounts_db.set_latest_full_snapshot_slot(slot2);
-    accounts_db.clean_accounts(Some(slot2), false);
+    accounts_db.clean_accounts(slot2, false);
     assert!(accounts_db.storage.get_slot_storage_entry(slot3).is_some());
 
     accounts_db.set_latest_full_snapshot_slot(slot2);
-    accounts_db.clean_accounts(None, false);
+    accounts_db.clean_accounts(slot3, false);
     assert!(accounts_db.storage.get_slot_storage_entry(slot3).is_some());
 
     accounts_db.set_latest_full_snapshot_slot(slot3);
-    accounts_db.clean_accounts(None, false);
+    accounts_db.clean_accounts(slot3, false);
     // The full snapshot now covers slot3, so clean reclaims the tombstone-only storage
     assert!(accounts_db.storage.get_slot_storage_entry(slot3).is_none());
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -876,7 +876,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         slot_list: &mut SlotListWriteGuard<T>,
         reclaims: &mut ReclaimsWithNewestSlot<T>,
-        max_clean_root_inclusive: Option<Slot>,
+        max_clean_root_inclusive: Slot,
     ) -> bool {
         if slot_list.len() <= 1 {
             self.purge_older_root_entries_one_slot_list
@@ -886,7 +886,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         let newest_slot = slot_list
             .iter()
             .map(|(slot, _)| *slot)
-            .filter(|slot| slot <= &max_clean_root_inclusive.unwrap_or(Slot::MAX))
+            .filter(|slot| slot <= &max_clean_root_inclusive)
             .max()
             .unwrap_or_default();
 
@@ -911,7 +911,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self,
         pubkey: &Pubkey,
         reclaims: &mut ReclaimsWithNewestSlot<T>,
-        max_clean_root_inclusive: Option<Slot>,
+        max_clean_root_inclusive: Slot,
     ) -> bool {
         let map = self.get_bin(pubkey);
         // `None` means the pubkey is not in the index; nothing was removed.
@@ -2048,7 +2048,7 @@ mod tests {
         let mut reclaims = ReclaimsWithNewestSlot::new();
 
         // No max clean root: keep the newest slot (9), reclaim everything older.
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Slot::MAX));
         assert_eq!(
             reclaims,
             ReclaimsWithNewestSlot::from([((1, true), 9), ((2, true), 9), ((5, true), 9)])
@@ -2059,7 +2059,7 @@ mod tests {
         // outcome
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsWithNewestSlot::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, 6));
         assert_eq!(
             reclaims,
             ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
@@ -2072,7 +2072,7 @@ mod tests {
         // Pass a max root, earlier slots should be reclaimed
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsWithNewestSlot::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, 5));
         assert_eq!(
             reclaims,
             ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
@@ -2085,7 +2085,7 @@ mod tests {
         // Max clean root 2: newest slot <= 2 is 2, so only slot 1 is older and reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsWithNewestSlot::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, 2));
         assert_eq!(reclaims, ReclaimsWithNewestSlot::from([((1, true), 2)]));
         assert_eq!(
             slot_list.clone_list(),
@@ -2096,7 +2096,7 @@ mod tests {
         // is reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsWithNewestSlot::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, 1));
         assert!(reclaims.is_empty());
         assert_eq!(
             slot_list.clone_list(),
@@ -2107,7 +2107,7 @@ mod tests {
         // some of the roots in the list, shouldn't return those smaller roots
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
         reclaims = ReclaimsWithNewestSlot::new();
-        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7)));
+        assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, 7));
         assert_eq!(
             reclaims,
             ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
@@ -2410,7 +2410,8 @@ mod tests {
         // If we set a root at `later_slot`, and clean, then even though the account with secondary_key1
         // was outdated by the update in the later slot, the primary account key is still alive,
         // so both secondary keys will still be kept alive.
-        let _ = index.clean_rooted_entries(&account_key, &mut ReclaimsWithNewestSlot::new(), None);
+        let _ =
+            index.clean_rooted_entries(&account_key, &mut ReclaimsWithNewestSlot::new(), Slot::MAX);
 
         check_secondary_index_mapping_correct(
             secondary_index,
@@ -2503,11 +2504,11 @@ mod tests {
 
         let mut gc = ReclaimsWithNewestSlot::new();
         // an unknown key has no index entry, so nothing is removed
-        assert!(!index.clean_rooted_entries(&key_unknown, &mut gc, None));
+        assert!(!index.clean_rooted_entries(&key_unknown, &mut gc, Slot::MAX));
 
         index.upsert_simple_test(&key, slot1, value);
 
-        assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
+        assert!(!index.clean_rooted_entries(&key, &mut gc, slot2));
         index.upsert_simple_test(&key, slot2, value);
 
         index.get_and_then(&key, |entry| {
@@ -2517,7 +2518,7 @@ mod tests {
             assert_eq!(&[(slot1, value), (slot2, value)], slot_list.as_ref());
             (false, ())
         });
-        assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot1)));
+        assert!(!index.clean_rooted_entries(&key, &mut gc, slot1));
         assert_eq!(
             2,
             index.get_and_then(&key, |entry| (
@@ -2527,7 +2528,7 @@ mod tests {
         );
 
         assert!(gc.is_empty());
-        assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
+        assert!(!index.clean_rooted_entries(&key, &mut gc, slot2));
         // The slot1 entry was reclaimed, updated by the surviving slot2 entry
         assert_eq!(gc, ReclaimsWithNewestSlot::from([((slot1, value), slot2)]));
         // The slot1 entry was removed at reclaim, leaving only the slot2 entry in the slot list

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -551,7 +551,7 @@ impl AccountsBackgroundService {
                                 bank.rc
                                     .accounts
                                     .accounts_db
-                                    .clean_accounts(Some(max_clean_slot_inclusive), false);
+                                    .clean_accounts(max_clean_slot_inclusive, false);
                                 last_cleaned_slot = max_clean_slot_inclusive;
                                 previous_clean_time = Instant::now();
                             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5856,7 +5856,7 @@ impl Bank {
                 self.rc
                     .accounts
                     .accounts_db
-                    .clean_accounts(Some(latest_full_snapshot_slot), true);
+                    .clean_accounts(latest_full_snapshot_slot, true);
                 info!("Cleaning... Done.");
             } else {
                 info!("Cleaning... Skipped.");
@@ -6191,7 +6191,7 @@ impl Bank {
         self.rc
             .accounts
             .accounts_db
-            .clean_accounts(Some(highest_slot_to_clean), false);
+            .clean_accounts(highest_slot_to_clean, false);
     }
 
     pub fn print_accounts_stats(&self) {


### PR DESCRIPTION
#### Problem
clean_root is required by all production callers, but not required by tests. This is unnecessary and adds some complexity to detecting the max_cleaned_root (which is the next PR) 

#### Summary of Changes
- Make max_clean_root non optional
- Modify clean_accounts_for_tests to calculate the highest storage and pass it in

#### Testing


Fixes #
