### PR TITLE
runtime: conformance: refactor txn harness

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8415,7 +8415,6 @@ dependencies = [
  "solana-account 4.7.0",
  "solana-clock",
  "solana-compute-budget",
- "solana-instruction",
  "solana-program-runtime",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -8424,7 +8423,6 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
- "solana-transaction-error",
 ]
 
 [[package]]

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -333,6 +333,23 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
     };
     effects.zero_precompile_custom_error(sanitized_message);
 
+    // Only keep modified accounts that were passed in as account keys or were
+    // loaded via an address lookup table.
+    let mut loaded_account_keys = AHashSet::<Pubkey>::new();
+    loaded_account_keys.extend(
+        proto_message
+            .account_keys
+            .iter()
+            .map(|key| Pubkey::try_from(key.as_slice()).unwrap()),
+    );
+    if let SanitizedMessage::V0(message) = sanitized_message {
+        loaded_account_keys.extend(message.loaded_addresses.writable.iter().copied());
+        loaded_account_keys.extend(message.loaded_addresses.readonly.iter().copied());
+    }
+    effects
+        .resulting_accounts
+        .retain(|(pubkey, _)| loaded_account_keys.contains(pubkey));
+
     let cu_avail = effects.cu_avail;
     let has_err = effects.status.is_err();
     let mut txn_result = ProtoTxnResult::from(effects);
@@ -346,25 +363,6 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
             .iter_mut()
             .map(|acc| &mut acc.data),
     );
-
-    // Only keep modified accounts that were passed in as account keys or were
-    // loaded via an address lookup table.
-    let account_keys = &proto_message.account_keys;
-    let mut loaded_account_keys = AHashSet::<Pubkey>::new();
-    loaded_account_keys.extend(
-        account_keys
-            .iter()
-            .map(|key| Pubkey::try_from(key.as_slice()).unwrap()),
-    );
-    if let SanitizedMessage::V0(message) = sanitized_message {
-        loaded_account_keys.extend(message.loaded_addresses.writable.iter().copied());
-        loaded_account_keys.extend(message.loaded_addresses.readonly.iter().copied());
-    }
-    txn_result.modified_accounts.retain(|account| {
-        Pubkey::try_from(account.address.as_slice())
-            .map(|pubkey| loaded_account_keys.contains(&pubkey))
-            .unwrap()
-    });
 
     txn_result
 }

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -52,27 +52,18 @@ use {
 use {
     super::{deserialize_accounts, fee_rate_governor_from_proto, restore_blockhash_queue},
     agave_feature_set::virtual_address_space_adjustments,
-    agave_precompiles::is_precompile,
     ahash::AHashSet,
-    protosol::protos::{
-        AcctState, FeeDetails as ProtoFeeDetails, TxnContext as ProtoTxnContext,
-        TxnResult as ProtoTxnResult,
-    },
-    solana_instruction::error::InstructionError,
+    protosol::protos::{TxnContext as ProtoTxnContext, TxnResult as ProtoTxnResult},
+    solana_account::Account,
     solana_message::SanitizedMessage,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_signature::Signature,
     solana_svm::conformance::{
-        account_state::account_to_proto, direct_mapping::direct_mapping_handle_cu_exhaustion,
-        err::serialized_error_code, feature_set::feature_set_from_proto,
-        versioned_transaction::versioned_transaction_from_proto,
+        direct_mapping::direct_mapping_handle_cu_exhaustion, feature_set::feature_set_from_proto,
+        txn::effects::TxnEffects, versioned_transaction::versioned_transaction_from_proto,
     },
-    solana_svm::transaction_processing_result::{
-        ProcessedTransaction, TransactionProcessingResultExtensions,
-    },
-    solana_svm::{
-        account_loader::FeesOnlyTransaction, transaction_execution_result::ExecutedTransaction,
-    },
+    solana_svm::rollback_accounts::RollbackAccounts,
+    solana_svm::transaction_processing_result::ProcessedTransaction,
 };
 // Imports used only by the FFI entry point, which is excluded from `test` builds.
 #[cfg(all(feature = "conformance", not(test)))]
@@ -207,199 +198,77 @@ pub fn execute_txn(
     }
 }
 
-/// Firedancer error numbers: the bincode-serialized enum discriminant `+ 1`.
 #[cfg(feature = "conformance")]
