### PR TITLE
chore(toolchain): bump rust toolchain to 1.98.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.98.0"
+rust-version = "1.98.1"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-07-03
+  nightly_version=2026-07-07
 fi
 
 

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-07-07
+  nightly_version=2026-07-16
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"


### PR DESCRIPTION
#### Problem
The pinned toolchain is 1.98.0; the [1.98.1](https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/) patch release is out. The patch fixes miscompilation (https://github.com/rust-lang/rust/issues/161441)

#### Summary of Changes
- bump `rust-toolchain.toml` channel and workspace `rust-version` to 1.98.1
- move nightly to 2026-07-16, the first one containing https://github.com/rust-lang/rust/pull/158993
 
#### Testing
CI
