### PR TITLE
runtime: size the accounts index from a fastboot startup hints file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ Release channels have their own copy of this changelog:
   and `--experimental-retransmit-xdp-zero-copy` have been removed. Use `--xdp-interface`, `--xdp-cpu-cores`
   and `--xdp-zero-copy` instead.
 #### Changes
-* Local snapshot dirs now record the bank's account count, which is used to pre-allocate the
-  accounts index when starting using fastboot state. `--accounts-index-initial-accounts-count`
-  still overrides it. Snapshot archives are unaffected, so restoring from an archive pre-allocates
-  only when that flag is given.
 
 ## 4.3.0
 ### RPC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Release channels have their own copy of this changelog:
   and `--experimental-retransmit-xdp-zero-copy` have been removed. Use `--xdp-interface`, `--xdp-cpu-cores`
   and `--xdp-zero-copy` instead.
 #### Changes
+* Local snapshot dirs now record the bank's account count, which is used to pre-allocate the
+  accounts index when starting using fastboot state. `--accounts-index-initial-accounts-count`
+  still overrides it. Snapshot archives are unaffected, so restoring from an archive pre-allocates
+  only when that flag is given.
 
 ## 4.3.0
 ### RPC

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -454,6 +454,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         &self.storage.storage.stats
     }
 
