### PR TITLE
logger: redirect stderr before building the logger

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -93,10 +93,12 @@ pub fn initialize_logging(logfile: Option<PathBuf>) {
         return;
     };
 
+    // Redirect before building the logger: env_logger probes stderr for color support once,
+    // at build time, so probing the launching tty writes ANSI escapes into the logfile.
     #[cfg(unix)]
     {
-        setup_with_default_filter();
         redirect_stderr(&logfile);
+        setup_with_default_filter();
     }
     #[cfg(not(unix))]
     {


### PR DESCRIPTION
#### Problem
* `initialize_logging` builds the env_logger instance and only then dup2's stderr onto the logfile
* env_logger resolves color support once, in Builder::build(), by probing whatever stderr is at that moment - so an interactive `--log <file>` run probes the launching tty, picks `ColorChoice::Always`, and every record afterwards carries ANSI escapes into the logfile
* observed on a pty: 6 escape sequences per record, e.g. `^[[90m[^[[0m<ts> ^[[32mINFO ^[[0m agave_validator^[[90m]^[[0m ...`
* daemonized runs are unaffected (stderr is already not a tty), which is why this mostly bites operators running the validator from a shell

#### Summary of Changes
* dup2 the logfile onto stderr first, then build the logger, so the probe sees the logfile and settles on `ColorChoice::Never`

##### Implications
* stderr writes emitted during logger construction now land in the logfile instead of the terminal - in practice env_filter's `warning: <error>`, ignoring it for a malformed RUST_LOG/_RUST_LOG, and any panic during setup
* redirect_stderr's own "Unable to open" eprintln still reaches the terminal; it runs ahead of the dup2 in either ordering
* only fixes tty detection: RUST_LOG_STYLE=always (honored via Env::new()) and CLICOLOR_FORCE=1 are explicit opt-ins and still put escapes in the logfile
* no effect when no logfile is passed: that path returns early and keeps colorizing the real terminal

#### Testing
Checked restart and logging on devbox validator