-#[derive(Default)]
-struct ProtoTxnErrorFields {
-    txn_error: u32,
-    instruction_error: u32,
-    custom_error: u32,
-    instruction_error_index: u32,
-}
-
-#[cfg(feature = "conformance")]
-impl ProtoTxnErrorFields {
-    fn from_processed_transaction(
-        txn: &ProcessedTransaction,
-        sanitized_message: &SanitizedMessage,
-    ) -> Self {
-        match txn.status() {
-            Ok(()) => Self::default(),
-            Err(transaction_error) => Self::from_transaction_error(&transaction_error)
-                .zero_precompile_custom_error(sanitized_message),
-        }
-    }
-
-    fn from_transaction_error(transaction_error: &TransactionError) -> Self {
-        let (instruction_error, custom_error, instruction_error_index) = match transaction_error {
-            TransactionError::InstructionError(instruction_error_index, instruction_error) => {
-                let custom_error = match instruction_error {
-                    InstructionError::Custom(custom_error) => *custom_error,
-                    _ => 0,
-                };
-                (
-                    serialized_error_code(instruction_error),
-                    custom_error,
-                    (*instruction_error_index).into(),
-                )
-            }
-            _ => (0, 0, 0),
-        };
-
-        Self {
-            txn_error: serialized_error_code(transaction_error),
-            instruction_error,
-            custom_error,
-            instruction_error_index,
-        }
-    }
-
-    /// Firedancer does not compare precompile custom error codes because minor
-    /// implementation differences can surface different custom values.
-    fn zero_precompile_custom_error(mut self, sanitized_message: &SanitizedMessage) -> Self {
-        // Custom error is zeroed when the failing instruction is a precompile.
-        if self.custom_error != 0
-            && instruction_is_precompile(self.instruction_error_index, sanitized_message)
-        {
-            self.custom_error = 0;
-        }
-        self
-    }
-}
-
-#[cfg(feature = "conformance")]
-fn instruction_is_precompile(
-    instruction_error_index: u32,
-    sanitized_message: &SanitizedMessage,
-) -> bool {
-    let Ok(instruction_error_index) = usize::try_from(instruction_error_index) else {
-        return false;
-    };
-
-    sanitized_message
-        .program_instructions_iter()
-        .nth(instruction_error_index)
-        .is_some_and(|(program_id, _)| is_precompile(program_id, |_| true))
-}
-
-#[cfg(feature = "conformance")]
-struct ProtoTxnEffects {
-    modified_accounts: Vec<AcctState>,
-    rollback_accounts: Vec<AcctState>,
-    return_data: Vec<u8>,
-}
-
-#[cfg(feature = "conformance")]
-impl ProtoTxnEffects {
-    fn from_processed_transaction(
-        txn: &ProcessedTransaction,
-        sanitized_message: &SanitizedMessage,
-    ) -> Self {
-        match txn {
-            ProcessedTransaction::Executed(executed_tx) => {
-                executed_transaction_effects(executed_tx, sanitized_message)
-            }
-            ProcessedTransaction::FeesOnly(tx) => fees_only_transaction_effects(tx),
-            ProcessedTransaction::NoOp(_) => ProtoTxnEffects {
-                modified_accounts: vec![],
-                rollback_accounts: vec![],
-                return_data: vec![],
-            },
-        }
-    }
-}
-
-#[cfg(feature = "conformance")]
-fn executed_transaction_effects(
-    executed_tx: &ExecutedTransaction,
-    sanitized_message: &SanitizedMessage,
-) -> ProtoTxnEffects {
-    let loaded = &executed_tx.loaded_transaction;
-    let modified_accounts = loaded
-        .accounts
+fn rollback_accounts_to_native(rollback_accounts: &RollbackAccounts) -> Vec<(Pubkey, Account)> {
+    rollback_accounts
         .iter()
-        .enumerate()
-        .filter(|(index, _)| sanitized_message.is_writable(*index))
-        .map(|(_, (pubkey, account))| account_to_proto((*pubkey, account.clone().into())))
-        .collect();
-    let rollback_accounts = if executed_tx.execution_details.status.is_err() {
-        loaded
-            .rollback_accounts
-            .iter()
-            .map(|(pubkey, account)| account_to_proto((*pubkey, account.clone().into())))
-            .collect()
-    } else {
-        vec![]
-    };
-    let return_data = executed_tx
-        .execution_details
-        .return_data
-        .as_ref()
-        .map(|info| info.data.clone())
-        .unwrap_or_default();
+        .map(|(pubkey, account)| (*pubkey, account.clone().into()))
+        .collect()
+}
 
-    ProtoTxnEffects {
-        modified_accounts,
+#[cfg(feature = "conformance")]
+fn processed_transaction_effects(
+    txn: &ProcessedTransaction,
+    sanitized_message: &SanitizedMessage,
+) -> TxnEffects {
+    let (resulting_accounts, rollback_accounts, return_data, compute_unit_limit) = match txn {
+        ProcessedTransaction::Executed(executed_tx) => {
+            let loaded = &executed_tx.loaded_transaction;
+            let resulting_accounts = loaded
+                .accounts
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| sanitized_message.is_writable(*index))
+                .map(|(_, (pubkey, account))| (*pubkey, account.clone().into()))
+                .collect();
+            let rollback_accounts = if executed_tx.execution_details.status.is_err() {
+                rollback_accounts_to_native(&loaded.rollback_accounts)
+            } else {
+                vec![]
+            };
+            let return_data = executed_tx
+                .execution_details
+                .return_data
+                .as_ref()
+                .map(|info| info.data.clone())
+                .unwrap_or_default();
+            (
+                resulting_accounts,
+                rollback_accounts,
+                return_data,
+                loaded.compute_budget.compute_unit_limit,
+            )
+        }
+        ProcessedTransaction::FeesOnly(tx) => (
+            vec![],
+            rollback_accounts_to_native(&tx.rollback_accounts),
+            vec![],
+            0,
+        ),
+        ProcessedTransaction::NoOp(_) => (vec![], vec![], vec![], 0),
+    };
+
+    let executed_units = txn.executed_units();
+    TxnEffects {
+        executed: true,
+        status: txn.status(),
+        resulting_accounts,
         rollback_accounts,
         return_data,
+        executed_units,
+        fee_details: txn.fee_details(),
+        loaded_accounts_data_size: u64::from(txn.loaded_accounts_data_size()),
+        // The bank records logs, but the fixture does not compare them.
+        logs: vec![],
+        cu_avail: compute_unit_limit.saturating_sub(executed_units),
     }
 }
 
 #[cfg(feature = "conformance")]
-fn fees_only_transaction_effects(tx: &FeesOnlyTransaction) -> ProtoTxnEffects {
-    ProtoTxnEffects {
-        modified_accounts: vec![],
-        rollback_accounts: tx
-            .rollback_accounts
-            .iter()
-            .map(|(pubkey, account)| account_to_proto((*pubkey, account.clone().into())))
-            .collect(),
-        return_data: vec![],
-    }
-}
-
-/// Map the processor's result for the single executed transaction into a
-/// `TxnResult`.
-#[cfg(feature = "conformance")]
-fn output_txn_result(
-    execution_result: &TransactionProcessingResult,
-    sanitized_message: &SanitizedMessage,
-) -> ProtoTxnResult {
-    let executed = execution_result.was_processed();
-    match execution_result {
-        Ok(txn) => {
-            let error = ProtoTxnErrorFields::from_processed_transaction(txn, sanitized_message);
-            let effects = ProtoTxnEffects::from_processed_transaction(txn, sanitized_message);
-            let fees = txn.fee_details();
-
-            ProtoTxnResult {
-                executed,
-                txn_error: error.txn_error,
-                instruction_error: error.instruction_error,
-                instruction_error_index: error.instruction_error_index,
-                custom_error: error.custom_error,
-                return_data: effects.return_data,
-                executed_units: txn.executed_units(),
-                fee_details: Some(ProtoFeeDetails {
-                    transaction_fee: fees.transaction_fee(),
-                    prioritization_fee: fees.prioritization_fee(),
-                }),
-                loaded_accounts_data_size: u64::from(txn.loaded_accounts_data_size()),
-                modified_accounts: effects.modified_accounts,
-                rollback_accounts: effects.rollback_accounts,
-            }
-        }
-        Err(transaction_error) => {
-            let error = ProtoTxnErrorFields::from_transaction_error(transaction_error);
-            ProtoTxnResult {
-                executed,
-                txn_error: error.txn_error,
-                instruction_error: error.instruction_error,
-                instruction_error_index: error.instruction_error_index,
-                custom_error: error.custom_error,
-                ..Default::default()
-            }
-        }
+fn unprocessed_txn_result(err: TransactionError) -> ProtoTxnResult {
+    ProtoTxnResult {
+        fee_details: None,
+        ..ProtoTxnResult::from(TxnEffects::from_unprocessed_error(err))
     }
 }
 
@@ -445,16 +314,10 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
         transaction,
     ) {
         BankTxnProcessingResult::FailedVerification(err) => {
-            let error = ProtoTxnErrorFields::from_transaction_error(&err);
-            return ProtoTxnResult {
-                executed: false,
-                txn_error: error.txn_error,
-                instruction_error: error.instruction_error,
-                instruction_error_index: error.instruction_error_index,
-                // Precompile error codes are not conformant, so they are ignored here.
-                custom_error: 0,
-                ..Default::default()
-            };
+            let mut txn_result = unprocessed_txn_result(err);
+            // Precompile error codes are not conformant, so they are ignored here.
+            txn_result.custom_error = 0;
+            return txn_result;
         }
         BankTxnProcessingResult::Processed {
             result,
@@ -464,20 +327,20 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
     let sanitized_transaction = runtime_transaction.as_sanitized_transaction();
     let sanitized_message = sanitized_transaction.message();
 
-    let mut txn_result = output_txn_result(&result, sanitized_message);
-
-    let cu_avail = match &result {
-        Ok(ProcessedTransaction::Executed(executed_tx)) => executed_tx
-            .loaded_transaction
-            .compute_budget
-            .compute_unit_limit
-            .saturating_sub(txn_result.executed_units),
-        _ => 0,
+    let mut effects = match &result {
+        Ok(txn) => processed_transaction_effects(txn, sanitized_message),
+        Err(err) => return unprocessed_txn_result(err.clone()),
     };
+    effects.zero_precompile_custom_error(sanitized_message);
+
+    let cu_avail = effects.cu_avail;
+    let has_err = effects.status.is_err();
+    let mut txn_result = ProtoTxnResult::from(effects);
+
     direct_mapping_handle_cu_exhaustion(
         virtual_address_space_adjustments_active,
         cu_avail,
-        txn_result.txn_error != 0,
+        has_err,
         txn_result
             .modified_accounts
             .iter_mut()
@@ -549,6 +412,8 @@ pub unsafe extern "C" fn sol_compat_txn_execute_v1(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "conformance")]
+    use std::collections::HashSet;
     use {
         super::{BankTxnProcessingResult, execute_txn},
         agave_feature_set::{FeatureSet, disable_sbpf_v0_execution, set_exempt_rent_epoch_max},
@@ -577,8 +442,6 @@ mod tests {
         solana_transaction::versioned::VersionedTransaction,
         std::{borrow::Cow, env, fs, sync::Arc},
     };
-    #[cfg(feature = "conformance")]
-    use {solana_instruction::error::InstructionError, std::collections::HashSet};
 
     /// All features enabled except `disable_sbpf_v0_execution`, so the v0
     /// `complex-transfer` program loads. `set_exempt_rent_epoch_max` is forced on
@@ -807,56 +670,27 @@ mod tests {
 
     #[cfg(feature = "conformance")]
     #[test]
-    fn proto_txn_error_fields_zeroes_precompile_custom_error() {
-        let error = solana_transaction_error::TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(7),
-        );
-        let fields = super::ProtoTxnErrorFields::from_transaction_error(&error)
-            .zero_precompile_custom_error(&sanitized_message_with_program(
-                solana_sdk_ids::secp256k1_program::id(),
-            ));
-
-        assert_eq!(fields.custom_error, 0);
-        assert_ne!(fields.instruction_error, 0);
-        assert_eq!(fields.instruction_error_index, 0);
-    }
-
-    #[cfg(feature = "conformance")]
-    #[test]
-    fn proto_txn_error_fields_keeps_non_precompile_custom_error() {
-        let error = solana_transaction_error::TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(7),
-        );
-        let fields = super::ProtoTxnErrorFields::from_transaction_error(&error)
-            .zero_precompile_custom_error(&sanitized_message_with_program(Pubkey::new_unique()));
-
-        assert_eq!(fields.custom_error, 7);
-        assert_ne!(fields.instruction_error, 0);
-        assert_eq!(fields.instruction_error_index, 0);
-    }
-
-    #[cfg(feature = "conformance")]
-    #[test]
-    fn output_txn_result_handles_noop_transaction() {
+    fn noop_transaction_effects() {
         const COMPUTE_UNIT_LIMIT: u64 = 123_456;
         const LOADED_ACCOUNTS_BYTES_LIMIT: u32 = 654_321;
         let validation_error = solana_transaction_error::TransactionError::AccountNotFound;
-        let processing_result = Ok(ProcessedTransaction::NoOp(Box::new(
-            solana_svm::account_loader::NoOpTransaction {
+        let processed =
+            ProcessedTransaction::NoOp(Box::new(solana_svm::account_loader::NoOpTransaction {
                 validation_error: validation_error.clone(),
                 fee_payer_balance: Some(42),
                 compute_unit_limit: COMPUTE_UNIT_LIMIT,
                 loaded_accounts_bytes_limit: LOADED_ACCOUNTS_BYTES_LIMIT,
                 nonce_address: None,
-            },
-        )));
+            }));
 
-        let result = super::output_txn_result(
-            &processing_result,
+        let effects = super::processed_transaction_effects(
+            &processed,
             &sanitized_message_with_program(Pubkey::new_unique()),
         );
+        // A NoOp reports the full limit as consumed, so nothing is left over.
+        assert_eq!(effects.cu_avail, 0);
+
+        let result = super::ProtoTxnResult::from(effects);
 
         assert!(result.executed);
         assert_eq!(

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -50,12 +50,10 @@ ffi = [
     "dep:prost",
     "dep:protosol",
     "dep:solana-compute-budget",
-    "dep:solana-instruction",
     "dep:solana-program-runtime",
     "dep:solana-pubkey",
     "dep:solana-svm",
     "dep:solana-syscalls",
-    "dep:solana-transaction-error",
     "solana-svm/conformance",
 ]
 frozen-abi = []
@@ -67,12 +65,10 @@ clap = { version = "4.5.59", features = ["derive"], optional = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
 solana-compute-budget = { workspace = true, optional = true }
-solana-instruction = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, optional = true }
 solana-pubkey = { workspace = true, optional = true }
 solana-svm = { workspace = true, optional = true }
 solana-syscalls = { workspace = true, optional = true }
-solana-transaction-error = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/svm-conformance/src/txn.rs
+++ b/svm-conformance/src/txn.rs
@@ -2,10 +2,8 @@
 
 use {
     agave_feature_set::virtual_address_space_adjustments,
-    agave_precompiles::is_precompile,
     prost::Message,
     protosol::protos::{TxnContext as ProtoTxnContext, TxnResult as ProtoTxnResult},
-    solana_instruction::error::InstructionError,
     solana_svm::conformance::{
         callback::ConformanceCallback,
         direct_mapping::direct_mapping_handle_cu_exhaustion,
@@ -16,7 +14,6 @@ use {
         },
         txn::{context::TxnContext, harness::execute_txn_with_callback},
     },
-    solana_transaction_error::TransactionError,
     std::ffi::c_int,
 };
 
@@ -52,28 +49,7 @@ pub fn execute_txn_proto(input: ProtoTxnContext) -> ProtoTxnResult {
     let mut effects =
         execute_txn_with_callback(&context, &callback, &mut program_cache, &sysvar_cache);
 
-    let precompile_custom_error_index = match &effects.status {
-        Err(TransactionError::InstructionError(index, InstructionError::Custom(_))) => context
-            .message
-            .instructions()
-            .get(usize::from(*index))
-            .and_then(|instruction| {
-                context
-                    .message
-                    .static_account_keys()
-                    .get(usize::from(instruction.program_id_index))
-            })
-            .is_some_and(|program_id| is_precompile(program_id, |_| true))
-            .then_some(*index),
-        _ => None,
-    };
-
-    if let Some(index) = precompile_custom_error_index {
-        effects.status = Err(TransactionError::InstructionError(
-            index,
-            InstructionError::Custom(0),
-        ));
-    }
+    effects.zero_precompile_custom_error(&context.message);
 
     let cu_avail = effects.cu_avail;
     let has_err = effects.status.is_err();

--- a/svm/src/conformance/txn/effects.rs
+++ b/svm/src/conformance/txn/effects.rs
@@ -20,6 +20,7 @@ pub struct TxnEffects {
     pub executed: bool,
     pub status: TransactionResult<()>,
     pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub rollback_accounts: Vec<(Pubkey, Account)>,
     pub return_data: Vec<u8>,
     pub executed_units: u64,
     pub fee_details: FeeDetails,
@@ -34,6 +35,7 @@ impl TxnEffects {
             executed: false,
             status: Err(err),
             resulting_accounts: vec![],
+            rollback_accounts: vec![],
             return_data: vec![],
             executed_units: 0,
             fee_details: FeeDetails::new(0, 0),
@@ -123,6 +125,11 @@ impl From<TxnEffects> for ProtoTxnResult {
             .into_iter()
             .map(|(pubkey, account)| account_to_proto((pubkey, account)))
             .collect();
+        let rollback_accounts = value
+            .rollback_accounts
+            .into_iter()
+            .map(|(pubkey, account)| account_to_proto((pubkey, account)))
+            .collect();
 
         Self {
             executed: value.executed,
@@ -135,7 +142,7 @@ impl From<TxnEffects> for ProtoTxnResult {
             fee_details,
             loaded_accounts_data_size: value.loaded_accounts_data_size,
             modified_accounts,
-            rollback_accounts: vec![],
+            rollback_accounts,
         }
     }
 }

--- a/svm/src/conformance/txn/effects.rs
+++ b/svm/src/conformance/txn/effects.rs
@@ -30,7 +30,7 @@ pub struct TxnEffects {
 }
 
 impl TxnEffects {
-    pub(crate) fn from_unprocessed_error(err: TransactionError) -> Self {
+    pub fn from_unprocessed_error(err: TransactionError) -> Self {
         Self {
             executed: false,
             status: Err(err),

--- a/svm/src/conformance/txn/effects.rs
+++ b/svm/src/conformance/txn/effects.rs
@@ -3,8 +3,10 @@
 #[cfg(feature = "conformance")]
 use {
     crate::conformance::{account_state::account_to_proto, err::serialized_error_code},
+    agave_precompiles::is_precompile,
     protosol::protos::{FeeDetails as ProtoFeeDetails, TxnResult as ProtoTxnResult},
     solana_instruction::error::InstructionError,
+    solana_message::SanitizedMessage,
 };
 use {
     solana_account::Account,
@@ -47,6 +49,32 @@ impl TxnEffects {
             .iter()
             .find(|(pk, _)| pk == pubkey)
             .map(|(_, account)| account)
+    }
+
+    /// Zero the custom error code when the failing instruction is a
+    /// precompile. Firedancer does not compare precompile custom codes.
+    #[cfg(feature = "conformance")]
+    pub fn zero_precompile_custom_error(&mut self, sanitized_message: &SanitizedMessage) {
+        let index = match &self.status {
+            Err(TransactionError::InstructionError(index, InstructionError::Custom(code)))
+                if *code != 0 =>
+            {
+                *index
+            }
+            _ => return,
+        };
+
+        let failed_on_precompile = sanitized_message
+            .program_instructions_iter()
+            .nth(usize::from(index))
+            .is_some_and(|(program_id, _)| is_precompile(program_id, |_| true));
+
+        if failed_on_precompile {
+            self.status = Err(TransactionError::InstructionError(
+                index,
+                InstructionError::Custom(0),
+            ));
+        }
     }
 }
 

--- a/svm/src/conformance/txn/harness.rs
+++ b/svm/src/conformance/txn/harness.rs
@@ -186,6 +186,7 @@ pub fn execute_txn_with_callback<C: InvokeContextCallback>(
         executed: true,
         status,
         resulting_accounts,
+        rollback_accounts: vec![],
         return_data,
         executed_units,
         fee_details: FeeDetails::new(0, 0),


### PR DESCRIPTION
#### Problem
The runtime transaction harness can share some code with the SVM transaction/message harness.

#### Summary of Changes
Do some refactoring so they share code.

#### Testing
Existing tests, and when we finally have vector runs for runtime transactions we'll see any issues.