+    /// Number of pubkeys tracked by the index, in-mem and on-disk.
+    pub fn num_accounts(&self) -> usize {
+        self.stats().total_count()
+    }
+
     /// get stats related to startup
     pub(crate) fn get_startup_stats(&self) -> &StartupStats {
         &self.storage.storage.startup_stats

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -350,7 +350,8 @@ impl SnapshotPackagerService {
         );
         if let Err(err) = result {
             warn!("Failed to write startup hints: {err}");
-            // Don't mark the bank snapshot as loadable with a truncated hints file, return early.
+            // If writing the startup hints failed, we do *NOT* want to mark the bank snapshot
+            // as loadable so return early.
             return;
         }
 

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -13,6 +13,7 @@ use {
     solana_perf::thread::renice_this_thread,
     solana_runtime::{
         accounts_background_service::PendingSnapshotPackages,
+        serde_snapshot::StartupHints,
         snapshot_controller::SnapshotController,
         snapshot_package::{BankSnapshotPackage, SnapshotPackage},
         snapshot_utils,
@@ -97,6 +98,10 @@ impl SnapshotPackagerService {
                             teardown_state = Some(TeardownState {
                                 snapshot_slot: snapshot_package.slot,
                                 snapshot_storages: snapshot_package.snapshot_storages.clone(),
+                                startup_hints: snapshot_package
+                                    .bank_snapshot_package
+                                    .startup_hints
+                                    .clone(),
                                 bank_snapshot_package: Some(snapshot_package.bank_snapshot_package),
                             });
 
@@ -112,6 +117,10 @@ impl SnapshotPackagerService {
                             teardown_state = Some(TeardownState {
                                 snapshot_slot: snapshot_package.slot,
                                 snapshot_storages: snapshot_package.snapshot_storages.clone(),
+                                startup_hints: snapshot_package
+                                    .bank_snapshot_package
+                                    .startup_hints
+                                    .clone(),
                                 bank_snapshot_package: None,
                             });
                         }
@@ -237,6 +246,7 @@ impl SnapshotPackagerService {
             snapshot_slot,
             snapshot_storages,
             bank_snapshot_package,
+            startup_hints,
         } = state;
 
         // Teardown, expedite IO using sqpoll thread, but fallback in case of error.
@@ -333,6 +343,17 @@ impl SnapshotPackagerService {
         }
         info!("Saving obsolete accounts... Done in {:?}", start.elapsed());
 
+        let result = snapshot_utils::write_startup_hints_to_snapshot(
+            &bank_snapshot_dir,
+            &startup_hints,
+            &io_setup,
+        );
+        if let Err(err) = result {
+            warn!("Failed to write startup hints: {err}");
+            // Don't mark the bank snapshot as loadable with a truncated hints file, return early.
+            return;
+        }
+
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {
             warn!("Failed to mark bank snapshot as loadable: {err}");
@@ -353,4 +374,6 @@ struct TeardownState {
     /// `bank_snapshot_package` will be `None` because the serialization would have already occurred
     /// when the snapshot archive was written.
     bank_snapshot_package: Option<BankSnapshotPackage>,
+    /// The startup hints of the latest snapshot
+    startup_hints: StartupHints,
 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -343,6 +343,8 @@ impl SnapshotPackagerService {
         }
         info!("Saving obsolete accounts... Done in {:?}", start.elapsed());
 
+        info!("Writing startup hints...");
+        let start = Instant::now();
         let result = snapshot_utils::write_startup_hints_to_snapshot(
             &bank_snapshot_dir,
             &startup_hints,
@@ -354,6 +356,7 @@ impl SnapshotPackagerService {
             // as loadable so return early.
             return;
         }
+        info!("Writing startup hints... Done in {:?}", start.elapsed());
 
         let result = snapshot_utils::mark_bank_snapshot_as_loadable(&bank_snapshot_dir);
         if let Err(err) = result {

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -98,10 +98,7 @@ impl SnapshotPackagerService {
                             teardown_state = Some(TeardownState {
                                 snapshot_slot: snapshot_package.slot,
                                 snapshot_storages: snapshot_package.snapshot_storages.clone(),
-                                startup_hints: snapshot_package
-                                    .bank_snapshot_package
-                                    .startup_hints
-                                    .clone(),
+                                startup_hints: snapshot_package.startup_hints.clone(),
                                 bank_snapshot_package: Some(snapshot_package.bank_snapshot_package),
                             });
 
@@ -117,10 +114,7 @@ impl SnapshotPackagerService {
                             teardown_state = Some(TeardownState {
                                 snapshot_slot: snapshot_package.slot,
                                 snapshot_storages: snapshot_package.snapshot_storages.clone(),
-                                startup_hints: snapshot_package
-                                    .bank_snapshot_package
-                                    .startup_hints
-                                    .clone(),
+                                startup_hints: snapshot_package.startup_hints.clone(),
                                 bank_snapshot_package: None,
                             });
                         }
@@ -141,6 +135,7 @@ impl SnapshotPackagerService {
                         snapshot_package.bank_snapshot_package,
                         snapshot_package.snapshot_storages.as_slice(),
                         exit_backpressure.is_none(),
+                        &snapshot_package.startup_hints,
                         &io_setup,
                     );
 
@@ -269,6 +264,7 @@ impl SnapshotPackagerService {
                 bank_snapshot_package,
                 snapshot_storages.as_slice(),
                 false,
+                &startup_hints,
                 &io_setup,
             );
             if let Err(err) = result {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -62,10 +62,11 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help(
+            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .long_help(
                 "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
-                 account count recorded in the local snapshot dir when starting using fastboot \
-                 state.",
+                 account count recorded in the local snapshot directory, which is otherwise used \
+                 when starting from local snapshot state rather than a snapshot archive.",
             )
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_index_limit")

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -62,7 +62,11 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .help(
+                "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
+                 account count recorded in the local snapshot dir when starting using fastboot \
+                 state.",
+            )
             .hidden(hidden_unless_forced()),
         Arg::with_name("accounts_index_limit")
             .long("accounts-index-limit")

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -68,12 +68,14 @@ use {
 };
 
 mod obsolete_accounts;
+mod startup_hints;
 mod status_cache;
 mod storage;
 mod storages_list;
 mod tests;
 mod types;
 
+pub use startup_hints::StartupHints;
 pub(crate) use {
     obsolete_accounts::{SerdeObsoleteAccounts, SerdeObsoleteAccountsMap},
     status_cache::{deserialize_status_cache, serialize_status_cache},

--- a/runtime/src/serde_snapshot/startup_hints.rs
+++ b/runtime/src/serde_snapshot/startup_hints.rs
@@ -1,0 +1,97 @@
+use {
+    crate::{bank::Bank, serde_snapshot::deserialize_wincode_from},
+    log::*,
+    wincode::{ReadError, ReadResult, SchemaRead, SchemaWrite, io::Reader},
+};
+
+/// A single startup tuning hint.
+///
+/// Hints are identified by tag, so extend by adding variants; never change an existing one.
+#[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub enum StartupHint {
+    /// Number of accounts in the snapshot's bank.
+    NumAccounts(u64),
+}
+
+/// The startup hints of a bank snapshot.
+///
+/// Written next to the bank snapshot on graceful exit, read back when starting from fastboot
+/// state. Local-only (never archived) and wholly optional: every component must still initialize
+/// correctly without it.
+#[derive(Clone, Debug, Default, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct StartupHints {
+    hints: Vec<StartupHint>,
+}
+
+impl StartupHints {
+    pub fn new_from_bank(bank: &Bank) -> Self {
+        Self::from_hints(vec![StartupHint::NumAccounts(
+            bank.rc.accounts.accounts_db.accounts_index.num_accounts() as u64,
+        )])
+    }
+
+    pub(crate) fn from_hints(hints: Vec<StartupHint>) -> Self {
+        Self { hints }
+    }
+
+    /// `None` when the hints came from a newer version: wincode cannot read past a tag it does
+    /// not know, so the whole lot is dropped rather than partially decoded.
+    pub(crate) fn read_from<'a>(reader: impl Reader<'a>) -> ReadResult<Option<Self>> {
+        match deserialize_wincode_from(reader) {
+            Ok(startup_hints) => Ok(Some(startup_hints)),
+            Err(ReadError::InvalidTagEncoding(tag)) => {
+                warn!("ignoring startup hints: unknown hint {tag}");
+                Ok(None)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    // not `map().next()`: the match stops being irrefutable once a second variant exists
+    #[allow(clippy::unnecessary_find_map)]
+    pub fn num_accounts(&self) -> Option<u64> {
+        self.hints.iter().find_map(|hint| match hint {
+            StartupHint::NumAccounts(num_accounts) => Some(*num_accounts),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::serde_snapshot::serialize_into};
+
+    fn roundtrip(hints: &StartupHints) -> StartupHints {
+        let mut buf = Vec::new();
+        serialize_into(&mut buf, hints).unwrap();
+        StartupHints::read_from(buf.as_slice()).unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_roundtrip_startup_hints() {
+        let hints = StartupHints::from_hints(vec![StartupHint::NumAccounts(1_234_567)]);
+        let decoded = roundtrip(&hints);
+        assert_eq!(decoded, hints);
+        assert_eq!(decoded.num_accounts(), Some(1_234_567));
+    }
+
+    #[test]
+    fn test_read_unknown_hint() {
+        let mut encoded = 1u64.to_le_bytes().to_vec(); // one hint
+        encoded.extend_from_slice(&u32::MAX.to_le_bytes()); // that no variant claims
+        encoded.extend_from_slice(&[0xAB; 16]);
+
+        assert!(
+            StartupHints::read_from(encoded.as_slice())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_startup_hints_empty() {
+        let hints = StartupHints::default();
+        let decoded = roundtrip(&hints);
+        assert_eq!(decoded, hints);
+        assert_eq!(decoded.num_accounts(), None);
+    }
+}

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -367,7 +367,7 @@ pub fn bank_from_snapshot_dir(
     leader_for_tests: Option<SlotLeader>,
     limit_load_slot_count_from_snapshot: Option<usize>,
     verify_index: bool,
-    accounts_db_config: AccountsDbConfig,
+    mut accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
 ) -> agave_snapshots::Result<Bank> {
@@ -375,6 +375,19 @@ pub fn bank_from_snapshot_dir(
         "Loading bank from snapshot dir: {}",
         bank_snapshot.snapshot_dir.display()
     );
+
+    // Size the index up front from the snapshot's account count, unless it was configured
+    // explicitly. Fastboot only: snapshot archives carry no such count.
+    let num_accounts_hint = snapshot_utils::read_startup_hints(&bank_snapshot.snapshot_dir)?
+        .and_then(|startup_hints| startup_hints.num_accounts());
+    if let Some(num_accounts) = num_accounts_hint {
+        let index_config = accounts_db_config.index.get_or_insert_default();
+        if index_config.num_initial_accounts.is_none() {
+            let num_accounts = num_accounts as usize;
+            info!("Sizing accounts index for {num_accounts} accounts, per the snapshot");
+            index_config.num_initial_accounts = Some(num_accounts);
+        }
+    }
 
     // Storages from this snapshot already live under `account_paths`; the storages list
     // inside the bank snapshot dir tells us which ones belong to it, and stale files
@@ -939,6 +952,7 @@ mod tests {
             bank_fields: bank.get_fields_to_serialize(),
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas: bank.status_cache.read().unwrap().root_slot_deltas(),
+            startup_hints: serde_snapshot::StartupHints::new_from_bank(bank),
         };
 
         let snapshot_storages = bank.get_snapshot_storages(None);
@@ -1846,6 +1860,44 @@ mod tests {
 
         assert!(purge_bank_snapshot(&bank_snapshot_dir).is_ok());
         assert!(fs::metadata(&bank_snapshot_dir).is_err());
+    }
+
+    #[test]
+    fn test_bank_snapshot_dir_startup_hints() {
+        let bank = Bank::new_for_tests(&GenesisConfig::default());
+        bank.fill_bank_with_ticks_for_tests();
+        bank.set_block_id(Some(Hash::default()));
+
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        create_bank_snapshot_from_bank(
+            &bank_snapshots_dir,
+            &bank,
+            SnapshotVersion::default(),
+            true,
+        )
+        .unwrap();
+
+        let bank_snapshot_dir = get_bank_snapshot_dir(&bank_snapshots_dir, bank.slot());
+        let startup_hints = snapshot_utils::read_startup_hints(&bank_snapshot_dir)
+            .unwrap()
+            .unwrap();
+        let num_accounts = bank.rc.accounts.accounts_db.accounts_index.num_accounts() as u64;
+        assert_ne!(num_accounts, 0);
+        assert_eq!(startup_hints.num_accounts(), Some(num_accounts));
+
+        // A truncated file is corrupt local state, not a missing hint
+        let startup_hints_path =
+            bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STARTUP_HINTS_FILENAME);
+        fs::write(&startup_hints_path, [0u8; 3]).unwrap();
+        assert!(snapshot_utils::read_startup_hints(&bank_snapshot_dir).is_err());
+
+        // Snapshots predating the hints file still load
+        fs::remove_file(&startup_hints_path).unwrap();
+        assert!(
+            snapshot_utils::read_startup_hints(&bank_snapshot_dir)
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// Test versioning when fastbooting

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -747,6 +747,7 @@ pub fn bank_to_full_snapshot_archive(
         snapshot_package.bank_snapshot_package,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
+        &snapshot_package.startup_hints,
         &io_setup,
     )?;
 
@@ -820,6 +821,7 @@ pub fn bank_to_incremental_snapshot_archive(
         snapshot_package.bank_snapshot_package,
         snapshot_storages.as_slice(),
         false, // we do not intend to fastboot, so skip flushing and hard linking the storages
+        &snapshot_package.startup_hints,
         &io_setup,
     )?;
 
@@ -952,7 +954,6 @@ mod tests {
             bank_fields: bank.get_fields_to_serialize(),
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas: bank.status_cache.read().unwrap().root_slot_deltas(),
-            startup_hints: serde_snapshot::StartupHints::new_from_bank(bank),
         };
 
         let snapshot_storages = bank.get_snapshot_storages(None);
@@ -963,6 +964,7 @@ mod tests {
             bank_snapshot_package,
             snapshot_storages.as_slice(),
             should_finalize,
+            &serde_snapshot::StartupHints::new_from_bank(bank),
             &IoSetupState::default(),
         )?;
 
@@ -1889,6 +1891,14 @@ mod tests {
         let startup_hints_path =
             bank_snapshot_dir.join(snapshot_paths::SNAPSHOT_STARTUP_HINTS_FILENAME);
         fs::write(&startup_hints_path, [0u8; 3]).unwrap();
+        assert!(snapshot_utils::read_startup_hints(&bank_snapshot_dir).is_err());
+
+        // An oversized file is rejected before being read
+        fs::write(
+            &startup_hints_path,
+            vec![0u8; snapshot_utils::MAX_STARTUP_HINTS_FILE_SIZE as usize + 1],
+        )
+        .unwrap();
         assert!(snapshot_utils::read_startup_hints(&bank_snapshot_dir).is_err());
 
         // Snapshots predating the hints file still load

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "dev-context-only-utils")]
 use solana_hash::Hash;
 use {
-    crate::bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
+    crate::{
+        bank::{Bank, BankFieldsToSerialize, BankHashStats, BankSlotDelta},
+        serde_snapshot::StartupHints,
+    },
     agave_snapshots::{SnapshotArchiveKind, SnapshotKind, snapshot_hash::SnapshotHash},
     solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
@@ -49,6 +52,7 @@ impl SnapshotPackage {
             bank_fields: bank_fields_to_serialize,
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas,
+            startup_hints: StartupHints::new_from_bank(bank),
         };
 
         Self {
@@ -71,6 +75,7 @@ impl SnapshotPackage {
             bank_fields: BankFieldsToSerialize::default_for_tests(),
             bank_hash_stats: BankHashStats::default(),
             status_cache_slot_deltas: Vec::default(),
+            startup_hints: StartupHints::default(),
         };
 
         Self {
@@ -99,4 +104,5 @@ pub struct BankSnapshotPackage {
     pub bank_fields: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
+    pub startup_hints: StartupHints,
 }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -21,6 +21,7 @@ pub struct SnapshotPackage {
     pub hash: SnapshotHash,
     pub snapshot_storages: Vec<Arc<AccountStorageEntry>>,
     pub bank_snapshot_package: BankSnapshotPackage,
+    pub startup_hints: StartupHints,
 
     /// The instant this snapshot package was sent to the queue.
     /// Used to track how long snapshot packages wait before handling.
@@ -52,7 +53,6 @@ impl SnapshotPackage {
             bank_fields: bank_fields_to_serialize,
             bank_hash_stats: bank.get_bank_hash_stats(),
             status_cache_slot_deltas,
-            startup_hints: StartupHints::new_from_bank(bank),
         };
 
         Self {
@@ -60,6 +60,7 @@ impl SnapshotPackage {
             slot,
             hash,
             bank_snapshot_package,
+            startup_hints: StartupHints::new_from_bank(bank),
             snapshot_storages,
             enqueued: Instant::now(),
         }
@@ -75,7 +76,6 @@ impl SnapshotPackage {
             bank_fields: BankFieldsToSerialize::default_for_tests(),
             bank_hash_stats: BankHashStats::default(),
             status_cache_slot_deltas: Vec::default(),
-            startup_hints: StartupHints::default(),
         };
 
         Self {
@@ -84,6 +84,7 @@ impl SnapshotPackage {
             hash: SnapshotHash(Hash::default()),
             snapshot_storages: Vec::default(),
             bank_snapshot_package,
+            startup_hints: StartupHints::default(),
             enqueued: Instant::now(),
         }
     }
@@ -104,5 +105,4 @@ pub struct BankSnapshotPackage {
     pub bank_fields: BankFieldsToSerialize,
     pub bank_hash_stats: BankHashStats,
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
-    pub startup_hints: StartupHints,
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -95,7 +95,9 @@ const AUX_SNAPSHOT_FILE_READ_BUF_SIZE: usize = 4 * 1024 * 1024;
 //         and the next teardown writes the new-format storages list.
 //         Note: 2.0.0 validators cannot fastboot from 3.0.0 snapshots because the per-storage
 //         hardlink dirs they rely on are no longer written; they must fall back to archive.
-const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(3, 0, 0);
+// 3.1.0 - Startup hints file added. Optional tuning state, so snapshots fastboot in either
+//         direction between 3.0.0 and 3.1.0; a validator finding no hints just skips the tuning.
+const SNAPSHOT_FASTBOOT_VERSION: Version = Version::new(3, 1, 0);
 
 /// Information about a bank snapshot. Namely the slot of the bank, the path to the snapshot, and
 /// the kind of the snapshot.

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5,8 +5,8 @@ use {
         bank::BankFieldsToDeserialize,
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerdeObsoleteAccountsMap,
-            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams, StorageListItem,
-            StoragesList,
+            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams, StartupHints,
+            StorageListItem, StoragesList,
         },
         snapshot_package::BankSnapshotPackage,
         snapshot_utils::snapshot_storage_rebuilder::{
@@ -75,6 +75,8 @@ pub const MAX_OBSOLETE_ACCOUNTS_FILE_SIZE: u64 = 1024 * 1024 * 1024 * 12; // 12 
 /// Each `(slot, id)` entry encodes to 12 bytes; 100 MiB covers ~8.7 million entries, well past
 /// any realistic storage count.
 pub const MAX_STORAGES_LIST_FILE_SIZE: u64 = 100 * 1024 * 1024; // 100 MiB
+/// The file holds a handful of scalars; this conservative bound limits the impact of bad state.
+pub const MAX_STARTUP_HINTS_FILE_SIZE: u64 = 4096;
 pub const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const MAX_SNAPSHOT_VERSION_FILE_SIZE: u64 = 8; // byte
 /// Buffer size for reading auxiliary per-snapshot files (obsolete accounts, storages list).
@@ -493,6 +495,7 @@ pub fn serialize_snapshot(
         mut bank_fields,
         bank_hash_stats,
         status_cache_slot_deltas,
+        startup_hints,
     } = bank_snapshot_package;
     let status_cache_slot_deltas = status_cache_slot_deltas.as_slice();
     let slot = bank_fields.slot;
@@ -591,6 +594,9 @@ pub fn serialize_snapshot(
                     )
                     .map_err(|err| AddBankSnapshotError::WriteStoragesList(Box::new(err)))?
                 );
+
+                write_startup_hints_to_snapshot(&bank_snapshot_dir, &startup_hints, io_setup)
+                    .map_err(|err| AddBankSnapshotError::WriteStartupHints(Box::new(err)))?;
 
                 mark_bank_snapshot_as_loadable(&bank_snapshot_dir)
                     .map_err(AddBankSnapshotError::MarkSnapshotLoadable)?;
@@ -814,6 +820,58 @@ fn deserialize_storages_list(
     Ok(serde_snapshot::deserialize_wincode_from(
         storages_list_reader,
     )?)
+}
+
+pub fn write_startup_hints_to_snapshot(
+    bank_snapshot_dir: impl AsRef<Path>,
+    startup_hints: &StartupHints,
+    io_setup: &IoSetupState,
+) -> Result<FileSize> {
+    let startup_hints_path = bank_snapshot_dir
+        .as_ref()
+        .join(snapshot_paths::SNAPSHOT_STARTUP_HINTS_FILENAME);
+    let mut file_stream = SizeLimitedWriter::new(
+        large_file_buf_writer(&startup_hints_path, io_setup)?,
+        MAX_STARTUP_HINTS_FILE_SIZE,
+    );
+    serde_snapshot::serialize_into(&mut file_stream, startup_hints).map_err(|err| {
+        IoError::other(format!(
+            "unable to serialize startup hints to file '{}': {err}",
+            startup_hints_path.display(),
+        ))
+    })?;
+    Ok(file_stream.bytes_written())
+}
+
+/// Reads the startup hints written next to a bank snapshot.
+///
+/// `Ok(None)` when the snapshot predates the hints file or its hints came from a newer version;
+/// any other failure to read a present file is an error.
+pub fn read_startup_hints(bank_snapshot_dir: impl AsRef<Path>) -> Result<Option<StartupHints>> {
+    let startup_hints_path = bank_snapshot_dir
+        .as_ref()
+        .join(snapshot_paths::SNAPSHOT_STARTUP_HINTS_FILENAME);
+    if !startup_hints_path.exists() {
+        return Ok(None);
+    }
+
+    let startup_hints_file_metadata = fs::metadata(&startup_hints_path)?;
+    if startup_hints_file_metadata.len() > MAX_STARTUP_HINTS_FILE_SIZE {
+        let error_message = format!(
+            "too large startup hints file to deserialize: '{}' has {} bytes (max size is \
+             {MAX_STARTUP_HINTS_FILE_SIZE} bytes)",
+            startup_hints_path.display(),
+            startup_hints_file_metadata.len(),
+        );
+        return Err(IoError::other(error_message).into());
+    }
+    let startup_hints_reader = ReadAdapter::new(large_file_buf_reader(
+        &startup_hints_path,
+        AUX_SNAPSHOT_FILE_READ_BUF_SIZE,
+        &IoSetupState::default(),
+    )?);
+
+    Ok(StartupHints::read_from(startup_hints_reader)?)
 }
 
 pub fn serialize_snapshot_data_file<F>(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -491,13 +491,13 @@ pub fn serialize_snapshot(
     bank_snapshot_package: BankSnapshotPackage,
     snapshot_storages: &[Arc<AccountStorageEntry>],
     should_finalize: bool,
+    startup_hints: &StartupHints,
     io_setup: &IoSetupState,
 ) -> Result<BankSnapshotInfo> {
     let BankSnapshotPackage {
         mut bank_fields,
         bank_hash_stats,
         status_cache_slot_deltas,
-        startup_hints,
     } = bank_snapshot_package;
     let status_cache_slot_deltas = status_cache_slot_deltas.as_slice();
     let slot = bank_fields.slot;
@@ -597,7 +597,7 @@ pub fn serialize_snapshot(
                     .map_err(|err| AddBankSnapshotError::WriteStoragesList(Box::new(err)))?
                 );
 
-                write_startup_hints_to_snapshot(&bank_snapshot_dir, &startup_hints, io_setup)
+                write_startup_hints_to_snapshot(&bank_snapshot_dir, startup_hints, io_setup)
                     .map_err(|err| AddBankSnapshotError::WriteStartupHints(Box::new(err)))?;
 
                 mark_bank_snapshot_as_loadable(&bank_snapshot_dir)

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -211,6 +211,9 @@ pub enum AddBankSnapshotError {
     #[error("failed to write storages list: {0}")]
     WriteStoragesList(#[source] Box<SnapshotError>),
 
+    #[error("failed to write startup hints: {0}")]
+    WriteStartupHints(#[source] Box<SnapshotError>),
+
     #[error("failed to write snapshot version file '{1}': {0}")]
     WriteSnapshotVersionFile(#[source] io::Error, PathBuf),
 

--- a/snapshots/src/paths.rs
+++ b/snapshots/src/paths.rs
@@ -25,6 +25,7 @@ pub const SNAPSHOT_ACCOUNTS_HARDLINKS: &str = "accounts_hardlinks";
 pub const SNAPSHOT_STORAGES_LIST_FILENAME: &str = "storages_list";
 pub const SNAPSHOT_ARCHIVE_DOWNLOAD_DIR: &str = "remote";
 pub const SNAPSHOT_OBSOLETE_ACCOUNTS_FILENAME: &str = "obsolete_accounts";
+pub const SNAPSHOT_STARTUP_HINTS_FILENAME: &str = "startup_hints";
 /// When a snapshot is taken of a bank, the state is serialized under this directory.
 /// Specifically in `BANK_SNAPSHOTS_DIR/SLOT/`.
 /// This is also where the bank state is located in the snapshot archive.

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1096,10 +1096,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help(
+            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .long_help(
                 "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
-                 account count recorded in the local snapshot dir when starting using fastboot \
-                 state.",
+                 account count recorded in the local snapshot directory, which is otherwise used \
+                 when starting from local snapshot state rather than a snapshot archive.",
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1096,7 +1096,11 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("NUMBER")
             .validator(is_parsable::<usize>)
             .takes_value(true)
-            .help("Pre-allocate the accounts index, assuming this many accounts")
+            .help(
+                "Pre-allocate the accounts index, assuming this many accounts. Overrides the \
+                 account count recorded in the local snapshot dir when starting using fastboot \
+                 state.",
+            )
             .hidden(hidden_unless_forced()),
     )
     .arg(


### PR DESCRIPTION
#### Problem
The accounts index grows from empty during startup index generation, rehashing every bin up to its final size. Avoiding that needs `--accounts-index-initial-accounts-count`, which operators must guess and keep up to date by hand. The bank's account count is known when the snapshot is written, but the manifest is a cross-client wire format and a pure startup tuning knob does not belong in it.

#### Summary of Changes
- add a local `startup_hints` file to the bank snapshot dir, holding the bank's accounts index entry count
- pre-size the index from it when starting using fastboot state, unless the cli flag was given
- write it before marking the snapshot loadable, and treat a present but unreadable file as a hard error, so corrupt local state gets reported
- tolerate its absence, and drop it whole when it holds a hint written by a newer version
- leave the manifest and snapshot archives untouched; restoring from an archive pre-sizes only when the cli flag is given

#### Testing
* restarting validator before (master), after (PR)
```
[2026-09-03T12:09:13.830824219Z INFO  solana_runtime::serde_snapshot] Building accounts index...
[2026-09-03T12:09:51.761508410Z INFO  solana_runtime::serde_snapshot] Building accounts index... Done in 37.930674267s
[2026-09-03T12:16:32.248023786Z INFO  solana_runtime::serde_snapshot] Building accounts index...
[2026-09-03T12:17:00.644701150Z INFO  solana_runtime::serde_snapshot] Building accounts index... Done in 28.396669393s
```
* restarting back to master
```
[2026-09-03T12:21:47.663448882Z INFO  solana_runtime::serde_snapshot] Building accounts index...
[2026-09-03T12:22:21.555117143Z INFO  solana_runtime::serde_snapshot] Building accounts index... Done in 33.891662543s
```