### PR TITLE
chore(ci): bump anza-xtask pins to 0.2.3

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,7 +51,7 @@ jobs:
           cargo install toml-cli --locked
 
           # install xtask
-          cargo install anza-xtask@0.2.1 --locked
+          cargo install anza-xtask@0.2.3 --locked
 
       - name: Process
         id: process

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: install anza-xtask
         run: |
-          cargo install anza-xtask@0.2.1 --locked
+          cargo install anza-xtask@0.2.3 --locked
 
       - name: update code
         env:


### PR DESCRIPTION
#### Problem

Nothing auto-updates these; they were two releases behind.

#### Summary of Changes

Update version pins

