### PR TITLE
nit: remove unnecessary binding

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2130,13 +2130,13 @@ impl fmt::Display for CliAgGenesisInfo {
                 let CliAgGenesisInfoPayload {
                     epoch,
                     slot,
-                    block_id: block_hash,
+                    block_id,
                     bitvec,
                     signature,
                 } = payload;
                 writeln!(f, "Alpenglow genesis information:")?;
                 writeln!(f, "  Feature flag activation: Epoch {epoch}")?;
-                writeln!(f, "  Genesis Block - Slot {slot}, Block ID {block_hash}")?;
+                writeln!(f, "  Genesis Block - Slot {slot}, Block ID {block_id}")?;
                 writeln!(
                     f,
                     "  Genesis Vote - {} validators participated, Signature {signature}",


### PR DESCRIPTION
#### Problem

We had done a renaming from `block_hash` to `block_id` and seems like we missed this binding.


#### Summary of Changes

Removes the unnecessary `block_hash` binding.

#### Testing

No new tests added.