### PR TITLE
feat(ledger-tool)!: remove program-count summaries

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -29,7 +29,7 @@ use {
     },
     std::{
         borrow::Cow,
-        collections::{BTreeMap, BTreeSet, HashMap},
+        collections::{BTreeMap, BTreeSet},
         fs::File,
         io::{BufRead, BufReader},
         path::{Path, PathBuf},
@@ -968,7 +968,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                     allow_dead_slots,
                     &output_format,
                     verbose_level,
-                    &mut HashMap::new(),
                 )?;
             }
         }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        error::{LedgerToolError, Result},
-        ledger_utils::get_program_ids,
-    },
+    crate::error::{LedgerToolError, Result},
     itertools::Either,
     pretty_hex::PrettyHex,
     serde::{
@@ -40,8 +37,6 @@ use {
     },
     std::{
         cell::RefCell,
-        cmp,
-        collections::HashMap,
         fmt::{self, Display, Formatter},
         io::{Write, stdout},
         rc::Rc,
@@ -849,7 +844,6 @@ pub fn output_slot(
     allow_dead_slots: bool,
     output_format: &OutputFormat,
     verbose_level: u64,
-    all_program_ids: &mut HashMap<Pubkey, u64>,
 ) -> Result<()> {
     let is_root = blockstore.is_root(slot);
     let is_dead = blockstore.is_dead(slot);
@@ -981,23 +975,10 @@ pub fn output_slot(
                 .map(|entry| entry.hash)
                 .unwrap_or_default();
 
-            let mut num_transactions = 0;
-            let mut program_ids = HashMap::new();
-
-            for transaction in block_contents.transactions() {
-                num_transactions += 1;
-                for program_id in get_program_ids(transaction) {
-                    *program_ids.entry(*program_id).or_insert(0) += 1;
-                }
-            }
+            let num_transactions = block_contents.transactions().count();
             println!(
                 "  Transactions: {num_transactions}, hashes: {num_hashes}, block_hash: {blockhash}",
             );
-            for (pubkey, count) in program_ids.iter() {
-                *all_program_ids.entry(*pubkey).or_insert(0) += count;
-            }
-            println!("  Programs:");
-            output_sorted_program_ids(program_ids);
         }
     } else if verbose_level == 2 {
         let encoded_block = EncodedConfirmedBlock::try_from(block_contents)?;
@@ -1044,7 +1025,6 @@ pub fn output_ledger(
 
     let num_slots = num_slots.unwrap_or(Slot::MAX);
     let mut num_printed = 0;
-    let mut all_program_ids = HashMap::new();
     for (slot, _slot_meta) in slot_iterator {
         if only_rooted && !blockstore.is_root(slot) {
             continue;
@@ -1059,7 +1039,6 @@ pub fn output_ledger(
             allow_dead_slots,
             &output_format,
             verbose_level,
-            &mut all_program_ids,
         ) {
             eprintln!("{err}");
         }
@@ -1071,20 +1050,8 @@ pub fn output_ledger(
 
     if output_format == OutputFormat::Json {
         stdout().write_all(b"\n]}\n")?;
-    } else {
-        println!("Summary of Programs:");
-        output_sorted_program_ids(all_program_ids);
     }
     Ok(())
-}
-
-pub fn output_sorted_program_ids(program_ids: HashMap<Pubkey, u64>) {
-    let mut program_ids_array: Vec<_> = program_ids.into_iter().collect();
-    // Sort descending by count of program id
-    program_ids_array.sort_by_key(|b| cmp::Reverse(b.1));
-    for (program_id, count) in program_ids_array.iter() {
-        println!("{:<44}: {}", program_id.to_string(), count);
-    }
 }
 
 /// A type to facilitate streaming account information to an output destination


### PR DESCRIPTION
#### Problem
We have methods that are not needed in the ledger-tool, and inflates the diff of #14638. See the comment thread linked below for more context.

Since we want to remove these anway

#### Summary of Changes
- removed `output_sorted_program_ids`
- removed summaries on program counts, (the building up of program_ids HashMap).

#### Testing
CI

Fixes https://github.com/anza-xyz/agave/pull/14638/changes/BASE..e6b5ff5c9acfa4d399ccc50e9b76521f2e24e99f#r3801155462
