### PR TITLE
bank: emit a RewardInfo for the VAT burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9723,9 +9723,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "6.3.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad654f315da0db7f2d6371767146b7ff212b4d891f7438d441830c5910ef3edd"
+checksum = "0d20f0760fe5f41208593d5111a13dff725a0b1af9986924c4a4ce5461520d0d"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ solana-quic-client = { path = "quic-client", version = "=4.4.0-alpha.3", feature
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-remote-wallet = { path = "remote-wallet", version = "=4.4.0-alpha.3", default-features = false, features = ["agave-unstable-api"] }
 solana-rent = "4.4.0"
-solana-reward-info = "6.3.0"
+solana-reward-info = "7.0.0"
 solana-rpc = { path = "rpc", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "rpc-client", version = "=4.4.0-alpha.3", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.4.0-alpha.3" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7564,9 +7564,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "6.3.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad654f315da0db7f2d6371767146b7ff212b4d891f7438d441830c5910ef3edd"
+checksum = "0d20f0760fe5f41208593d5111a13dff725a0b1af9986924c4a4ce5461520d0d"
 dependencies = [
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7776,9 +7776,9 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "6.3.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad654f315da0db7f2d6371767146b7ff212b4d891f7438d441830c5910ef3edd"
+checksum = "0d20f0760fe5f41208593d5111a13dff725a0b1af9986924c4a4ce5461520d0d"
 dependencies = [
  "serde",
  "serde_derive",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2771,7 +2771,10 @@ impl Bank {
         // +1 for the incinerator account
         let mut accounts_to_store: Vec<(Pubkey, AccountSharedData)> =
             Vec::with_capacity(vote_accounts.len() + 1);
+        let mut vat_rewards = Vec::with_capacity(vote_accounts.len());
         let mut total_vat = 0u64;
+        let vat_reward_lamports =
+            -i64::try_from(vat_to_burn_per_epoch).expect("VAT amount should fit in an i64");
 
         // Vote accounts have already been filtered by clone_and_filter_for_vat to only include
         // accounts with non-zero stake and sufficient balance.
@@ -2787,6 +2790,15 @@ impl Bank {
                          balance for the VAT",
                     ),
             );
+            vat_rewards.push((
+                *vote_pubkey,
+                RewardInfo {
+                    reward_type: RewardType::VATDebit,
+                    lamports: vat_reward_lamports,
+                    post_balance: account.lamports(),
+                    commission_bps: None,
+                },
+            ));
             accounts_to_store.push((*vote_pubkey, account));
         }
 
@@ -2801,6 +2813,7 @@ impl Bank {
         accounts_to_store.push((incinerator::id(), incinerator_account));
 
         self.store_accounts((self.slot, accounts_to_store.as_slice()), None);
+        self.rewards.write().unwrap().extend(vat_rewards);
         info!(
             "Transferred total VAT of {total_vat} lamports to incinerator from staked vote \
              accounts"

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6909,9 +6909,15 @@ fn test_reduce_slot_time_features() {
 
 #[test]
 fn test_vat_burn_slot_params() {
-    let voting_keypair = ValidatorVoteKeypairs::new_rand();
-    let validator_keypairs = [&voting_keypair];
-    let vote_pubkey = voting_keypair.vote_keypair.pubkey();
+    let validator_keypairs = [
+        ValidatorVoteKeypairs::new_rand(),
+        ValidatorVoteKeypairs::new_rand(),
+        ValidatorVoteKeypairs::new_rand(),
+    ];
+    let vote_pubkeys = validator_keypairs
+        .iter()
+        .map(|keypairs| keypairs.vote_keypair.pubkey())
+        .collect::<Vec<_>>();
 
     // Loop through slot reduction features one at a time.
     for (slot_time_feature_id, params) in std::iter::once((None, LEGACY_SLOT_PARAMS))
@@ -6923,7 +6929,7 @@ fn test_vat_burn_slot_params() {
         } = genesis_utils::create_genesis_config_with_vote_accounts_and_cluster_type(
             1_000 * LAMPORTS_PER_SOL,
             &validator_keypairs,
-            vec![minimum_vote_account_balance_for_vat(100)],
+            vec![minimum_vote_account_balance_for_vat(100); validator_keypairs.len()],
             ClusterType::Development,
             &FeatureSet::default(),
             false,
@@ -6944,19 +6950,54 @@ fn test_vat_burn_slot_params() {
         assert_eq!(bank.vat_to_burn_per_epoch(), params.vat_to_burn_per_epoch());
 
         // Verify correct VAT amount is burned.
-        let vote_lamports_before = bank.get_balance(&vote_pubkey);
+        let vote_lamports_before = vote_pubkeys
+            .iter()
+            .map(|vote_pubkey| bank.get_balance(vote_pubkey))
+            .collect::<Vec<_>>();
         let incinerator_lamports_before = bank.get_balance(&incinerator::id());
+        let rewards_len_before = bank.rewards.read().unwrap().len();
         let stakes = SerdeStakesToStakeFormat::from(bank.get_top_epoch_stakes());
         let epoch_stakes = VersionedEpochStakes::new(stakes, bank.epoch());
         bank.maybe_burn_vat_from_staked_accounts(&epoch_stakes);
-        assert_eq!(
-            bank.get_balance(&vote_pubkey),
-            vote_lamports_before - params.vat_to_burn_per_epoch()
-        );
+        let vat_to_burn_per_epoch = params.vat_to_burn_per_epoch();
+        let vote_lamports_after = vote_lamports_before
+            .iter()
+            .map(|lamports| lamports.checked_sub(vat_to_burn_per_epoch).unwrap())
+            .collect::<Vec<_>>();
+        for (vote_pubkey, vote_lamports_after) in vote_pubkeys.iter().zip(&vote_lamports_after) {
+            assert_eq!(bank.get_balance(vote_pubkey), *vote_lamports_after);
+        }
         assert_eq!(
             bank.get_balance(&incinerator::id()),
-            incinerator_lamports_before + params.vat_to_burn_per_epoch()
+            incinerator_lamports_before
+                .checked_add(
+                    vat_to_burn_per_epoch
+                        .checked_mul(u64::try_from(vote_pubkeys.len()).unwrap())
+                        .unwrap(),
+                )
+                .unwrap()
         );
+        let vat_reward_lamports = -i64::try_from(vat_to_burn_per_epoch).unwrap();
+        let expected_rewards = vote_pubkeys
+            .iter()
+            .zip(&vote_lamports_after)
+            .map(|(vote_pubkey, vote_lamports_after)| {
+                (
+                    *vote_pubkey,
+                    RewardInfo {
+                        reward_type: RewardType::VATDebit,
+                        lamports: vat_reward_lamports,
+                        post_balance: *vote_lamports_after,
+                        commission_bps: None,
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let rewards = bank.rewards.read().unwrap();
+        let vat_rewards = &rewards[rewards_len_before..];
+        assert_eq!(vat_rewards.len(), vote_pubkeys.len());
+        let actual_rewards = vat_rewards.iter().copied().collect::<HashMap<_, _>>();
+        assert_eq!(actual_rewards, expected_rewards);
     }
 }
 

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -130,6 +130,7 @@ enum RewardType {
     Staking = 3;
     Voting = 4;
     DeactivatedStake = 5;
+    VATDebit = 6;
 }
 
 message Reward {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -130,6 +130,7 @@ impl From<Reward> for generated::Reward {
                 Some(RewardType::Staking) => generated::RewardType::Staking,
                 Some(RewardType::Voting) => generated::RewardType::Voting,
                 Some(RewardType::DeactivatedStake) => generated::RewardType::DeactivatedStake,
+                Some(RewardType::VATDebit) => generated::RewardType::VatDebit,
             } as i32,
             commission: reward.commission.map(|c| c.to_string()).unwrap_or_default(),
             commission_bps: reward
@@ -153,6 +154,7 @@ impl From<generated::Reward> for Reward {
                 3 => Some(RewardType::Staking),
                 4 => Some(RewardType::Voting),
                 5 => Some(RewardType::DeactivatedStake),
+                6 => Some(RewardType::VATDebit),
                 _ => None,
             },
             commission: reward.commission.parse::<u8>().ok(),
@@ -1421,6 +1423,10 @@ mod test {
         assert_eq!(reward, gen_reward.into());
 
         reward.reward_type = Some(RewardType::DeactivatedStake);
+        let gen_reward: generated::Reward = reward.clone().into();
+        assert_eq!(reward, gen_reward.into());
+
+        reward.reward_type = Some(RewardType::VATDebit);
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());
     }


### PR DESCRIPTION
#### Problem
There's no observability about the VAT burn.

#### Summary of Changes
Update the `reward-info` dependency and emit a `RewardType::VATDebit` for the burn

#### Testing
Unit Test

Fixes #15073 