### PR TITLE
clippy: use update or try_update instead of the deprecated fetch_update

### DIFF
--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -388,7 +388,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     // is perhaps being flushed by another thread already.
     pub fn next_bucket_to_flush(&self) -> usize {
         self.next_bucket_to_flush
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
                 Some((bucket + 1) % self.bins)
             })
             .unwrap()

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -388,10 +388,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     // is perhaps being flushed by another thread already.
     pub fn next_bucket_to_flush(&self) -> usize {
         self.next_bucket_to_flush
-            .try_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
-                Some((bucket + 1) % self.bins)
+            .update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
+                (bucket + 1) % self.bins
             })
-            .unwrap()
     }
 
     /// prepare for this to be dynamic if necessary

--- a/net-utils/src/token_bucket.rs
+++ b/net-utils/src/token_bucket.rs
@@ -77,6 +77,7 @@ impl TokenBucket {
     pub fn consume_tokens(&self, request_size: u64) -> Result<u64, u64> {
         let now = self.time_us();
         self.update_state(now);
+        #[cfg_attr(not(feature = "shuttle-test"), allow(deprecated))]
         match self.tokens.fetch_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
@@ -105,6 +106,7 @@ impl TokenBucket {
         let now = self.time_us();
         self.update_state(now);
         let mut consumed = 0u64;
+        #[cfg_attr(not(feature = "shuttle-test"), allow(deprecated))]
         let _ = self.tokens.fetch_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
@@ -119,6 +121,7 @@ impl TokenBucket {
     /// Adds given amount of tokens, up to a maximum of self.max_tokens.
     #[inline]
     pub fn add_tokens(&self, new_tokens: u64) {
+        #[cfg_attr(not(feature = "shuttle-test"), allow(deprecated))]
         let _ = self.tokens.fetch_update(
             Ordering::AcqRel,  // writer publishes new amount
             Ordering::Acquire, //we fetch the correct amount
@@ -316,6 +319,7 @@ where
         };
 
         if entry_added {
+            #[cfg_attr(not(feature = "shuttle-test"), allow(deprecated))]
             if let Ok(count) =
                 self.countdown_to_shrink
                     .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -43,7 +43,7 @@ impl ProgramStatistics {
     fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
         let duration_ema = duration_us.saturating_mul(EMA_SCALE);
         counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
                 // Exponential moving average iteratively is computed as $ema' = alpha *
                 // observation + (1 - alpha) * ema$. This works great for floating point, but we
                 // want integers. For purposes of convenience we also want to really think in terms

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -42,35 +42,33 @@ pub(crate) const EMA_SCALE: u64 = 1_000;
 impl ProgramStatistics {
     fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
         let duration_ema = duration_us.saturating_mul(EMA_SCALE);
-        counter
-            .try_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
-                // Exponential moving average iteratively is computed as $ema' = alpha *
-                // observation + (1 - alpha) * ema$. This works great for floating point, but we
-                // want integers. For purposes of convenience we also want to really think in terms
-                // of simple moving average window sizes as that is easier to reason about.
-                //
-                // Exponential moving average and simple moving average of window N has a rough
-                // equivalence of `alpha ≈ 2 / (N + 1)`. Slotting this into our original iterative
-                // formula:
-                //
-                // $$ ema' = 2 / (N+1) * observation + (1 - 2/(N+1)) * ema $$
-                //
-                // we get
-                //
-                // $$ ema' = (2*observation)/(N+1) + (N+1-2)*ema/(N+1) $$
-                let (numer, denom) = const { (2, 1 + WINDOW_SIZE) };
-                Some(if ema == 0 {
-                    duration_ema
-                } else {
-                    let weighted_observation = duration_ema.saturating_mul(numer);
-                    let previous_observations = ema.saturating_mul(denom.saturating_sub(numer));
-                    weighted_observation
-                        .saturating_add(previous_observations)
-                        .checked_div(denom)
-                        .expect("unreachable: denom is >= 1")
-                })
-            })
-            .expect("unreachable: closure always returns a Some");
+        counter.update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+            // Exponential moving average iteratively is computed as $ema' = alpha *
+            // observation + (1 - alpha) * ema$. This works great for floating point, but we
+            // want integers. For purposes of convenience we also want to really think in terms
+            // of simple moving average window sizes as that is easier to reason about.
+            //
+            // Exponential moving average and simple moving average of window N has a rough
+            // equivalence of `alpha ≈ 2 / (N + 1)`. Slotting this into our original iterative
+            // formula:
+            //
+            // $$ ema' = 2 / (N+1) * observation + (1 - 2/(N+1)) * ema $$
+            //
+            // we get
+            //
+            // $$ ema' = (2*observation)/(N+1) + (N+1-2)*ema/(N+1) $$
+            let (numer, denom) = const { (2, 1 + WINDOW_SIZE) };
+            if ema == 0 {
+                duration_ema
+            } else {
+                let weighted_observation = duration_ema.saturating_mul(numer);
+                let previous_observations = ema.saturating_mul(denom.saturating_sub(numer));
+                weighted_observation
+                    .saturating_add(previous_observations)
+                    .checked_div(denom)
+                    .expect("unreachable: denom is >= 1")
+            }
+        });
     }
 
     /// Record information about JIT compilation.

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -602,7 +602,7 @@ impl SubscriberCountGuard {
         let max = control.max_active_subscriptions;
         control
             .subscriber_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 (current < max).then_some(current + 1)
             })
             .ok()?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4415,7 +4415,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_on_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
                 Some(accounts_data_size_delta_on_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`
@@ -4430,7 +4430,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_off_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
                 Some(accounts_data_size_delta_off_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4414,12 +4414,13 @@ impl Bank {
             return;
         }
 
-        self.accounts_data_size_delta_on_chain
-            .try_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
-                Some(accounts_data_size_delta_on_chain.saturating_add(amount))
-            })
-            // SAFETY: unwrap() is safe since our update fn always returns `Some`
-            .unwrap();
+        self.accounts_data_size_delta_on_chain.update(
+            AcqRel,
+            Acquire,
+            |accounts_data_size_delta_on_chain| {
+                accounts_data_size_delta_on_chain.saturating_add(amount)
+            },
+        );
     }
 
     /// Update the accounts data size delta from off-chain events by adding `amount`.
@@ -4429,12 +4430,13 @@ impl Bank {
             return;
         }
 
-        self.accounts_data_size_delta_off_chain
-            .try_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
-                Some(accounts_data_size_delta_off_chain.saturating_add(amount))
-            })
-            // SAFETY: unwrap() is safe since our update fn always returns `Some`
-            .unwrap();
+        self.accounts_data_size_delta_off_chain.update(
+            AcqRel,
+            Acquire,
+            |accounts_data_size_delta_off_chain| {
+                accounts_data_size_delta_off_chain.saturating_add(amount)
+            },
+        );
     }
 
     /// Calculate the data size delta and update the off-chain accounts data size delta


### PR DESCRIPTION
#### Problem
`Atomic::fetch_update` was renamed to `try_update` for consistency, and the old name is deprecated as of 1.99.0-nightly.

#### Summary of Changes
- rename `fetch_update` call sites reached through `std` atomics to `try_update`
- convert callsites always passing `Some` into `update`
- allow the deprecation on the four token bucket calls, only for the std backend (those calls go through `solana-svm-type-overrides` and shuttle's atomics expose no `try_update`).

#### Testing
CI / checks on rust 1.98.1 bump branch, which needs to pull 1.99 nightly
