### PR TITLE
refactor(cost-model): decouple transaction costs from transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7949,7 +7949,6 @@ dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
  "ahash 0.8.12",
- "itertools 0.15.0",
  "log",
  "solana-bincode",
  "solana-compute-budget",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7965,7 +7965,6 @@ dependencies = [
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
  "solana-sdk-ids",
- "solana-signature",
  "solana-signer",
  "solana-svm-transaction",
  "solana-system-interface 3.3.0",

--- a/conformance/src/cost.rs
+++ b/conformance/src/cost.rs
@@ -88,10 +88,7 @@ fn runtime_transaction_from_proto(
     .expect("failed to create RuntimeTransaction")
 }
 
-fn cost_result_to_proto<Tx>(cost: &TransactionCost<'_, Tx>) -> ProtoCostResult
-where
-    Tx: solana_runtime_transaction::transaction_meta::TransactionMeta,
-{
+fn cost_result_to_proto(cost: &TransactionCost) -> ProtoCostResult {
     ProtoCostResult {
         has_cost: true,
         signature_cost: cost.signature_cost(),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -236,6 +236,7 @@ impl Consumer {
         // were not included in the block should have their cost removed, the rest
         // should update with their actually consumed units.
         QosService::remove_or_update_costs(
+            txs.iter(),
             transaction_qos_cost_results.iter(),
             commit_transactions_result.as_ref().ok(),
             bank,

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -11,7 +11,7 @@ use {
         cost_model::CostModel, cost_tracker::UpdatedCosts, transaction_cost::TransactionCost,
     },
     solana_runtime::bank::Bank,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::transaction_with_meta::{TransactionWithMeta, writable_accounts},
     solana_transaction_error::TransactionError,
 };
 
@@ -19,9 +19,8 @@ mod transaction {
     pub use solana_transaction_error::TransactionResult as Result;
 }
 
-type TransactionCostResults<'a, Tx> = SmallVec<
-    [transaction::Result<TransactionCost<'a, Tx>>;
-        super::consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH],
+type TransactionCostResults = SmallVec<
+    [transaction::Result<TransactionCost>; super::consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH],
 >;
 
 // QosService is local to each banking thread, each instance of QosService provides services to
@@ -36,11 +35,11 @@ impl QosService {
     /// include in the slot, and accumulate costs in the cost tracker.
     /// Returns a vector of results containing selected transaction costs, and the number of
     /// transactions that were *NOT* selected.
-    pub fn select_and_accumulate_transaction_costs<'a, Tx: TransactionWithMeta>(
+    pub fn select_and_accumulate_transaction_costs<Tx: TransactionWithMeta>(
         bank: &Bank,
-        transactions: &'a [Tx],
+        transactions: &[Tx],
         pre_results: impl Iterator<Item = transaction::Result<()>>,
-    ) -> (TransactionCostResults<'a, Tx>, u64) {
+    ) -> (TransactionCostResults, u64) {
         let transaction_costs =
             Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
         let (transactions_qos_cost_results, num_included) =
@@ -56,11 +55,11 @@ impl QosService {
 
     // invoke cost_model to calculate cost for the given list of transactions that have not
     // been filtered out already.
-    fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
+    fn compute_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
         feature_set: &FeatureSet,
         transactions: impl Iterator<Item = &'a Tx>,
         pre_results: impl Iterator<Item = transaction::Result<()>>,
-    ) -> TransactionCostResults<'a, Tx> {
+    ) -> TransactionCostResults {
         transactions
             .zip(pre_results)
             .map(|(tx, pre_result)| {
@@ -82,11 +81,11 @@ impl QosService {
     /// Given a list of transactions and their costs, this function returns a corresponding
     /// list of Results that indicate if a transaction is selected to be included in the current block,
     /// and a count of the number of transactions that would fit in the block
-    fn select_transactions_per_cost<'a, Tx: TransactionWithMeta>(
+    fn select_transactions_per_cost<'a, Tx: TransactionWithMeta + 'a>(
         transactions: impl Iterator<Item = &'a Tx>,
-        mut transactions_costs: TransactionCostResults<'a, Tx>,
+        mut transactions_costs: TransactionCostResults,
         bank: &Bank,
-    ) -> (TransactionCostResults<'a, Tx>, usize) {
+    ) -> (TransactionCostResults, usize) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut num_included = 0;
         transactions
@@ -96,7 +95,7 @@ impl QosService {
                     return;
                 };
 
-                match cost_tracker.try_add(cost) {
+                match cost_tracker.try_add(cost, writable_accounts(tx)) {
                     Ok(UpdatedCosts {
                         updated_block_cost,
                         updated_costliest_account_cost,
@@ -133,34 +132,42 @@ impl QosService {
     /// Removes transaction costs from the cost tracker if not committed or recorded, or
     /// updates the transaction costs for committed transactions.
     pub fn remove_or_update_costs<'a, Tx: TransactionWithMeta + 'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        transactions: impl Iterator<Item = &'a Tx>,
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
         bank: &Bank,
     ) {
         match transaction_committed_status {
             Some(transaction_committed_status) => {
                 Self::remove_or_update_recorded_transaction_costs(
+                    transactions,
                     transaction_cost_results,
                     transaction_committed_status,
                     bank,
                 )
             }
-            None => Self::remove_unrecorded_transaction_costs(transaction_cost_results, bank),
+            None => Self::remove_unrecorded_transaction_costs(
+                transactions,
+                transaction_cost_results,
+                bank,
+            ),
         }
     }
 
     /// For recorded transactions, remove units reserved by uncommitted transaction, or update
     /// units for committed transactions.
     fn remove_or_update_recorded_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        transactions: impl Iterator<Item = &'a Tx>,
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         transaction_committed_status: &Vec<CommitTransactionDetails>,
         bank: &Bank,
     ) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut num_included = 0;
-        transaction_cost_results
+        transactions
+            .zip(transaction_cost_results)
             .zip(transaction_committed_status)
-            .for_each(|(tx_cost, transaction_committed_details)| {
+            .for_each(|((transaction, tx_cost), transaction_committed_details)| {
                 // Only transactions that the qos service included have to be
                 // checked for update
                 if let Ok(tx_cost) = tx_cost {
@@ -172,17 +179,23 @@ impl QosService {
                             result: _,
                             fee_payer_post_balance: _,
                         } => {
-                            cost_tracker.update_execution_cost(
-                                tx_cost,
-                                *compute_units,
+                            let estimated_load_and_execution_units = tx_cost
+                                .programs_execution_cost()
+                                .saturating_add(tx_cost.loaded_accounts_data_size_cost());
+                            let actual_load_and_execution_units = compute_units.saturating_add(
                                 CostModel::calculate_loaded_accounts_data_size_cost(
                                     *loaded_accounts_data_size,
                                     &bank.feature_set,
                                 ),
                             );
+                            cost_tracker.update_cost(
+                                estimated_load_and_execution_units,
+                                actual_load_and_execution_units,
+                                writable_accounts(transaction),
+                            );
                         }
                         CommitTransactionDetails::NotCommitted(_err) => {
-                            cost_tracker.remove(tx_cost);
+                            cost_tracker.remove(tx_cost, writable_accounts(transaction));
                         }
                     }
                 }
@@ -192,19 +205,22 @@ impl QosService {
 
     /// Remove reserved units for transaction batch that unsuccessfully recorded.
     fn remove_unrecorded_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
-        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        transactions: impl Iterator<Item = &'a Tx>,
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost>>,
         bank: &Bank,
     ) {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         let mut num_included = 0;
-        transaction_cost_results.for_each(|tx_cost| {
-            // Only transactions that the qos service included have to be
-            // removed
-            if let Ok(tx_cost) = tx_cost {
-                num_included += 1;
-                cost_tracker.remove(tx_cost);
-            }
-        });
+        transactions
+            .zip(transaction_cost_results)
+            .for_each(|(transaction, tx_cost)| {
+                // Only transactions that the qos service included have to be
+                // removed
+                if let Ok(tx_cost) = tx_cost {
+                    num_included += 1;
+                    cost_tracker.remove(tx_cost, writable_accounts(transaction));
+                }
+            });
         cost_tracker.sub_transactions_in_flight(num_included);
     }
 }
@@ -376,6 +392,7 @@ mod tests {
                     * transaction_count;
 
             QosService::remove_or_update_costs(
+                txs.iter(),
                 qos_cost_results.iter(),
                 Some(&committed_status),
                 &bank,
@@ -430,7 +447,7 @@ mod tests {
                 bank.read_cost_tracker().unwrap().block_cost()
             );
 
-            QosService::remove_or_update_costs(qos_cost_results.iter(), None, &bank);
+            QosService::remove_or_update_costs(txs.iter(), qos_cost_results.iter(), None, &bank);
             assert_eq!(0, bank.read_cost_tracker().unwrap().block_cost());
             assert_eq!(0, bank.read_cost_tracker().unwrap().transaction_count());
         }
@@ -505,6 +522,7 @@ mod tests {
                 .collect();
 
             QosService::remove_or_update_costs(
+                txs.iter(),
                 qos_cost_results.iter(),
                 Some(&committed_status),
                 &bank,
@@ -603,6 +621,7 @@ mod tests {
                 })
                 .collect();
             QosService::remove_or_update_costs(
+                txs.iter(),
                 qos_cost_results.iter(),
                 Some(&committed_status),
                 &bank,
@@ -655,6 +674,7 @@ mod tests {
                 })
                 .collect();
             QosService::remove_or_update_costs(
+                txs.iter(),
                 qos_cost_results.iter(),
                 Some(&committed_status),
                 &bank,

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -24,7 +24,6 @@ agave-unstable-api = []
 dev-context-only-utils = [
     "dep:solana-hash",
     "dep:solana-message",
-    "dep:solana-signature",
     "dep:solana-transaction",
     "solana-compute-budget-interface/dev-context-only-utils",
 ]
@@ -53,7 +52,6 @@ solana-packet = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-signature = { workspace = true, optional = true }
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, optional = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -61,7 +61,6 @@ solana-vote-program = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
-itertools = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-hash = { workspace = true, features = ["atomic"] }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -33,10 +33,10 @@ enum SystemProgramAccountAllocation {
 }
 
 impl CostModel {
-    pub fn calculate_cost<'a, Tx: TransactionMeta + SVMStaticMessage>(
-        transaction: &'a Tx,
+    pub fn calculate_cost<Tx: TransactionMeta + SVMStaticMessage>(
+        transaction: &Tx,
         feature_set: &FeatureSet,
-    ) -> TransactionCost<'a, Tx> {
+    ) -> TransactionCost {
         let (programs_execution_cost, loaded_accounts_data_size_cost) =
             Self::get_estimated_execution_cost(transaction, feature_set);
         let data_bytes_cost = Self::get_instructions_data_cost(transaction);
@@ -53,12 +53,12 @@ impl CostModel {
 
     // Calculate executed transaction CU cost, with actual execution and loaded accounts size
     // costs.
-    pub fn calculate_cost_for_executed_transaction<'a, Tx: TransactionMeta + SVMStaticMessage>(
-        transaction: &'a Tx,
+    pub fn calculate_cost_for_executed_transaction<Tx: TransactionMeta + SVMStaticMessage>(
+        transaction: &Tx,
         actual_programs_execution_cost: u64,
         actual_loaded_accounts_data_size_bytes: u32,
         feature_set: &FeatureSet,
-    ) -> TransactionCost<'a, Tx> {
+    ) -> TransactionCost {
         let loaded_accounts_data_size_cost = Self::calculate_loaded_accounts_data_size_cost(
             actual_loaded_accounts_data_size_bytes,
             feature_set,
@@ -81,11 +81,11 @@ impl CostModel {
     /// - `instructions` - transaction instructions
     /// - `num_write_locks` - number of requested write locks
     pub fn estimate_cost<'a, Tx: TransactionMeta>(
-        transaction: &'a Tx,
+        transaction: &Tx,
         instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
         feature_set: &FeatureSet,
-    ) -> TransactionCost<'a, Tx> {
+    ) -> TransactionCost {
         let (programs_execution_cost, loaded_accounts_data_size_cost) =
             Self::get_estimated_execution_cost(transaction, feature_set);
         let data_bytes_cost = Self::get_instructions_data_cost(transaction);
@@ -101,14 +101,14 @@ impl CostModel {
     }
 
     fn calculate_transaction_cost<'a, Tx: TransactionMeta>(
-        transaction: &'a Tx,
+        transaction: &Tx,
         instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
         num_write_locks: u64,
         programs_execution_cost: u64,
         loaded_accounts_data_size_cost: u64,
         data_bytes_cost: u16,
         feature_set: &FeatureSet,
-    ) -> TransactionCost<'a, Tx> {
+    ) -> TransactionCost {
         let signature_cost = Self::get_signature_cost(transaction);
         let write_lock_cost = Self::get_write_lock_cost(num_write_locks);
 
@@ -116,7 +116,6 @@ impl CostModel {
             Self::calculate_allocated_accounts_data_size(instructions, feature_set);
 
         TransactionCost {
-            transaction,
             signature_cost,
             write_lock_cost,
             data_bytes_cost,
@@ -305,7 +304,6 @@ impl CostModel {
 mod tests {
     use {
         super::*,
-        itertools::Itertools,
         solana_compute_budget::{
             self,
             compute_budget_limits::{
@@ -317,7 +315,9 @@ mod tests {
         solana_instruction::Instruction,
         solana_keypair::Keypair,
         solana_message::{Message, compiled_instruction::CompiledInstruction},
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction, transaction_with_meta::writable_accounts,
+        },
         solana_sdk_ids::{compute_budget, system_program},
         solana_signer::Signer,
         solana_svm_transaction::svm_message::SVMStaticMessage,
@@ -621,7 +621,7 @@ mod tests {
         // write-lock counts towards cost, even if it is demoted.
         let tx_cost = CostModel::calculate_cost(&simple_transaction, &FeatureSet::default());
         assert_eq!(2 * WRITE_LOCK_UNITS, tx_cost.write_lock_cost());
-        assert_eq!(1, tx_cost.writable_accounts().count());
+        assert_eq!(1, writable_accounts(&simple_transaction).count());
     }
 
     #[test]
@@ -767,38 +767,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cost_model_sort_message_accounts_by_type() {
-        // construct a transaction with two random instructions with same signer
-        let signer1 = Keypair::new();
-        let signer2 = Keypair::new();
-        let key1 = Pubkey::new_unique();
-        let key2 = Pubkey::new_unique();
-        let prog1 = Pubkey::new_unique();
-        let prog2 = Pubkey::new_unique();
-        let instructions = vec![
-            CompiledInstruction::new(4, &(), vec![0, 2]),
-            CompiledInstruction::new(5, &(), vec![1, 3]),
-        ];
-        let tx = RuntimeTransaction::from_transaction_for_tests(
-            Transaction::new_with_compiled_instructions(
-                &[&signer1, &signer2],
-                &[key1, key2],
-                Hash::new_unique(),
-                vec![prog1, prog2],
-                instructions,
-            ),
-        );
-
-        let tx_cost = CostModel::calculate_cost(&tx, &FeatureSet::all_enabled());
-        let writable_accounts = tx_cost.writable_accounts().collect_vec();
-        assert_eq!(2 + 2, writable_accounts.len());
-        assert_eq!(signer1.pubkey(), *writable_accounts[0]);
-        assert_eq!(signer2.pubkey(), *writable_accounts[1]);
-        assert_eq!(key1, *writable_accounts[2]);
-        assert_eq!(key2, *writable_accounts[3]);
-    }
-
-    #[test]
     fn test_cost_model_calculate_cost_all_default() {
         let (mint_keypair, start_hash) = test_setup();
         let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -821,7 +789,6 @@ mod tests {
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
         assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
         assert_eq!(expected_execution_cost, tx_cost.programs_execution_cost());
-        assert_eq!(2, tx_cost.writable_accounts().count());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
             tx_cost.loaded_accounts_data_size_cost()
@@ -852,7 +819,6 @@ mod tests {
         let tx_cost = CostModel::calculate_cost(&tx, &feature_set);
         assert_eq!(expected_account_cost, tx_cost.write_lock_cost());
         assert_eq!(expected_execution_cost, tx_cost.programs_execution_cost());
-        assert_eq!(2, tx_cost.writable_accounts().count());
         assert_eq!(
             expected_loaded_accounts_data_size_cost,
             tx_cost.loaded_accounts_data_size_cost()

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -7,7 +7,6 @@ use {
         transaction_cost::TransactionCost,
     },
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_transaction_error::TransactionError,
     std::{
         collections::{HashMap, hash_map::Entry},
@@ -189,11 +188,12 @@ impl CostTracker {
     /// Account costs applied before the failing account are rolled back,
     /// and the block-level state (including the lock free shared `block_cost`)
     /// is only published after every check has passed.
-    pub fn try_add(
+    pub fn try_add<'a>(
         &mut self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        transaction_cost: &TransactionCost,
+        writable_accounts: impl Iterator<Item = &'a Pubkey> + Clone,
     ) -> Result<UpdatedCosts, CostTrackerError> {
-        let cost = tx_cost.sum();
+        let cost = transaction_cost.sum();
 
         if self.block_cost().saturating_add(cost) > self.limits.block_cost {
             // check against the total package cost
@@ -208,7 +208,7 @@ impl CostTracker {
         let allocated_accounts_data_size = self
             .allocated_accounts_data_size
             .load()
-            .saturating_add(tx_cost.allocated_accounts_data_size());
+            .saturating_add(transaction_cost.allocated_accounts_data_size());
 
         if allocated_accounts_data_size > self.limits.allocated_data_size {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
@@ -217,7 +217,7 @@ impl CostTracker {
         // Check each account against account_cost_limit and apply the cost in
         // the same lookup. On failure, undo the applied prefix.
         let mut updated_costliest_account_cost = 0;
-        for (index, account_key) in tx_cost.writable_accounts().enumerate() {
+        for (index, account_key) in writable_accounts.clone().enumerate() {
             let new_account_cost = match self.cost_by_writable_accounts.entry(*account_key) {
                 Entry::Occupied(mut entry) => {
                     let new_account_cost = entry.get().saturating_add(cost);
@@ -237,7 +237,7 @@ impl CostTracker {
             };
             let Some(new_account_cost) = new_account_cost else {
                 // the first `index` accounts were applied before this failure
-                self.roll_back_applied_costs(tx_cost, cost, index);
+                self.roll_back_applied_costs(writable_accounts, cost, index);
                 return Err(CostTrackerError::WouldExceedAccountMaxLimit);
             };
             updated_costliest_account_cost = updated_costliest_account_cost.max(new_account_cost);
@@ -255,30 +255,20 @@ impl CostTracker {
         })
     }
 
-    pub fn update_execution_cost(
+    /// Updates tracked cost by the difference between corresponding old and new cost components.
+    pub fn update_cost<'a>(
         &mut self,
-        estimated_tx_cost: &TransactionCost<impl TransactionWithMeta>,
-        actual_execution_units: u64,
-        actual_loaded_accounts_data_size_cost: u64,
+        old_cost_component: u64,
+        new_cost_component: u64,
+        writable_accounts: impl Iterator<Item = &'a Pubkey>,
     ) {
-        let actual_load_and_execution_units =
-            actual_execution_units.saturating_add(actual_loaded_accounts_data_size_cost);
-        let estimated_load_and_execution_units = estimated_tx_cost
-            .programs_execution_cost()
-            .saturating_add(estimated_tx_cost.loaded_accounts_data_size_cost());
-        match actual_load_and_execution_units.cmp(&estimated_load_and_execution_units) {
+        match new_cost_component.cmp(&old_cost_component) {
             std::cmp::Ordering::Equal => (),
             std::cmp::Ordering::Greater => {
-                self.add_transaction_execution_cost(
-                    estimated_tx_cost,
-                    actual_load_and_execution_units - estimated_load_and_execution_units,
-                );
+                self.add_cost(writable_accounts, new_cost_component - old_cost_component);
             }
             std::cmp::Ordering::Less => {
-                self.sub_transaction_execution_cost(
-                    estimated_tx_cost,
-                    estimated_load_and_execution_units - actual_load_and_execution_units,
-                );
+                self.sub_cost(writable_accounts, old_cost_component - new_cost_component);
             }
         }
     }
@@ -286,13 +276,13 @@ impl CostTracker {
     /// Undoes the first `num_applied` per account cost applications of a
     /// partially applied transaction by subtracting the cost each one added.
     /// Entries left with zero cost are removed.
-    fn roll_back_applied_costs(
+    fn roll_back_applied_costs<'a>(
         &mut self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        writable_accounts: impl Iterator<Item = &'a Pubkey>,
         cost: u64,
         num_applied: usize,
     ) {
-        for account_key in tx_cost.writable_accounts().take(num_applied) {
+        for account_key in writable_accounts.take(num_applied) {
             if let Entry::Occupied(mut entry) = self.cost_by_writable_accounts.entry(*account_key) {
                 let new_account_cost = entry.get().saturating_sub(cost);
                 if new_account_cost == 0 {
@@ -304,8 +294,18 @@ impl CostTracker {
         }
     }
 
-    pub fn remove(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
-        self.remove_transaction_cost(tx_cost);
+    pub fn remove<'a>(
+        &mut self,
+        transaction_cost: &TransactionCost,
+        writable_accounts: impl Iterator<Item = &'a Pubkey>,
+    ) {
+        self.sub_cost(writable_accounts, transaction_cost.sum());
+        self.allocated_accounts_data_size.store(
+            self.allocated_accounts_data_size
+                .load()
+                .saturating_sub(transaction_cost.allocated_accounts_data_size()),
+        );
+        self.transaction_count -= 1;
     }
 
     pub fn block_cost(&self) -> u64 {
@@ -360,24 +360,12 @@ impl CostTracker {
             .count()
     }
 
-    fn remove_transaction_cost(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
-        let cost = tx_cost.sum();
-        self.sub_transaction_execution_cost(tx_cost, cost);
-        self.allocated_accounts_data_size.store(
-            self.allocated_accounts_data_size
-                .load()
-                .saturating_sub(tx_cost.allocated_accounts_data_size()),
-        );
-        self.transaction_count -= 1;
-    }
-
-    /// Apply additional actual execution units to cost_tracker.
-    fn add_transaction_execution_cost(
+    fn add_cost<'a>(
         &mut self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        writable_accounts: impl Iterator<Item = &'a Pubkey>,
         adjustment: u64,
     ) {
-        for account_key in tx_cost.writable_accounts() {
+        for account_key in writable_accounts {
             let account_cost = self
                 .cost_by_writable_accounts
                 .entry(*account_key)
@@ -387,13 +375,12 @@ impl CostTracker {
         self.block_cost.fetch_add(adjustment);
     }
 
-    /// Subtract extra execution units from cost_tracker
-    fn sub_transaction_execution_cost(
+    fn sub_cost<'a>(
         &mut self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        writable_accounts: impl Iterator<Item = &'a Pubkey>,
         adjustment: u64,
     ) {
-        for account_key in tx_cost.writable_accounts() {
+        for account_key in writable_accounts {
             let account_cost = self
                 .cost_by_writable_accounts
                 .entry(*account_key)
@@ -465,13 +452,18 @@ impl SharedAllocatedAccountsDataSize {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::transaction_cost::{WritableKeysTransaction, *},
-        solana_keypair::Keypair,
-        solana_signer::Signer,
-        std::cmp,
-    };
+    use {super::*, std::cmp};
+
+    fn test_cost(cost_units: u64) -> TransactionCost {
+        TransactionCost {
+            signature_cost: 0,
+            write_lock_cost: 0,
+            data_bytes_cost: 0,
+            programs_execution_cost: cost_units,
+            loaded_accounts_data_size_cost: 0,
+            allocated_accounts_data_size: 0,
+        }
+    }
 
     impl CostTracker {
         fn new(account_cost_limit: u64, block_cost_limit: u64) -> Self {
@@ -486,49 +478,13 @@ mod tests {
         }
     }
 
-    fn test_setup() -> Keypair {
+    fn test_setup() -> Pubkey {
         agave_logger::setup();
-        Keypair::new()
+        Pubkey::new_unique()
     }
 
-    fn build_simple_transaction(mint_keypair: &Keypair) -> WritableKeysTransaction {
-        WritableKeysTransaction::new(vec![mint_keypair.pubkey()])
-    }
-
-    fn build_simple_vote_transaction(mint_keypair: &Keypair) -> WritableKeysTransaction {
-        WritableKeysTransaction {
-            writable_keys: vec![mint_keypair.pubkey()],
-            is_simple_vote: true,
-        }
-    }
-
-    fn simple_transaction_cost(
-        transaction: &WritableKeysTransaction,
-        programs_execution_cost: u64,
-    ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost {
-            transaction,
-            signature_cost: 0,
-            write_lock_cost: 0,
-            data_bytes_cost: 0,
-            programs_execution_cost,
-            loaded_accounts_data_size_cost: 0,
-            allocated_accounts_data_size: 0,
-        }
-    }
-
-    fn simple_vote_transaction_cost(
-        transaction: &WritableKeysTransaction,
-    ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost {
-            transaction,
-            signature_cost: 1,
-            write_lock_cost: 2,
-            data_bytes_cost: 0,
-            programs_execution_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
-            loaded_accounts_data_size_cost: 8,
-            allocated_accounts_data_size: 0,
-        }
+    fn vote_cost() -> u64 {
+        1 + 2 + solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS + 8
     }
 
     #[test]
@@ -543,13 +499,12 @@ mod tests {
     #[test]
     fn test_cost_tracker_ok_add_one() {
         let mint_keypair = test_setup();
-        let tx = build_simple_transaction(&mint_keypair);
-        let tx_cost = simple_transaction_cost(&tx, 5);
-        let cost = tx_cost.sum();
+        let accts = [mint_keypair];
+        let cost = 5;
 
-        // build testee to have capacity for one simple transaction
+        // build testee to have capacity for one cost
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         assert_eq!(cost, testee.block_cost());
         let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost, costliest_account_cost);
@@ -558,13 +513,12 @@ mod tests {
     #[test]
     fn test_cost_tracker_ok_add_one_vote() {
         let mint_keypair = test_setup();
-        let tx = build_simple_vote_transaction(&mint_keypair);
-        let tx_cost = simple_vote_transaction_cost(&tx);
-        let cost = tx_cost.sum();
+        let accts = [mint_keypair];
+        let cost = vote_cost();
 
-        // build testee to have capacity for one simple transaction
+        // build testee to have capacity for one cost
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         assert_eq!(cost, testee.block_cost());
         let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost, costliest_account_cost);
@@ -573,37 +527,37 @@ mod tests {
     #[test]
     fn test_cost_tracker_add_data() {
         let mint_keypair = test_setup();
-        let tx = build_simple_transaction(&mint_keypair);
-        let mut tx_cost = simple_transaction_cost(&tx, 5);
-        tx_cost.allocated_accounts_data_size = 1;
-        let cost = tx_cost.sum();
+        let accts = [mint_keypair];
+        let cost = 5;
+        let transaction_cost = TransactionCost {
+            allocated_accounts_data_size: 1,
+            ..test_cost(cost)
+        };
 
-        // build testee to have capacity for one simple transaction
+        // build testee to have capacity for one cost
         let mut testee = CostTracker::new(cost, cost);
         let shared_allocated_accounts_data_size = testee.shared_allocated_accounts_data_size();
         let old = shared_allocated_accounts_data_size.load();
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&transaction_cost, accts.iter()).is_ok());
         assert_eq!(old + 1, shared_allocated_accounts_data_size.load());
     }
 
     #[test]
     fn test_cost_tracker_ok_add_two_same_accounts() {
         let mint_keypair = test_setup();
-        // build two transactions with same signed account
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let cost1 = tx_cost1.sum();
-        let tx2 = build_simple_transaction(&mint_keypair);
-        let tx_cost2 = simple_transaction_cost(&tx2, 5);
-        let cost2 = tx_cost2.sum();
+        // use the same writable account for both costs
+        let accts1 = [mint_keypair];
+        let cost1 = 5;
+        let accts2 = [mint_keypair];
+        let cost2 = 5;
 
-        // build testee to have capacity for two simple transactions, with same accounts
+        // build testee to have capacity for both costs on the same account
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2);
         {
-            assert!(testee.try_add(&tx_cost1).is_ok());
+            assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         }
         {
-            assert!(testee.try_add(&tx_cost2).is_ok());
+            assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_ok());
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
         assert_eq!(1, testee.cost_by_writable_accounts.len());
@@ -614,23 +568,21 @@ mod tests {
     #[test]
     fn test_cost_tracker_ok_add_two_diff_accounts() {
         let mint_keypair = test_setup();
-        // build two transactions with diff accounts
-        let second_account = Keypair::new();
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let cost1 = tx_cost1.sum();
+        // use a different writable account for each cost
+        let second_account = Pubkey::new_unique();
+        let accts1 = [mint_keypair];
+        let cost1 = 5;
 
-        let tx2 = build_simple_transaction(&second_account);
-        let tx_cost2 = simple_transaction_cost(&tx2, 5);
-        let cost2 = tx_cost2.sum();
+        let accts2 = [second_account];
+        let cost2 = 5;
 
-        // build testee to have capacity for two simple transactions, with same accounts
+        // build testee to have capacity for both costs
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
         {
-            assert!(testee.try_add(&tx_cost1).is_ok());
+            assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         }
         {
-            assert!(testee.try_add(&tx_cost2).is_ok());
+            assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_ok());
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
         assert_eq!(2, testee.cost_by_writable_accounts.len());
@@ -641,106 +593,120 @@ mod tests {
     #[test]
     fn test_cost_tracker_chain_reach_limit() {
         let mint_keypair = test_setup();
-        // build two transactions with same signed account
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let cost1 = tx_cost1.sum();
-        let tx2 = build_simple_transaction(&mint_keypair);
-        let tx_cost2 = simple_transaction_cost(&tx2, 5);
-        let cost2 = tx_cost2.sum();
+        // use the same writable account for both costs
+        let accts1 = [mint_keypair];
+        let cost1 = 5;
+        let accts2 = [mint_keypair];
+        let cost2 = 5;
 
-        // build testee to have capacity for two simple transactions, but not for same accounts
+        // build testee to have block capacity for both costs, but account capacity for only one
         let mut testee = CostTracker::new(cmp::min(cost1, cost2), cost1 + cost2);
-        // should have room for first transaction
+        // should have room for the first cost
         {
-            assert!(testee.try_add(&tx_cost1).is_ok());
+            assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         }
         // but no more sapce on the same chain (same signer account)
         {
-            assert!(testee.try_add(&tx_cost2).is_err());
+            assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_err());
         }
     }
 
     #[test]
     fn test_cost_tracker_reach_limit() {
         let mint_keypair = test_setup();
-        // build two transactions with diff accounts
-        let second_account = Keypair::new();
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let cost1 = tx_cost1.sum();
-        let tx2 = build_simple_transaction(&second_account);
-        let tx_cost2 = simple_transaction_cost(&tx2, 5);
-        let cost2 = tx_cost2.sum();
+        // use a different writable account for each cost
+        let second_account = Pubkey::new_unique();
+        let accts1 = [mint_keypair];
+        let cost1 = 5;
+        let accts2 = [second_account];
+        let cost2 = 5;
 
-        // build testee to have capacity for each chain, but not enough room for both transactions
+        // build testee with account capacity for each cost, but insufficient block capacity for both
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1);
-        // should have room for first transaction
+        // should have room for the first cost
         {
-            assert!(testee.try_add(&tx_cost1).is_ok());
+            assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         }
         // but no more room for package as whole
         {
-            assert!(testee.try_add(&tx_cost2).is_err());
+            assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_err());
         }
     }
 
     #[test]
     fn test_cost_tracker_vote_transactions_use_regular_limits() {
         let mint_keypair = test_setup();
-        // build two mocking vote transactions with diff accounts
-        let second_account = Keypair::new();
-        let tx1 = build_simple_vote_transaction(&mint_keypair);
-        let tx_cost1 = simple_vote_transaction_cost(&tx1);
-        let cost1 = tx_cost1.sum();
-        let tx2 = build_simple_vote_transaction(&second_account);
-        let tx_cost2 = simple_vote_transaction_cost(&tx2);
-        let cost2 = tx_cost2.sum();
+        // use a different writable account for each vote cost
+        let second_account = Pubkey::new_unique();
+        let accts1 = [mint_keypair];
+        let cost1 = vote_cost();
+        let accts2 = [second_account];
+        let cost2 = vote_cost();
 
-        // build testee to have capacity for both vote transactions
+        // build testee to have capacity for both vote costs
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
         // should have room for first vote
         {
-            assert!(testee.try_add(&tx_cost1).is_ok());
+            assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         }
-        assert!(testee.try_add(&tx_cost2).is_ok());
+        assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_ok());
     }
 
     #[test]
     fn test_cost_tracker_reach_data_block_limit() {
         let mint_keypair = test_setup();
-        // build two transactions with diff accounts
-        let second_account = Keypair::new();
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let mut tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let tx2 = build_simple_transaction(&second_account);
-        let mut tx_cost2 = simple_transaction_cost(&tx2, 5);
-        tx_cost1.allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
-        tx_cost2.allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA + 1;
-        let cost1 = tx_cost1.sum();
-        let cost2 = tx_cost2.sum();
+        // use a different writable account for each cost
+        let second_account = Pubkey::new_unique();
+        let accts1 = [mint_keypair];
+        let accts2 = [second_account];
+        let cost1 = 5;
+        let cost2 = 5;
 
         // build testee that passes
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
-        assert!(testee.try_add(&tx_cost1).is_ok());
+        assert!(
+            testee
+                .try_add(
+                    &TransactionCost {
+                        allocated_accounts_data_size: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
+                        ..test_cost(cost1)
+                    },
+                    accts1.iter(),
+                )
+                .is_ok()
+        );
         // data is too big
         assert!(matches!(
-            testee.try_add(&tx_cost2),
+            testee.try_add(
+                &TransactionCost {
+                    allocated_accounts_data_size: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA + 1,
+                    ..test_cost(cost2)
+                },
+                accts2.iter(),
+            ),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
         ));
     }
 
     #[test]
     fn test_cost_tracker_respects_custom_allocated_data_size_limit() {
-        // Setup transaction that allocates 2 bytes.
+        // Set up a cost that allocates 2 bytes.
         let mint_keypair = test_setup();
-        let tx = build_simple_transaction(&mint_keypair);
-        let mut tx_cost = simple_transaction_cost(&tx, 5);
-        tx_cost.allocated_accounts_data_size = 2;
+        let accts = [mint_keypair];
 
         // Transaction fits with default limit.
         let mut testee = CostTracker::new(u64::MAX, u64::MAX);
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(
+            testee
+                .try_add(
+                    &TransactionCost {
+                        allocated_accounts_data_size: 2,
+                        ..test_cost(5)
+                    },
+                    accts.iter(),
+                )
+                .is_ok()
+        );
 
         // Transaction does not fit with 1B limit.
         testee.set_limits(CostTrackerLimits {
@@ -748,7 +714,13 @@ mod tests {
             ..testee.get_limits()
         });
         assert!(matches!(
-            testee.try_add(&tx_cost),
+            testee.try_add(
+                &TransactionCost {
+                    allocated_accounts_data_size: 2,
+                    ..test_cost(5)
+                },
+                accts.iter(),
+            ),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
         ));
     }
@@ -756,32 +728,30 @@ mod tests {
     #[test]
     fn test_cost_tracker_remove() {
         let mint_keypair = test_setup();
-        // build two transactions with diff accounts
-        let second_account = Keypair::new();
-        let tx1 = build_simple_transaction(&mint_keypair);
-        let tx_cost1 = simple_transaction_cost(&tx1, 5);
-        let tx2 = build_simple_transaction(&second_account);
-        let tx_cost2 = simple_transaction_cost(&tx2, 5);
-        let cost1 = tx_cost1.sum();
-        let cost2 = tx_cost2.sum();
+        // use a different writable account for each cost
+        let second_account = Pubkey::new_unique();
+        let accts1 = [mint_keypair];
+        let accts2 = [second_account];
+        let cost1 = 5;
+        let cost2 = 5;
 
         // build testee
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2);
 
-        assert!(testee.try_add(&tx_cost1).is_ok());
-        assert!(testee.try_add(&tx_cost2).is_ok());
+        assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
+        assert!(testee.try_add(&test_cost(cost2), accts2.iter()).is_ok());
         assert_eq!(cost1 + cost2, testee.block_cost());
 
-        // removing a tx_cost affects block_cost
-        testee.remove(&tx_cost1);
+        // removing a cost affects block_cost
+        testee.remove(&test_cost(cost1), accts1.iter());
         assert_eq!(cost2, testee.block_cost());
 
-        // add back tx1
-        assert!(testee.try_add(&tx_cost1).is_ok());
+        // add back the first cost
+        assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_ok());
         assert_eq!(cost1 + cost2, testee.block_cost());
 
-        // cannot add tx1 again, cost limit would be exceeded
-        assert!(testee.try_add(&tx_cost1).is_err());
+        // cannot add the first cost again, cost limit would be exceeded
+        assert!(testee.try_add(&test_cost(cost1), accts1.iter()).is_err());
     }
 
     #[test]
@@ -795,30 +765,28 @@ mod tests {
 
         let mut testee = CostTracker::new(account_max, block_max);
 
-        // case 1: a tx writes to 3 accounts, should success, we will have:
+        // case 1: apply the cost to 3 accounts; we will have:
         // | acct1 | $cost |
         // | acct2 | $cost |
         // | acct3 | $cost |
         // and block_cost = $cost
         {
-            let transaction = WritableKeysTransaction::new(vec![acct1, acct2, acct3]);
-            let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_ok());
+            let accts = [acct1, acct2, acct3];
+            assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
             let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
             assert_eq!(cost, costliest_account_cost);
         }
 
-        // case 2: add tx writes to acct2 with $cost, should succeed, result to
+        // case 2: apply the cost to acct2, resulting in:
         // | acct1 | $cost |
         // | acct2 | $cost * 2 |
         // | acct3 | $cost |
         // and block_cost = $cost * 2
         {
-            let transaction = WritableKeysTransaction::new(vec![acct2]);
-            let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_ok());
+            let accts = [acct2];
+            assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost * 2, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
@@ -826,16 +794,15 @@ mod tests {
             assert_eq!(acct2, costliest_account);
         }
 
-        // case 3: add tx writes to [acct1, acct2], acct2 exceeds limit, should failed atomically,
+        // case 3: apply the cost to [acct1, acct2]; acct2 exceeds the limit, so this fails atomically,
         // we should still have:
         // | acct1 | $cost |
         // | acct2 | $cost * 2 |
         // | acct3 | $cost |
         // and block_cost = $cost * 2
         {
-            let transaction = WritableKeysTransaction::new(vec![acct1, acct2]);
-            let tx_cost = simple_transaction_cost(&transaction, cost);
-            assert!(testee.try_add(&tx_cost).is_err());
+            let accts = [acct1, acct2];
+            assert!(testee.try_add(&test_cost(cost), accts.iter()).is_err());
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
             assert_eq!(cost * 2, testee.block_cost());
             assert_eq!(3, testee.cost_by_writable_accounts.len());
@@ -845,15 +812,14 @@ mod tests {
             assert_eq!(Some(&cost), testee.cost_by_writable_accounts.get(&acct1));
         }
 
-        // case 4: add tx writes to [acct4 (unseen), acct2], acct2 exceeds limit;
+        // case 4: apply the cost to [acct4 (unseen), acct2]; acct2 exceeds the limit,
         // the entry freshly inserted for acct4 must be removed by the rollback,
         // leaving the tracker exactly as after case 2
         {
             let acct4 = Pubkey::new_unique();
-            let transaction = WritableKeysTransaction::new(vec![acct4, acct2]);
-            let tx_cost = simple_transaction_cost(&transaction, cost);
+            let accts = [acct4, acct2];
             assert!(matches!(
-                testee.try_add(&tx_cost),
+                testee.try_add(&test_cost(cost), accts.iter()),
                 Err(CostTrackerError::WouldExceedAccountMaxLimit)
             ));
             let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
@@ -872,20 +838,18 @@ mod tests {
         let mut testee = CostTracker::new(cost * 2, cost * 1000);
 
         // drive hot_account to the limit so the next charge fails
-        let transaction = WritableKeysTransaction::new(vec![hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
-        assert!(testee.try_add(&tx_cost).is_ok());
+        let accts = [hot_account];
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         let block_cost_before = testee.block_cost();
 
         // 100 fresh accounts followed by hot_account, all 100 fresh entries
         // are inserted before the failure at index 100
         let mut keys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
         keys.push(hot_account);
-        let transaction = WritableKeysTransaction::new(keys);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
+        let accts = keys;
         assert!(matches!(
-            testee.try_add(&tx_cost),
+            testee.try_add(&test_cost(cost), accts.iter()),
             Err(CostTrackerError::WouldExceedAccountMaxLimit)
         ));
 
@@ -907,33 +871,29 @@ mod tests {
         let mut testee = CostTracker::new(cost * 4, cost * 1000);
 
         // drive hot_account to the limit so any further charge fails
-        let transaction = WritableKeysTransaction::new(vec![hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
+        let accts = [hot_account];
         for _ in 0..4 {
-            assert!(testee.try_add(&tx_cost).is_ok());
+            assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         }
         let block_cost_before = testee.block_cost();
 
         // fresh dup - each undo subtracts what that occurrence added; the entry reaches zero on the second undo and is removed
-        let transaction = WritableKeysTransaction::new(vec![dup, dup, hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
+        let accts = [dup, dup, hot_account];
         assert!(matches!(
-            testee.try_add(&tx_cost),
+            testee.try_add(&test_cost(cost), accts.iter()),
             Err(CostTrackerError::WouldExceedAccountMaxLimit)
         ));
         assert!(!testee.cost_by_writable_accounts.contains_key(&dup));
         assert_eq!(block_cost_before, testee.block_cost());
 
         // pre-existing dup
-        let transaction = WritableKeysTransaction::new(vec![dup]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
+        let accts = [dup];
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         let block_cost_before = testee.block_cost();
 
-        let transaction = WritableKeysTransaction::new(vec![dup, dup, hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
+        let accts = [dup, dup, hot_account];
         assert!(matches!(
-            testee.try_add(&tx_cost),
+            testee.try_add(&test_cost(cost), accts.iter()),
             Err(CostTrackerError::WouldExceedAccountMaxLimit)
         ));
         assert_eq!(Some(&cost), testee.cost_by_writable_accounts.get(&dup));
@@ -948,23 +908,20 @@ mod tests {
         let mut testee = CostTracker::new(cost * 2, cost * 1000);
 
         // leave `zeroed` in the map with zero cost
-        let transaction = WritableKeysTransaction::new(vec![zeroed]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
-        testee.remove(&tx_cost);
+        let accts = [zeroed];
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
+        testee.remove(&test_cost(cost), accts.iter());
         assert_eq!(Some(&0), testee.cost_by_writable_accounts.get(&zeroed));
 
         // drive hot_account to the limit so the next charge fails
-        let transaction = WritableKeysTransaction::new(vec![hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        assert!(testee.try_add(&tx_cost).is_ok());
-        assert!(testee.try_add(&tx_cost).is_ok());
+        let accts = [hot_account];
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         let block_cost_before = testee.block_cost();
 
-        let transaction = WritableKeysTransaction::new(vec![zeroed, hot_account]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
+        let accts = [zeroed, hot_account];
         assert!(matches!(
-            testee.try_add(&tx_cost),
+            testee.try_add(&test_cost(cost), accts.iter()),
             Err(CostTrackerError::WouldExceedAccountMaxLimit)
         ));
         assert!(!testee.cost_by_writable_accounts.contains_key(&zeroed));
@@ -976,7 +933,7 @@ mod tests {
     }
 
     #[test]
-    fn test_adjust_transaction_execution_cost() {
+    fn test_adjust_cost() {
         let acct1 = Pubkey::new_unique();
         let acct2 = Pubkey::new_unique();
         let acct3 = Pubkey::new_unique();
@@ -985,11 +942,10 @@ mod tests {
         let block_max = account_max * 3; // for three accts
 
         let mut testee = CostTracker::new(account_max, block_max);
-        let transaction = WritableKeysTransaction::new(vec![acct1, acct2, acct3]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        let mut expected_block_cost = tx_cost.sum();
+        let accts = [acct1, acct2, acct3];
+        let mut expected_block_cost = cost;
         let expected_tx_count = 1;
-        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&test_cost(cost), accts.iter()).is_ok());
         assert_eq!(expected_block_cost, testee.block_cost());
         assert_eq!(expected_tx_count, testee.transaction_count());
         testee
@@ -1002,8 +958,9 @@ mod tests {
         // adjust down
         {
             let adjustment = 50u64;
-            testee.sub_transaction_execution_cost(&tx_cost, adjustment);
-            expected_block_cost -= 50;
+            let new_cost = expected_block_cost - adjustment;
+            testee.update_cost(expected_block_cost, new_cost, accts.iter());
+            expected_block_cost = new_cost;
             assert_eq!(expected_block_cost, testee.block_cost());
             assert_eq!(expected_tx_count, testee.transaction_count());
             testee
@@ -1013,23 +970,41 @@ mod tests {
                     assert_eq!(expected_block_cost, *units);
                 });
         }
+
+        // adjust up
+        {
+            let new_cost = expected_block_cost + 25;
+            testee.update_cost(expected_block_cost, new_cost, accts.iter());
+            expected_block_cost = new_cost;
+            assert_eq!(expected_block_cost, testee.block_cost());
+            assert_eq!(expected_tx_count, testee.transaction_count());
+        }
+
+        // no adjustment
+        testee.update_cost(expected_block_cost, expected_block_cost, accts.iter());
+        assert_eq!(expected_block_cost, testee.block_cost());
     }
 
     #[test]
-    fn test_remove_transaction_cost() {
+    fn test_remove_cost() {
         let mut cost_tracker = CostTracker::default();
 
         let cost = 100u64;
-        let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        cost_tracker.try_add(&tx_cost).unwrap();
+        let accts = [Pubkey::new_unique()];
+        let transaction_cost = || TransactionCost {
+            allocated_accounts_data_size: 7,
+            ..test_cost(cost)
+        };
+        cost_tracker
+            .try_add(&transaction_cost(), accts.iter())
+            .unwrap();
         // assert cost_tracker is reverted to default
         assert_eq!(1, cost_tracker.transaction_count.0);
         assert_eq!(1, cost_tracker.number_of_accounts());
         assert_eq!(cost, cost_tracker.block_cost());
-        assert_eq!(0, cost_tracker.allocated_accounts_data_size.load());
+        assert_eq!(7, cost_tracker.allocated_accounts_data_size.load());
 
-        cost_tracker.remove_transaction_cost(&tx_cost);
+        cost_tracker.remove(&transaction_cost(), accts.iter());
         // assert cost_tracker is reverted to default
         assert_eq!(0, cost_tracker.transaction_count.0);
         assert_eq!(0, cost_tracker.number_of_accounts());
@@ -1039,7 +1014,7 @@ mod tests {
         assert_eq!(stats.block_cost, 0);
         assert_eq!(stats.transaction_count, 0);
         assert_eq!(stats.number_of_accounts, 0);
-        assert_eq!(stats.costliest_account, transaction.writable_keys[0]);
+        assert_eq!(stats.costliest_account, accts[0]);
         assert_eq!(stats.costliest_account_cost, 0);
         assert_eq!(stats.allocated_accounts_data_size, 0);
         assert_eq!(stats.in_flight_transaction_count, 0);
@@ -1049,25 +1024,29 @@ mod tests {
     #[test]
     fn test_cost_tracker_stats() {
         let mint_keypair = test_setup();
-        let transaction = build_simple_transaction(&mint_keypair);
-        let mut tx_cost = simple_transaction_cost(&transaction, 95);
-        tx_cost.allocated_accounts_data_size = 7;
+        let accts = [mint_keypair];
+        let transaction_cost = TransactionCost {
+            allocated_accounts_data_size: 7,
+            ..test_cost(95)
+        };
 
         let mut cost_tracker = CostTracker::new(100, 1_000);
-        cost_tracker.try_add(&tx_cost).unwrap();
+        cost_tracker
+            .try_add(&transaction_cost, accts.iter())
+            .unwrap();
         cost_tracker.add_transactions_in_flight(2);
 
         let stats = cost_tracker.stats();
         assert_eq!(stats.block_cost, 95);
         assert_eq!(stats.transaction_count, 1);
         assert_eq!(stats.number_of_accounts, 1);
-        assert_eq!(stats.costliest_account, mint_keypair.pubkey());
+        assert_eq!(stats.costliest_account, mint_keypair);
         assert_eq!(stats.costliest_account_cost, 95);
         assert_eq!(stats.allocated_accounts_data_size, 7);
         assert_eq!(stats.in_flight_transaction_count, 2);
         assert_eq!(stats.number_of_contended_accounts, 1);
 
-        cost_tracker.update_execution_cost(&tx_cost, 90, 0);
+        cost_tracker.update_cost(95, 90, accts.iter());
         let adjusted_stats = cost_tracker.stats();
         assert_eq!(adjusted_stats.block_cost, 90);
         assert_eq!(adjusted_stats.costliest_account_cost, 90);
@@ -1078,9 +1057,10 @@ mod tests {
     fn test_get_cost_by_writable_accounts_post_analysis() {
         let mut cost_tracker = CostTracker::default();
         let cost = 100u64;
-        let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
-        let tx_cost = simple_transaction_cost(&transaction, cost);
-        cost_tracker.try_add(&tx_cost).unwrap();
+        let accts = [Pubkey::new_unique()];
+        cost_tracker
+            .try_add(&test_cost(cost), accts.iter())
+            .unwrap();
         let cost_by_writable_accounts = cost_tracker.get_cost_by_writable_accounts();
         assert_eq!(1, cost_by_writable_accounts.len());
         assert_eq!(cost, *cost_by_writable_accounts.values().next().unwrap());

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -1,9 +1,6 @@
-use {solana_pubkey::Pubkey, solana_svm_transaction::svm_message::SVMMessage};
-
 // Costs are stored in compute units.
 #[derive(Debug)]
-pub struct TransactionCost<'a, Tx> {
-    pub transaction: &'a Tx,
+pub struct TransactionCost {
     pub signature_cost: u64,
     pub write_lock_cost: u64,
     pub data_bytes_cost: u16,
@@ -12,7 +9,7 @@ pub struct TransactionCost<'a, Tx> {
     pub allocated_accounts_data_size: u64,
 }
 
-impl<'a, Tx> TransactionCost<'a, Tx> {
+impl TransactionCost {
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)
@@ -43,194 +40,6 @@ impl<'a, Tx> TransactionCost<'a, Tx> {
 
     pub fn write_lock_cost(&self) -> u64 {
         self.write_lock_cost
-    }
-}
-
-impl<Tx: SVMMessage> TransactionCost<'_, Tx> {
-    pub fn writable_accounts(&self) -> impl Iterator<Item = &Pubkey> {
-        let transaction = self.transaction;
-        transaction
-            .account_keys()
-            .iter()
-            .enumerate()
-            .filter_map(|(index, key)| transaction.is_writable(index).then_some(key))
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-#[derive(Debug)]
-pub struct WritableKeysTransaction {
-    pub writable_keys: Vec<Pubkey>,
-    pub is_simple_vote: bool,
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl WritableKeysTransaction {
-    pub fn new(writable_keys: Vec<Pubkey>) -> Self {
-        WritableKeysTransaction {
-            writable_keys,
-            is_simple_vote: false,
-        }
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTransaction {
-    fn version(&self) -> solana_transaction::versioned::TransactionVersion {
-        unimplemented!("WritableKeysTransaction::version")
-    }
-
-    fn num_transaction_signatures(&self) -> u64 {
-        unimplemented!("WritableKeysTransaction::num_transaction_signatures")
-    }
-
-    fn num_write_locks(&self) -> u64 {
-        unimplemented!("WritableKeysTransaction::num_write_locks")
-    }
-
-    fn num_readonly_signed_static_accounts(&self) -> u8 {
-        unimplemented!("WritableKeysTransaction::num_readonly_signed_static_accounts")
-    }
-
-    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
-        unimplemented!("WritableKeysTransaction::num_readonly_unsigned_static_accounts")
-    }
-
-    fn recent_blockhash(&self) -> &solana_hash::Hash {
-        unimplemented!("WritableKeysTransaction::recent_blockhash")
-    }
-
-    fn num_instructions(&self) -> usize {
-        unimplemented!("WritableKeysTransaction::num_instructions")
-    }
-
-    fn instructions_iter(
-        &self,
-    ) -> impl Iterator<Item = solana_svm_transaction::instruction::SVMInstruction<'_>> {
-        core::iter::empty()
-    }
-
-    fn program_instructions_iter(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            &Pubkey,
-            solana_svm_transaction::instruction::SVMInstruction<'_>,
-        ),
-    > + Clone {
-        core::iter::empty()
-    }
-
-    fn static_account_keys(&self) -> &[Pubkey] {
-        &self.writable_keys
-    }
-
-    fn fee_payer(&self) -> &Pubkey {
-        unimplemented!("WritableKeysTransaction::fee_payer")
-    }
-
-    fn num_lookup_tables(&self) -> usize {
-        unimplemented!("WritableKeysTransaction::num_lookup_tables")
-    }
-
-    fn message_address_table_lookups(
-        &self,
-    ) -> impl Iterator<
-        Item = solana_svm_transaction::message_address_table_lookup::SVMMessageAddressTableLookup<
-            '_,
-        >,
-    > {
-        core::iter::empty()
-    }
-
-    fn is_requested_writable(&self, _index: usize) -> bool {
-        unimplemented!("WritableKeysTransaction::is_requested_writable")
-    }
-
-    fn is_signer(&self, _index: usize) -> bool {
-        unimplemented!("WritableKeysTransaction::is_signer")
-    }
-
-    fn is_invoked(&self, _key_index: usize) -> bool {
-        unimplemented!("WritableKeysTransaction::is_invoked")
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
-    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
-        solana_message::AccountKeys::new(&self.writable_keys, None)
-    }
-
-    fn is_writable(&self, _index: usize) -> bool {
-        true
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_transaction::SVMStaticTransaction for WritableKeysTransaction {
-    fn signature(&self) -> &solana_signature::Signature {
-        unimplemented!("WritableKeysTransaction::signature")
-    }
-
-    fn signatures(&self) -> &[solana_signature::Signature] {
-        unimplemented!("WritableKeysTransaction::signatures")
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_runtime_transaction::transaction_meta::TransactionMeta for WritableKeysTransaction {
-    fn message_hash(&self) -> &solana_hash::Hash {
-        unimplemented!("WritableKeysTransaction::message_hash")
-    }
-
-    fn is_simple_vote_transaction(&self) -> bool {
-        self.is_simple_vote
-    }
-
-    fn signature_details(&self) -> &solana_message::TransactionSignatureDetails {
-        const DUMMY: solana_message::TransactionSignatureDetails =
-            solana_message::TransactionSignatureDetails::new(0, 0, 0, 0);
-        &DUMMY
-    }
-
-    fn transaction_configuration(
-        &self,
-        _feature_set: &agave_feature_set::FeatureSet,
-    ) -> Result<
-        solana_runtime_transaction::transaction_meta::TransactionConfiguration,
-        solana_transaction::TransactionError,
-    > {
-        unimplemented!("WritableKeysTransaction::transaction_configuration")
-    }
-
-    fn instruction_data_len(&self) -> u16 {
-        unimplemented!("WritableKeysTransaction::instruction_data_len")
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_runtime_transaction::transaction_with_meta::StaticTransactionWithMeta
-    for WritableKeysTransaction
-{
-    fn to_versioned_transaction(&self) -> solana_transaction::versioned::VersionedTransaction {
-        unimplemented!("WritableKeysTransaction::to_versioned_transaction")
-    }
-
-    fn serialized_size(&self) -> usize {
-        unimplemented!("WritableKeysTransaction::serialized_size")
-    }
-}
-
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
-    for WritableKeysTransaction
-{
-    #[allow(refining_impl_trait)]
-    fn as_sanitized_transaction(
-        &self,
-    ) -> std::borrow::Cow<'_, solana_transaction::sanitized::SanitizedTransaction> {
-        unimplemented!("WritableKeysTransaction::as_sanitized_transaction");
     }
 }
 
@@ -315,7 +124,6 @@ mod tests {
                     &feature_set,
                 );
             let vote_program_cost = TransactionCost {
-                transaction: &vote_transaction,
                 signature_cost,
                 write_lock_cost,
                 data_bytes_cost,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -76,7 +76,9 @@ use {
         stake_utils,
         transaction_execution::{TransactionStatusMessage, TransactionStatusSender},
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        runtime_transaction::RuntimeTransaction, transaction_with_meta::writable_accounts,
+    },
     solana_shred_version::compute_shred_version,
     solana_stake_interface::{self as stake, state::StakeStateV2},
     solana_system_interface::program as system_program,
@@ -487,7 +489,7 @@ fn compute_slot_cost(
                 num_programs += transaction.message().instructions().len();
 
                 let tx_cost = CostModel::calculate_cost(&transaction, &feature_set);
-                let result = cost_tracker.try_add(&tx_cost);
+                let result = cost_tracker.try_add(&tx_cost, writable_accounts(&transaction));
                 if result.is_err() {
                     println!(
                         "Slot: {slot}, CostModel rejected transaction {transaction:?}, reason \

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -1,7 +1,8 @@
 use {
     crate::transaction_meta::TransactionMeta,
+    solana_pubkey::Pubkey,
     solana_svm_transaction::{
-        svm_message::SVMStaticMessage,
+        svm_message::{SVMMessage, SVMStaticMessage},
         svm_transaction::{SVMStaticTransaction, SVMTransaction},
     },
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
@@ -10,6 +11,14 @@ use {
 
 pub trait StaticMessageWithMeta: TransactionMeta + SVMStaticMessage {}
 impl<T: TransactionMeta + SVMStaticMessage> StaticMessageWithMeta for T {}
+
+pub fn writable_accounts(transaction: &impl SVMMessage) -> impl Iterator<Item = &Pubkey> + Clone {
+    transaction
+        .account_keys()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, key)| transaction.is_writable(index).then_some(key))
+}
 
 pub trait StaticTransactionWithMeta: TransactionMeta + SVMStaticTransaction {
     /// Required to interact with several legacy interfaces that require

--- a/runtime/src/conformance/block.rs
+++ b/runtime/src/conformance/block.rs
@@ -34,6 +34,7 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_leader_schedule::{LeaderSchedule, NUM_CONSECUTIVE_LEADER_SLOTS},
     solana_pubkey::Pubkey,
+    solana_runtime_transaction::transaction_with_meta::writable_accounts,
     solana_sdk_ids::sysvar,
     solana_stake_interface::state::Delegation,
     solana_svm::{
@@ -624,7 +625,7 @@ pub fn execute_block(context: &ProtoBlockContext) -> ProtoBlockEffects {
             if bank
                 .write_cost_tracker()
                 .unwrap()
-                .try_add(&tx_cost)
+                .try_add(&tx_cost, writable_accounts(sanitized))
                 .is_err()
             {
                 has_err = true;

--- a/runtime/src/transaction_execution.rs
+++ b/runtime/src/transaction_execution.rs
@@ -12,7 +12,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_measure::measure::Measure,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::transaction_with_meta::{TransactionWithMeta, writable_accounts},
     solana_signature::Signature,
     solana_svm::{
         transaction_commit_result::{
@@ -89,7 +89,8 @@ pub fn execute_batch<'a>(
     let mut check_block_costs_elapsed = Measure::start("check_block_costs");
 
     let tx_costs = get_transaction_costs(bank, &commit_results, batch.sanitized_transactions());
-    let checked_tx_costs_result = check_block_cost_limits(bank, &tx_costs);
+    let checked_tx_costs_result =
+        check_block_cost_limits(bank, batch.sanitized_transactions(), &tx_costs);
 
     check_block_costs_elapsed.stop();
     timings.saturating_add_in_place(
@@ -156,24 +157,28 @@ pub fn execute_batch<'a>(
 
 fn check_block_cost_limits<Tx: TransactionWithMeta>(
     bank: &Bank,
-    tx_costs: &[Option<TransactionCost<'_, Tx>>],
+    transactions: &[Tx],
+    tx_costs: &[Option<TransactionCost>],
 ) -> TransactionResult<()> {
+    assert_eq!(transactions.len(), tx_costs.len());
     let mut cost_tracker = bank.write_cost_tracker().unwrap();
-    for tx_cost in tx_costs.iter().flatten() {
-        cost_tracker
-            .try_add(tx_cost)
-            .map_err(TransactionError::from)?;
+    for (transaction, tx_cost) in transactions.iter().zip(tx_costs) {
+        if let Some(tx_cost) = tx_cost {
+            cost_tracker
+                .try_add(tx_cost, writable_accounts(transaction))
+                .map_err(TransactionError::from)?;
+        }
     }
 
     Ok(())
 }
 
 // Get actual transaction execution costs from transaction commit results
-fn get_transaction_costs<'a, Tx: TransactionWithMeta>(
+fn get_transaction_costs<Tx: TransactionWithMeta>(
     bank: &Bank,
     commit_results: &[TransactionCommitResult],
-    sanitized_transactions: &'a [Tx],
-) -> Vec<Option<TransactionCost<'a, Tx>>> {
+    sanitized_transactions: &[Tx],
+) -> Vec<Option<TransactionCost>> {
     assert_eq!(sanitized_transactions.len(), commit_results.len());
 
     commit_results
@@ -339,16 +344,17 @@ mod tests {
             .unwrap()
             .set_limits(CostTrackerLimits::new(u64::MAX, block_limit, u64::MAX));
 
-        let tx_costs = vec![None, Some(tx_cost), None];
+        let transactions = std::slice::from_ref(&tx);
+        let tx_costs = [Some(tx_cost)];
         // The transaction will fit when added the first time
-        assert!(check_block_cost_limits(&bank, &tx_costs).is_ok());
+        assert!(check_block_cost_limits(&bank, transactions, &tx_costs).is_ok());
         // But adding a second time will exceed the block limit
         assert_eq!(
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
-            check_block_cost_limits(&bank, &tx_costs)
+            check_block_cost_limits(&bank, transactions, &tx_costs)
         );
         // Adding another None will noop (even though the block is already full)
-        assert!(check_block_cost_limits(&bank, &tx_costs[0..1]).is_ok());
+        assert!(check_block_cost_limits(&bank, transactions, &[None]).is_ok());
     }
 
     #[test]
@@ -546,7 +552,7 @@ mod tests {
         let noop_cost = tx_costs[0].as_ref().unwrap().sum();
         assert_eq!(noop_cost, sig + locks + data + compute + size);
 
-        check_block_cost_limits(&bank, &tx_costs).unwrap();
+        check_block_cost_limits(&bank, batch.sanitized_transactions(), &tx_costs).unwrap();
         assert_eq!(bank.read_cost_tracker().unwrap().block_cost(), noop_cost);
 
         drop(batch);


### PR DESCRIPTION
#### Problem
- TransactionCost holds a reference to transaction
	- this couples cost-tracking to transaction type
	- this creates complications when trying to do cost-tracking in the scheduler without redoing scans

#### Summary of Changes
- TransactionCost no longer holds a reference to a transaction

#### Testing
- CI

Fixes #
