### PR TITLE
fix(remote-wallet): accept a longer Ledger app-configuration vector

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -69,6 +69,10 @@ const LEDGER_NANO_GEN5_PIDS: [u16; 33] = [
 ];
 const LEDGER_TRANSPORT_HEADER_LEN: usize = 5;
 
+/// Bytes of the current-format app-configuration vector that are actually read:
+/// blind-signing flag, pubkey display mode, then major, minor and patch.
+const CURRENT_APP_CONFIGURATION_LEN: usize = 5;
+
 const HID_PACKET_SIZE: usize = 64 + HID_PREFIX_ZERO;
 
 #[cfg(windows)]
@@ -346,7 +350,11 @@ impl LedgerWallet {
 
     fn get_configuration_vector(&self) -> Result<ConfigurationVersion, RemoteWalletError> {
         if let Ok(config) = self._send_apdu(commands::GET_APP_CONFIGURATION, 0, 0, &[], false) {
-            if config.len() != 5 {
+            // Newer Solana app versions append fields to this vector, and only
+            // the first five bytes are read (see `get_settings` and
+            // `get_firmware_version`), so a longer one is forward compatible.
+            // App 1.16.0 returns seven.
+            if !is_parsable_app_config(config.len()) {
                 return Err(RemoteWalletError::Protocol("Version packet size mismatch"));
             }
             Ok(ConfigurationVersion::Current(config))
@@ -650,6 +658,16 @@ pub fn get_wallet_from_info(
 }
 
 //
+/// Whether a current-format app-configuration payload is long enough to parse.
+///
+/// Only the first `CURRENT_APP_CONFIGURATION_LEN` bytes are read, so any vector
+/// at least that long is usable. Requiring an exact length rejected Solana app
+/// 1.16.0, which returns seven bytes, and prevented the device enumerating at
+/// all.
+fn is_parsable_app_config(len: usize) -> bool {
+    len >= CURRENT_APP_CONFIGURATION_LEN
+}
+
 fn is_last_part(p2: u8) -> bool {
     p2 & P2_MORE == 0
 }
@@ -680,6 +698,23 @@ mod tests {
         let p2 = P2_EXTEND | P2_MORE;
         assert!(!is_last_part(p2));
         assert!(is_last_part(p2 & !P2_MORE));
+    }
+
+    #[test]
+    fn test_is_parsable_app_config() {
+        // Exactly the fields that are read.
+        assert!(is_parsable_app_config(CURRENT_APP_CONFIGURATION_LEN));
+
+        // Solana app 1.16.0 answers with seven bytes: 00 00 01 10 00 00 00.
+        // The first five are unchanged -- blind-signing, pubkey display, then
+        // 1, 16, 0 -- and the two trailing bytes are simply not read here.
+        // Requiring exactly five made every Ledger running that app fail to
+        // enumerate.
+        assert!(is_parsable_app_config(7));
+
+        // Anything shorter cannot be indexed and must still be rejected.
+        assert!(!is_parsable_app_config(4));
+        assert!(!is_parsable_app_config(0));
     }
 
     #[test]

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -658,6 +658,10 @@ pub fn get_wallet_from_info(
 }
 
 //
+fn is_last_part(p2: u8) -> bool {
+    p2 & P2_MORE == 0
+}
+
 /// Whether a current-format app-configuration payload is long enough to parse.
 ///
 /// Only the first `CURRENT_APP_CONFIGURATION_LEN` bytes are read, so any vector
@@ -666,10 +670,6 @@ pub fn get_wallet_from_info(
 /// all.
 fn is_parsable_app_config(len: usize) -> bool {
     len >= CURRENT_APP_CONFIGURATION_LEN
-}
-
-fn is_last_part(p2: u8) -> bool {
-    p2 & P2_MORE == 0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #15099.

#### Problem

`solana-remote-wallet` cannot enumerate a Ledger Stax, Flex or Nano Gen5 running Solana app **1.16.0** or **1.16.1**, the production releases for those devices since 2026-09-02. Nano X and Nano S+ are not affected (see the scope note below). `update_devices()` returns `Protocol("Version packet size mismatch")` and `list_devices()` returns nothing — on a device that is plugged in, unlocked, running the Solana app, and answering BOLOS dashboard commands normally.

`GET_APP_CONFIGURATION` (`0xe0 0x04`) answers status `0x9000` with a **7-byte** payload:

```
00 00 01 10 00 00 00
```

and `get_configuration_vector` requires exactly five. The `DEPRECATED_GET_APP_CONFIGURATION` fallback below it is never reached, because the first call *succeeded* — control is already inside the `if let Ok(..)` arm. Probed directly on this app, the deprecated opcode answers `0x6a83`, so that path would not have helped either.

**The payload is backward compatible.** Every field the crate reads is present and correct, checked against `get_settings` and `get_firmware_version`:

| Byte | Field read today | Value | Meaning |
|---|---|---|---|
| 0 | `enable_blind_signing` | `00` | disabled |
| 1 | `pubkey_display` | `00` | `Long` |
| 2 | major | `01` | |
| 3 | minor | `10` | 16 |
| 4 | patch | `00` | |
| 5–6 | *(new, unread)* | `00 00` | Transaction Checks opt-in / enable |

Bytes 2–4 give **1.16.0**, independently confirmed by BOLOS `getAppAndVersion` on the same device (`... 06 31 2e 31 36 2e 30 ...` → `"1.16.0"`). The app appended two trailing fields and left the existing five untouched. The two trailing fields are the Transaction Checks settings (`tx_check_opt_in`, `tx_check_enable`) added in LedgerHQ/app-solana#196.

**Scope, corrected 2026-09-18.** This is device-class specific, not version specific. The two extra bytes are compiled under `HAVE_TRANSACTION_CHECKS`, which [`feature_transaction_check.h`](https://github.com/LedgerHQ/app-solana/blob/f36225a6cc4615d64df1533cfc40f49b28ef659d/src/feature_transaction_check.h) defines only when the SDK sets `SCREEN_SIZE_WALLET`: Stax, Flex and Nano Gen5. Nano X and Nano S+ build with `SCREEN_SIZE_NANO` and answer 5 bytes on every version, including 1.16.1, which is why a Nano X does not reproduce this. Ledger's own [functional test](https://github.com/LedgerHQ/app-solana/blob/f36225a6cc4615d64df1533cfc40f49b28ef659d/tests/python/test_app_configuration.py) asserts 5 bytes on a Nano and 7 otherwise. Reproduced on a Flex running 1.16.1: `00 00 01 10 01 00 00`. Separate from the Nano Gen5 product-id support added in 4.1: a build with those PIDs still cannot use a Gen5, because it fails later, here.

#### Summary of changes

The behavioural change is one comparison: `!=` becomes `>=` via a named predicate. The constant and predicate exist so the rule is testable without a device, matching the pure-function style of `test_is_last_part` and `test_parse_status` already in that module. Happy to collapse it to a bare `config.len() < 5` if you would rather not carry the helper.

#### Testing

`test_is_parsable_app_config` covers the accepted and rejected lengths, including the real 7-byte payload. Verified compiling and passing against the 4.2.2 sources with the identical edit:

```
test ledger::tests::test_is_last_part ... ok
test ledger::tests::test_is_parsable_app_config ... ok
test ledger::tests::test_parse_status ... ok
```

**Verified on hardware.** Nano Gen5 (`apex_p`, PID `0x8000`, BOLOS 1.1.1), Solana app 1.16.0, macOS 15 arm64:

| | |
|---|---|
| Enumeration + connect | pass |
| Pubkey at `m/44'/501'/0'` | pass |
| Transaction signing | pass |
| Off-chain message signing | pass |
| Reject on device, then sign again | pass |
| Reconnect cycle × 20 in one process | 20/20 |

Before the change none of these were reachable: enumeration failed first.

