### PR TITLE
rpc: support minContextSlot in getTransaction and getSignatureStatuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Release channels have their own copy of this changelog:
 ### RPC
 #### Breaking
 #### Changes
+* `getTransaction` now accepts `minContextSlot`, and `getSignatureStatuses` now accepts `commitment`
+  and `minContextSlot`, in their config objects. Both return `MinContextSlotNotReached` (-32016) when
+  the node's context slot at the requested commitment is below the minimum. `getSignatureStatuses`
+  still defaults to `processed` when no commitment is given.
+* Added `RpcClient::get_signature_statuses_with_config`.
 ### Validator
 #### Breaking
 * scheduler-bindings version has been increased to 5. Connecting external schedulers must be updated.

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2040,6 +2040,7 @@ pub async fn process_transaction_history(
                             encoding: Some(UiTransactionEncoding::Base64),
                             commitment: Some(CommitmentConfig::confirmed()),
                             max_supported_transaction_version: Some(1),
+                            min_context_slot: None,
                         },
                     )
                     .await

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -835,6 +835,7 @@ pub async fn process_confirm(
                                 encoding: Some(UiTransactionEncoding::Base64),
                                 commitment: Some(CommitmentConfig::confirmed()),
                                 max_supported_transaction_version: Some(1),
+                                min_context_slot: None,
                             },
                         )
                         .await

