### PR TITLE
fix(toolchain): bump rust toolchain to 1.98.1 and nightly=2026-07-16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.98.0"
+rust-version = "1.98.1"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
@@ -330,6 +330,8 @@ serde_with = { version = "3.22.0", default-features = false }
 serde_yaml = "0.9.34"
 serial_test = "4.0.1"
 shaq = { version = "4.1.0" }
+# When upgrading shuttle, check for try_update support to replace fetch_update in
+# net-utils/src/token_bucket.rs and remove its allow(deprecated) attributes.
 shuttle = "0.7.1"
 signal-hook = "0.4.4"
 slab = "0.4.12"

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -388,7 +388,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     // is perhaps being flushed by another thread already.
     pub fn next_bucket_to_flush(&self) -> usize {
         self.next_bucket_to_flush
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
                 Some((bucket + 1) % self.bins)
             })
             .unwrap()

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-07-03
+  nightly_version=2026-07-16
 fi
 
 

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -171,35 +171,35 @@ macro_rules! datapoint {
 #[macro_export]
 macro_rules! datapoint_error {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Error, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Error, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_warn {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Warn, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Warn, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_info {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Info, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Info, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_debug {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Debug, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Debug, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_trace {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Trace, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Trace, $name, $($fields)+)
     };
 }
 

--- a/net-utils/src/token_bucket.rs
+++ b/net-utils/src/token_bucket.rs
@@ -77,6 +77,10 @@ impl TokenBucket {
     pub fn consume_tokens(&self, request_size: u64) -> Result<u64, u64> {
         let now = self.time_us();
         self.update_state(now);
+        #[allow(
+            deprecated,
+            reason = "shuttle lacks try_update, the replacement for fetch_update"
+        )]
         match self.tokens.fetch_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
@@ -105,6 +109,10 @@ impl TokenBucket {
         let now = self.time_us();
         self.update_state(now);
         let mut consumed = 0u64;
+        #[allow(
+            deprecated,
+            reason = "shuttle lacks try_update, the replacement for fetch_update"
+        )]
         let _ = self.tokens.fetch_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
@@ -119,6 +127,10 @@ impl TokenBucket {
     /// Adds given amount of tokens, up to a maximum of self.max_tokens.
     #[inline]
     pub fn add_tokens(&self, new_tokens: u64) {
+        #[allow(
+            deprecated,
+            reason = "shuttle lacks try_update, the replacement for fetch_update"
+        )]
         let _ = self.tokens.fetch_update(
             Ordering::AcqRel,  // writer publishes new amount
             Ordering::Acquire, //we fetch the correct amount
@@ -316,6 +328,10 @@ where
         };
 
         if entry_added {
+            #[allow(
+                deprecated,
+                reason = "shuttle lacks try_update, the replacement for fetch_update"
+            )]
             if let Ok(count) =
                 self.countdown_to_shrink
                     .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -43,7 +43,7 @@ impl ProgramStatistics {
     fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
         let duration_ema = duration_us.saturating_mul(EMA_SCALE);
         counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
                 // Exponential moving average iteratively is computed as $ema' = alpha *
                 // observation + (1 - alpha) * ema$. This works great for floating point, but we
                 // want integers. For purposes of convenience we also want to really think in terms

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -602,7 +602,7 @@ impl SubscriberCountGuard {
         let max = control.max_active_subscriptions;
         control
             .subscriber_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 (current < max).then_some(current + 1)
             })
             .ok()?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4415,7 +4415,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_on_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
                 Some(accounts_data_size_delta_on_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`
@@ -4430,7 +4430,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_off_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
                 Some(accounts_data_size_delta_off_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"


### PR DESCRIPTION
#### Problem
Rust 1.98.0 can miscompile vtables and cause crashes, [including on `x86_64-unknown-linux-gnu`](https://github.com/rust-lang/rust/issues/161441#issuecomment-5381500635). Rust 1.98.1 fixes this regression: https://github.com/rust-lang/rust/issues/161441.

#### Summary of Changes
- bumped stable version to `1.98.1`
- bumped nightly to, `2026-07-16` (`1.99.0-nightly`) which is the earliest nightly containing the fix.
- `fetch_update` is deprecated and updated to use `try_update` on atomics, except for in `metrics/src/datapoint.rs` due to shuttle not supporting this new method name.
- Removed semi-colon to macros in `metrics/src/datapoint.rs` due to [`semicolon_in_expressions_from_macros`](https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint_defs/builtin/static.SEMICOLON_IN_EXPRESSIONS_FROM_MACROS.html).

#### Testing
CI