### PR TITLE
votor-transport: improve send error stats

### DIFF
--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -352,17 +352,15 @@ impl OutboundLoop {
                     self.stats.connection_lost.fetch_add(1, Ordering::Relaxed);
                     dead_peers.push(*peer);
                 }
-                Err(SendDatagramError::UnsupportedByPeer) => {
-                    debug!("OutboundLoop: peer {peer} does not support datagrams.");
-                    // The wrong-direction reader holds a clone, so close explicitly before removal.
-                    close_codes::NORMAL_CLOSE.close(connection);
-                    // reconnecting is not likely to help, but it is the least we can do
-                    self.stats.connect_failed.fetch_add(1, Ordering::Relaxed);
-                    dead_peers.push(*peer);
-                }
-                Err(SendDatagramError::TooLarge) => {
-                    error!("Votor message too large and does not fit into transport MTU");
-                    debug_assert!(false, "Votor message too large ({} bytes)", message.len());
+                // The peer either does not support datagrams or advertises max size below our
+                // message size. Both are misconfigurations that reconnecting will not fix,
+                // so keep the connection to avoid churn but report errors for visibility.
+                Err(e @ (SendDatagramError::UnsupportedByPeer | SendDatagramError::TooLarge)) => {
+                    debug!(
+                        "OutboundLoop: peer {peer} refused a {} byte datagram: {e}",
+                        message.len()
+                    );
+                    self.stats.peer_config_error.fetch_add(1, Ordering::Relaxed);
                 }
                 Err(SendDatagramError::Disabled) => {
                     unreachable!("By construction (we enable datagrams)");

--- a/votor-transport/src/stats.rs
+++ b/votor-transport/src/stats.rs
@@ -21,6 +21,10 @@ pub struct ClientStats {
     pub(crate) connect_failed: AtomicU64,
     /// A peer in the peer_list had no resolvable address.
     pub(crate) connect_failed_no_address: AtomicU64,
+    /// Datagrams dropped because the peer does not accept them: datagrams
+    /// disabled, or a size limit below our message. The connection is kept, so
+    /// this counts sends, not peers.
+    pub(crate) peer_config_error: AtomicU64,
     /// Connections closed because the local identity changed.
     pub(crate) connection_closed_identity_changed: AtomicU64,
     /// Existing connection closed because the peer's gossip address changed.
@@ -163,6 +167,7 @@ impl ClientStats {
         let datagrams_sent = swap(&self.datagrams_sent);
         let connect_failed = swap(&self.connect_failed);
         let connect_failed_no_address = swap(&self.connect_failed_no_address);
+        let peer_config_error = swap(&self.peer_config_error);
         let connection_lost = swap(&self.connection_lost);
         let connection_closed_peer_moved = swap(&self.connection_closed_peer_moved);
         let connection_closed_not_in_peer_list = swap(&self.connection_closed_not_in_peer_list);
@@ -173,6 +178,7 @@ impl ClientStats {
             ("datagrams_sent", datagrams_sent, i64),
             ("connect_failed", connect_failed, i64),
             ("connect_failed_no_address", connect_failed_no_address, i64),
+            ("peer_config_error", peer_config_error, i64),
             ("connection_lost", connection_lost, i64),
             (
                 "connection_closed_peer_moved",


### PR DESCRIPTION
#### Problem
Consistently report peer datagram misconfiguration in metrics.
https://github.com/anza-xyz/agave/pull/14673 got reverted due to poor taste in metric naming

#### Summary of Changes

Report remote peer votor-transport implementation misconfigs as  "peer_config_error" metric.
Reduce spam in logs.

#### Testing

CI
