### PR TITLE
Bound ancient shrink by max_cleaned_root

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -957,6 +957,11 @@ pub struct AccountsDb {
     /// eligibility.
     last_swept_full_snapshot_slot: AtomicU64,
 
+    /// The highest root that has been cleaned at least once by clean_accounts
+    /// Clean reclaims every slot older than the newest slot at or below its max_clean_root, so
+    /// each account has at most one entry at or below this slot
+    max_cleaned_root: AtomicU64,
+
     /// These are the ancient storages that could be valuable to
     /// shrink, sorted by amount of dead bytes.  The elements
     /// are sorted from the largest dead bytes to the smallest.
@@ -1109,6 +1114,7 @@ impl AccountsDb {
             accounts_file_provider: accounts_db_config.accounts_file_provider,
             latest_full_snapshot_slot: SeqLock::new(None),
             last_swept_full_snapshot_slot: AtomicU64::new(0),
+            max_cleaned_root: AtomicU64::new(0),
             best_ancient_slots_to_shrink: RwLock::default(),
             max_root: AtomicU64::new(0),
         };
@@ -1720,6 +1726,10 @@ impl AccountsDb {
         self.clean_accounts_older_than_root(&reclaims);
         clean_old_rooted.stop();
         drop(active_guard);
+
+        // Advance only once clean has finished.
+        self.max_cleaned_root
+            .fetch_max(max_clean_root_inclusive, Ordering::Relaxed);
 
         measure_all.stop();
 
@@ -2439,18 +2449,30 @@ impl AccountsDb {
         (shrink_slots, shrink_slots_next_batch)
     }
 
-    /// return all slots that are more than one epoch old and thus could already be an ancient append vec
-    /// or which could need to be combined into a new or existing ancient append vec
-    /// offset is used to combine newer slots than we normally would. This is designed to be used for testing.
+    /// return all slots that are more than one epoch old and at or below `max_cleaned_root`,
+    /// and thus could be combined into a new or existing ancient append vec
     fn get_sorted_potential_ancient_slots(&self, oldest_non_ancient_slot: Slot) -> Vec<Slot> {
+        // Limit the slots considered for ancient slots to slots that have been cleaned.
+        // This simplifies the logic as it is guaranteed that any given pubkey is only
+        // indexed once in any slot older than the max cleaned root.
+        let max_slot_exclusive = oldest_non_ancient_slot.min(
+            self.max_cleaned_root
+                .load(Ordering::Relaxed)
+                .saturating_add(1),
+        );
+        if max_slot_exclusive < oldest_non_ancient_slot {
+            self.shrink_ancient_stats
+                .shrinks_bounded_by_max_cleaned_root
+                .fetch_add(1, Ordering::Relaxed);
+        }
         // Only storages can be combined into ancient append vecs, so the storage map is the
         // source of truth here.
-        let mut ancient_slots = self.storage.slots_less_than(oldest_non_ancient_slot);
+        let mut ancient_slots = self.storage.slots_less_than(max_slot_exclusive);
         ancient_slots.sort_unstable();
         ancient_slots
     }
 
-    /// get a sorted list of slots older than an epoch
+    /// get a sorted list of slots older than an epoch and at or below `max_cleaned_root`
     /// squash those slots into ancient append vecs
     pub fn shrink_ancient_slots(&self, epoch_schedule: &EpochSchedule) {
         if self.ancient_append_vec_offset.is_none() {
@@ -5463,6 +5485,11 @@ impl AccountsDb {
         let slot_marked_obsolete = storages.last().unwrap().slot();
         let obsolete_account_stats =
             self.mark_obsolete_accounts_at_startup(slot_marked_obsolete, unique_pubkeys_by_bin);
+
+        // mark_obsolete_accounts_at_startup is effectively a clean up to slot_marked_obsolete
+        // so set max_cleaned_root
+        self.max_cleaned_root
+            .fetch_max(slot_marked_obsolete, Ordering::Relaxed);
 
         mark_obsolete_accounts_time.stop();
         timings.mark_obsolete_accounts_us = mark_obsolete_accounts_time.as_us();

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -309,6 +309,7 @@ pub struct ShrinkAncientStats {
     pub select_slots_us: AtomicU64,
     pub random_shrink: AtomicU64,
     pub slots_considered: AtomicU64,
+    pub shrinks_bounded_by_max_cleaned_root: AtomicU64,
     pub bytes_ancient_created: AtomicU64,
     pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
@@ -724,6 +725,12 @@ impl ShrinkAncientStats {
             (
                 "slots_considered",
                 self.slots_considered.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "shrinks_bounded_by_max_cleaned_root",
+                self.shrinks_bounded_by_max_cleaned_root
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             ("total_us", self.total_us.swap(0, Ordering::Relaxed), i64),

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -5787,6 +5787,8 @@ fn test_sweep_get_oldest_non_ancient_slot2() {
 #[test]
 fn test_get_sorted_potential_ancient_slots() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    // Ensure all slots are considered for ancients
+    db.max_cleaned_root.store(Slot::MAX, Ordering::Relaxed);
     let ancient_append_vec_offset = db.ancient_append_vec_offset.unwrap();
     let epoch_schedule = EpochSchedule::default();
     let oldest_non_ancient_slot = db.get_oldest_non_ancient_slot(&epoch_schedule);
@@ -5845,6 +5847,70 @@ fn test_get_sorted_potential_ancient_slots() {
         db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot),
         vec![root2]
     );
+}
+
+/// Storages above `max_cleaned_root` are not a potential for packing, since clean may not have
+/// reclaimed their older duplicates yet.
+#[test]
+fn test_get_sorted_potential_ancient_slots_bounded_by_max_cleaned_root() {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let ancient_append_vec_offset = db.ancient_append_vec_offset.unwrap();
+    let epoch_schedule = EpochSchedule::default();
+
+    let root1 = DEFAULT_MAX_ANCIENT_STORAGES as u64 + ancient_append_vec_offset as u64 + 1;
+    let root2 = root1 + 1;
+    for root in [root1, root2] {
+        db.add_root(root);
+        db.storage.insert(Arc::new(db.create_store(root, 4096)));
+    }
+    // put both roots more than an epoch behind, so only the cleaned root bound is in play
+    db.add_root(AccountsDb::apply_offset_to_slot(
+        epoch_schedule.slots_per_epoch + root2,
+        ancient_append_vec_offset,
+    ));
+    let oldest_non_ancient_slot = db.get_oldest_non_ancient_slot(&epoch_schedule);
+
+    // clean has not run
+    assert!(
+        db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot)
+            .is_empty()
+    );
+
+    // cleaned root1; root2 is still uncleaned, so not included
+    db.max_cleaned_root.store(root1, Ordering::Relaxed);
+    assert_eq!(
+        db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot),
+        vec![root1]
+    );
+
+    // cleaned root2 so it is included
+    db.max_cleaned_root.store(root2, Ordering::Relaxed);
+    assert_eq!(
+        db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot),
+        vec![root1, root2]
+    );
+}
+
+/// Clean advances `max_cleaned_root` to the root it cleaned, and never backwards.
+#[test]
+fn test_max_cleaned_root_advances_with_clean() {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    assert_eq!(db.max_cleaned_root.load(Ordering::Relaxed), 0);
+
+    let key = Pubkey::new_unique();
+    for slot in 1..=3 {
+        store_rooted_nonzero_accounts(&db, slot, [&key]);
+    }
+
+    db.clean_accounts(2, false);
+    assert_eq!(db.max_cleaned_root.load(Ordering::Relaxed), 2);
+
+    // a lower bound does not decrease max_cleaned_root
+    db.clean_accounts(1, false);
+    assert_eq!(db.max_cleaned_root.load(Ordering::Relaxed), 2);
+
+    db.clean_accounts(3, false);
+    assert_eq!(db.max_cleaned_root.load(Ordering::Relaxed), 3);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
With obsolete accounts enabled, it is extremely unlikely that any account can reach a point where it can be squashed and still have multiple slots in the slot list. It can only occur with extremely long running RPC scans (18 hours). However, since it is technically possible, it needs to be supported.

Here's some stats from our canaries showing that all the related stats are zeroes: 
<img width="1647" height="565" alt="image" src="https://github.com/user-attachments/assets/a8d5ef44-9937-4357-8dc4-86cfe00d0efb" />


Recently there have been some bugs found in this space, that while relatively benign... Need to be resolved. 


#### Summary of Changes
- Rather than trying to fix the edge scenarios, just block them from occurring entirely by not allowing squash on any slot that hasn't been cleaned at least once. If a slot has been cleaned, it may still be a multi slot account (due to scans), but crucially it is guaranteed that there is only one instance of the account elligable for squash.
- If it's guaranteed that only one version of account is old enough for squash, any type of re-ordering is allowed. 
- So the fix is simply adding a bound of the highest cleaned slot, and only allowing squash up to that slot. 
- Code removal will follow 

- Also note: Even under the scenario that squash is blocked, it doesn't effect storage sizes, it just effects the number of storages. Shrink still runs on storages in this range. Although, I don't know if shrink would have much to do if clean is still blocked.  

#### Testing
- Tested on mainnet, all counters are still zero even with RPC scans. Not sure what else would be useful. 

Fixes #
