### PR TITLE
agave-conformance: add test_exec_gossip binary

### DIFF
--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -17,14 +17,22 @@ targets = ["x86_64-unknown-linux-gnu"]
 crate-type = ["lib", "cdylib"]
 bench = false
 
+[[bin]]
+name = "test_exec_gossip"
+path = "src/bin/test_exec_gossip.rs"
+required-features = ["cli", "ffi"]
+
 [features]
+default = ["cli", "ffi"]
 agave-unstable-api = []
+cli = ["dep:clap"]
 dev-context-only-utils = []
 dummy-for-ci-check = ["ffi"]
 ffi = ["dep:prost", "dep:protosol", "agave-unstable-api"]
 
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
+clap = { version = "4.5.59", features = ["derive"], optional = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
 solana-bloom = { workspace = true }

--- a/conformance/src/bin/test_exec_gossip.rs
+++ b/conformance/src/bin/test_exec_gossip.rs
@@ -1,0 +1,43 @@
+use {clap::Parser, prost::Message, protosol::protos::GossipFixture, std::path::PathBuf};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let Ok(fixture) = GossipFixture::decode(&blob[..]) else {
+        println!("Failed to parse fixture.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+
+    let effects = agave_conformance::gossip::gossip_decode_to_effects(&fixture.input);
+
+    let ok = effects == expected;
+    if ok {
+        println!("OK: {input:?}");
+    } else {
+        println!("FAIL: {input:?}");
+        println!("Expected: {expected:?}");
+        println!("Actual: {effects:?}");
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -114,6 +114,7 @@ version = "4.4.0-alpha.2"
 dependencies = [
  "bincode",
  "bv",
+ "clap 4.6.1",
  "prost",
  "protosol",
  "solana-bloom",


### PR DESCRIPTION
#### Problem

The `agave-conformance` dev-bin now hosts the gossip harness, but it doesn't
yet offer a runner bin for processing fixtures.

#### Summary of Changes

Add the `test_exec_gossip` runner bin target.

#### Testing

Build the test vectors:

```
git clone https://github.com/firedancer-io/test-vectors.git
cd test-vectors
./scripts/package.sh
```

Build and run the conformance target:

```
cargo build --release --manifest-path conformance/Cargo.toml
dev-bins/target/release/test_exec_gossip -- ~/test-vectors/gossip/fixtures/*.fix
```

Part of #13422