--- a/rpc-client-types/src/config.rs
+++ b/rpc-client-types/src/config.rs
@@ -9,10 +9,14 @@ pub use {
     solana_transaction_status_client_types::{TransactionDetails, UiTransactionEncoding},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSignatureStatusConfig {
+    #[serde(default)]
     pub search_transaction_history: bool,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+    pub min_context_slot: Option<Slot>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -309,6 +313,7 @@ pub struct RpcTransactionConfig {
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
     pub max_supported_transaction_version: Option<u8>,
+    pub min_context_slot: Option<Slot>,
 }
 
 impl EncodingConfig for RpcTransactionConfig {

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -1669,6 +1669,24 @@ impl RpcClient {
         .await
     }
 
+    /// Gets the statuses of a list of transaction signatures with the given
+    /// [`RpcSignatureStatusConfig`], which can select a commitment level and a
+    /// minimum context slot.
+    ///
+    /// [`RpcSignatureStatusConfig`]: solana_rpc_client_api::config::RpcSignatureStatusConfig
+    pub async fn get_signature_statuses_with_config(
+        &self,
+        signatures: &[Signature],
+        config: solana_rpc_client_api::config::RpcSignatureStatusConfig,
+    ) -> RpcResult<Vec<Option<TransactionStatus>>> {
+        let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
+        self.send(
+            RpcRequest::GetSignatureStatuses,
+            json!([signatures, config]),
+        )
+        .await
+    }
+
     /// Check if a transaction has been processed with the given [commitment level][cl].
     ///
     /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
@@ -2984,6 +3002,7 @@ impl RpcClient {
     ///     encoding: Some(UiTransactionEncoding::Json),
     ///     commitment: Some(CommitmentConfig::confirmed()),
     ///     max_supported_transaction_version: Some(0),
+    ///     min_context_slot: None,
     /// };
     /// let transaction = rpc_client.get_transaction_with_config(
     ///     &signature,

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -1495,6 +1495,21 @@ impl RpcClient {
         self.invoke((self.rpc_client.as_ref()).get_signature_statuses_with_history(signatures))
     }
 
+    /// Gets the statuses of a list of transaction signatures with the given
+    /// [`RpcSignatureStatusConfig`], which can select a commitment level and a
+    /// minimum context slot.
+    ///
+    /// [`RpcSignatureStatusConfig`]: solana_rpc_client_api::config::RpcSignatureStatusConfig
+    pub fn get_signature_statuses_with_config(
+        &self,
+        signatures: &[Signature],
+        config: RpcSignatureStatusConfig,
+    ) -> RpcResult<Vec<Option<TransactionStatus>>> {
+        self.invoke(
+            (self.rpc_client.as_ref()).get_signature_statuses_with_config(signatures, config),
+        )
+    }
+
     /// Check if a transaction has been processed with the given [commitment level][cl].
     ///
     /// [cl]: https://solana.com/docs/rpc#configuring-state-commitment
@@ -2604,6 +2619,7 @@ impl RpcClient {
     ///     encoding: Some(UiTransactionEncoding::Json),
     ///     commitment: Some(CommitmentConfig::confirmed()),
     ///     max_supported_transaction_version: Some(0),
+    ///     min_context_slot: None,
     /// };
     /// let transaction = rpc_client.get_transaction_with_config(
     ///     &signature,
@@ -4629,6 +4645,35 @@ mod tests {
         assert_eq!(commitment.total_stake, 42);
         let slots = commitment.commitment.expect("commitment available");
         assert_eq!(slots.len(), MAX_LOCKOUT_HISTORY + 1);
+    }
+
+    #[test]
+    fn test_get_signature_statuses_with_config() {
+        let signature = Signature::default();
+        let config = RpcSignatureStatusConfig {
+            search_transaction_history: false,
+            commitment: Some(CommitmentConfig::confirmed()),
+            min_context_slot: Some(1),
+        };
+
+        // The "succeeds" mock answers with one finalized status per signature.
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+        let statuses = rpc_client
+            .get_signature_statuses_with_config(&[signature], config)
+            .unwrap()
+            .value;
+        assert_eq!(statuses.len(), 1);
+        let status = statuses[0].as_ref().unwrap();
+        assert_eq!(status.slot, 1);
+        assert!(status.err.is_none());
+
+        // The "sig_not_found" mock answers with None per signature.
+        let rpc_client = RpcClient::new_mock("sig_not_found".to_string());
+        let statuses = rpc_client
+            .get_signature_statuses_with_config(&[signature], config)
+            .unwrap()
+            .value;
+        assert_eq!(statuses, vec![None]);
     }
 
     #[test]

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1683,14 +1683,22 @@ impl JsonRpcRequestProcessor {
         signatures: Vec<Signature>,
         config: Option<RpcSignatureStatusConfig>,
     ) -> Result<RpcResponse<Vec<Option<TransactionStatus>>>> {
-        let search_transaction_history = config
-            .map(|x| x.search_transaction_history)
-            .unwrap_or(false);
+        let config = config.unwrap_or_default();
+        let search_transaction_history = config.search_transaction_history;
         if search_transaction_history {
             self.check_if_transaction_history_enabled()?;
         }
 
-        let bank = self.bank(Some(CommitmentConfig::processed()));
+        // Default to processed to preserve this method's historical behavior
+        // for callers that do not pass a commitment.
+        let bank = self.get_bank_with_config(RpcContextConfig {
+            commitment: Some(
+                config
+                    .commitment
+                    .unwrap_or_else(CommitmentConfig::processed),
+            ),
+            min_context_slot: config.min_context_slot,
+        })?;
         let mut statuses: Vec<Option<TransactionStatus>> = vec![];
 
         for signature in signatures {
@@ -1794,6 +1802,21 @@ impl JsonRpcRequestProcessor {
         check_is_at_least_confirmed(commitment)?;
 
         let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
+        // Fail fast, before consulting the blockstore or bigtable, when this
+        // node's view at the requested commitment is behind the caller's
+        // minimum. Mirrors getSignaturesForAddress.
+        let min_context_slot = config.min_context_slot.unwrap_or_default();
+        let context_slot = if commitment.is_confirmed() {
+            confirmed_bank.slot()
+        } else {
+            self.block_commitment_cache
+                .read()
+                .unwrap()
+                .highest_super_majority_root()
+        };
+        if context_slot < min_context_slot {
+            return Err(RpcCustomError::MinContextSlotNotReached { context_slot }.into());
+        }
         let confirmed_transaction = self
             .runtime
             .spawn_blocking({
@@ -4664,6 +4687,7 @@ pub mod tests {
         solana_rpc_client_api::{
             custom_error::{
                 JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+                JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
                 JSON_RPC_SERVER_ERROR_TRANSACTION_HISTORY_NOT_AVAILABLE,
                 JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
             },
@@ -6950,6 +6974,33 @@ pub mod tests {
                 .expect("actual response deserialization");
         assert_eq!(expected_res, result.as_ref().unwrap().status);
 
+        // minContextSlot ahead of the node's processed bank: fail fast with
+        // the context slot instead of answering from a stale view.
+        let req = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"getSignatureStatuses","params":[["{}"], {{"minContextSlot": {}}}]}}"#,
+            confirmed_block_signatures[0],
+            bank.slot() + 1000
+        );
+        let res = io.handle_request_sync(&req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        assert_eq!(
+            json["error"]["code"],
+            JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED
+        );
+        assert!(json["error"]["data"]["contextSlot"].is_u64());
+
+        // minContextSlot already satisfied: same answer as without it.
+        let req = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"getSignatureStatuses","params":[["{}"], {{"minContextSlot": 0}}]}}"#,
+            confirmed_block_signatures[0]
+        );
+        let res = io.handle_request_sync(&req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let result: Option<TransactionStatus> =
+            serde_json::from_value(json["result"]["value"][0].clone())
+                .expect("actual response deserialization");
+        assert!(result.is_some());
+
         // disable rpc-tx-history, but attempt historical query
         meta.config.enable_rpc_transaction_history = false;
         let req = format!(
@@ -7480,6 +7531,35 @@ pub mod tests {
             ),
         );
         assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn test_rpc_get_transaction_min_context_slot() {
+        let rpc = RpcHandler::start();
+        let signature = rpc.create_test_transactions_and_populate_blockstore()[0].to_string();
+        let expected = (
+            JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
+            String::from("Minimum context slot has not been reached"),
+        );
+
+        for commitment in ["confirmed", "finalized"] {
+            // Far ahead of anything this node has seen: fail fast instead of
+            // answering with an ambiguous null.
+            let config = json!({ "commitment": commitment, "minContextSlot": u64::MAX / 2 });
+            let request =
+                create_test_request("getTransaction", Some(json!([signature.clone(), config])));
+            assert_eq!(
+                parse_failure_response(rpc.handle_request_sync(request)),
+                expected
+            );
+
+            // Already satisfied: the normal lookup proceeds.
+            let config = json!({ "commitment": commitment, "minContextSlot": 0 });
+            let request =
+                create_test_request("getTransaction", Some(json!([signature.clone(), config])));
+            let result: Value = parse_success_result(rpc.handle_request_sync(request));
+            assert!(!result.is_null());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Neither method accepted `minContextSlot`, so a client polling for a transaction on a node that is behind gets an ambiguous `null` instead of a fast failure.

- `getTransaction`: new `minContextSlot` in the config. Checked before the blockstore/bigtable lookup, confirmed against the confirmed bank's slot and finalized against `highest_super_majority_root`, same as `getSignaturesForAddress`.
- `getSignatureStatuses`: config gains `commitment` and `minContextSlot`. Commitment selects the bank whose status cache is consulted and defaults to processed, so existing callers see no change. `searchTransactionHistory` is now optional in the config.
- `rpc-client`: `get_signature_statuses_with_config`.

Both fail with -32016 `MinContextSlotNotReached` carrying the node's context slot.
