### PR TITLE
runtime: inline the txn harness bank setup into execute_txn_proto

### DIFF
--- a/runtime/src/conformance/mod.rs
+++ b/runtime/src/conformance/mod.rs
@@ -1,33 +1,28 @@
 //! Solana runtime conformance harnesses.
 
-#[cfg(feature = "conformance")]
 pub mod block;
 pub mod txn;
 
-#[cfg(feature = "conformance")]
 use {
     protosol::protos::{
         AcctState, BlockhashQueueEntry as ProtoBlockhashQueueEntry,
         FeeRateGovernor as ProtoFeeRateGovernor,
     },
     solana_account::AccountSharedData,
-    solana_accounts_db::blockhash_queue::BlockhashQueue,
+    solana_accounts_db::{
+        accounts::Accounts,
+        accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig},
+        blockhash_queue::BlockhashQueue,
+    },
     solana_fee_calculator::FeeRateGovernor,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_svm::conformance::account_state::account_from_proto,
-};
-use {
-    solana_accounts_db::{
-        accounts::Accounts,
-        accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig},
-    },
     std::{num::NonZeroUsize, sync::Arc},
 };
 
 /// Parse the input accounts into keyed `AccountSharedData`, dropping zero-lamport
 /// accounts (treated as nonexistent).
-#[cfg(feature = "conformance")]
 pub(crate) fn deserialize_accounts(accounts: &[AcctState]) -> Vec<(Pubkey, AccountSharedData)> {
     accounts
         .iter()
@@ -39,7 +34,6 @@ pub(crate) fn deserialize_accounts(accounts: &[AcctState]) -> Vec<(Pubkey, Accou
         .collect()
 }
 
-#[cfg(feature = "conformance")]
 pub(crate) fn restore_blockhash_queue(entries: &[ProtoBlockhashQueueEntry]) -> BlockhashQueue {
     let mut blockhash_queue = BlockhashQueue::default();
     for entry in entries {
@@ -50,7 +44,6 @@ pub(crate) fn restore_blockhash_queue(entries: &[ProtoBlockhashQueueEntry]) -> B
     blockhash_queue
 }
 
-#[cfg(feature = "conformance")]
 pub(crate) fn fee_rate_governor_from_proto(
     value: &ProtoFeeRateGovernor,
     lamports_per_signature: u64,

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -1,204 +1,60 @@
 //! Transaction conformance harness.
 //!
-//! Split into two layers, mirroring the SVM harness convention:
+//! Decodes a `TxnContext`, builds a [`Bank`] from it, runs the transaction
+//! through `bank.load_and_execute_transactions`, and encodes the effects as a
+//! `TxnResult`. `sol_compat_txn_execute_v1` is the FFI entry point.
 //!
-//! * The **native** core ([`execute_txn`] + [`BankTxnProcessingResult`]) builds a
-//!   [`Bank`] via [`Bank::new_for_txn_tests`], runs
-//!   `bank.load_and_execute_transactions`, and returns the native execution
-//!   result. It depends only on `solana-runtime`/SVM types, so it is available
-//!   under `dev-context-only-utils` and is what the unit tests exercise.
-//! * The **conformance** layer (gated by the `conformance` feature) is the
-//!   protobuf glue: it decodes a `TxnContext`, converts it into native inputs,
-//!   calls [`execute_txn`], encodes the effects as a `TxnResult`, and exposes the
-//!   `sol_compat_txn_execute_v1` FFI entry point.
-//!
-//! Living inside `solana-runtime` lets the harness use the real `Bank` execution
-//! path (rather than driving the SVM directly), which keeps it at parity with
-//! SolFuzz-Agave.
+//! Living inside `solana-runtime` lets the harness use the real [`Bank`]
+//! execution path (rather than driving the SVM directly), which keeps it at
+//! parity with SolFuzz-Agave.
 
 use {
-    super::new_accounts_for_tests_single_threaded,
+    super::{
+        deserialize_accounts, fee_rate_governor_from_proto, new_accounts_for_tests_single_threaded,
+        restore_blockhash_queue,
+    },
     crate::{
         bank::{Bank, BankFieldsToDeserialize, BankRc},
         epoch_stakes::VersionedEpochStakes,
         stake_history::StakeHistory,
         stakes::{DeserializableDelegationStakes, SerdeStakesToStakeFormat, Stakes},
     },
-    agave_feature_set::FeatureSet,
+    agave_feature_set::virtual_address_space_adjustments,
     agave_transaction_view::transaction_view::UnsanitizedTransactionView,
+    ahash::AHashSet,
     bytes::Bytes,
-    solana_account::AccountSharedData,
-    solana_accounts_db::{ancestors::Ancestors, blockhash_queue::BlockhashQueue},
+    protosol::protos::{TxnContext as ProtoTxnContext, TxnResult as ProtoTxnResult},
+    solana_account::Account,
+    solana_accounts_db::ancestors::Ancestors,
     solana_clock::{BankId, Clock, DEFAULT_TICKS_PER_SLOT, Epoch, MAX_PROCESSING_AGE},
     solana_epoch_schedule::EpochSchedule,
-    solana_fee_calculator::FeeRateGovernor,
+    solana_message::SanitizedMessage,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_sdk_ids::sysvar,
+    solana_signature::Signature,
     solana_stake_interface::state::Stake,
     solana_svm::{
-        conformance::setup::sysvar_from_accounts,
+        conformance::{
+            direct_mapping::direct_mapping_handle_cu_exhaustion,
+            feature_set::feature_set_from_proto, setup::sysvar_from_accounts,
+            txn::effects::TxnEffects, versioned_transaction::versioned_transaction_from_proto,
+        },
+        rollback_accounts::RollbackAccounts,
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processing_result::TransactionProcessingResult,
+        transaction_processing_result::ProcessedTransaction,
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     solana_svm_timings::ExecuteTimings,
-    solana_transaction::{TransactionVerificationMode, versioned::VersionedTransaction},
+    solana_transaction::TransactionVerificationMode,
     solana_transaction_error::TransactionError,
     solana_vote::vote_account::VoteAccounts,
     std::collections::HashMap,
 };
-#[cfg(feature = "conformance")]
-use {
-    super::{deserialize_accounts, fee_rate_governor_from_proto, restore_blockhash_queue},
-    agave_feature_set::virtual_address_space_adjustments,
-    ahash::AHashSet,
-    protosol::protos::{TxnContext as ProtoTxnContext, TxnResult as ProtoTxnResult},
-    solana_account::Account,
-    solana_message::SanitizedMessage,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-    solana_signature::Signature,
-    solana_svm::conformance::{
-        direct_mapping::direct_mapping_handle_cu_exhaustion, feature_set::feature_set_from_proto,
-        txn::effects::TxnEffects, versioned_transaction::versioned_transaction_from_proto,
-    },
-    solana_svm::rollback_accounts::RollbackAccounts,
-    solana_svm::transaction_processing_result::ProcessedTransaction,
-};
 // Imports used only by the FFI entry point, which is excluded from `test` builds.
-#[cfg(all(feature = "conformance", not(test)))]
+#[cfg(not(test))]
 use {prost::Message, std::ffi::c_int};
 
-/// Result of executing a single transaction through the [`Bank`].
-pub enum BankTxnProcessingResult {
-    /// The transaction failed verification before processing.
-    FailedVerification(TransactionError),
-    /// The transaction was processed (executed, fees-only, or no-op). Carries the
-    /// processing result and transaction for effect extraction.
-    Processed {
-        result: TransactionProcessingResult,
-        runtime_transaction: Box<ReplayTransaction>,
-    },
-}
-
-/// Build a [`Bank`] from the supplied native inputs and execute `transaction`.
-///
-/// The clock and epoch-schedule sysvars are read out of `accounts` to derive the
-/// bank's slot/epoch.
-pub fn execute_txn(
-    accounts: &[(Pubkey, AccountSharedData)],
-    feature_set: FeatureSet,
-    blockhash_queue: BlockhashQueue,
-    fee_rate_governor: FeeRateGovernor,
-    total_epoch_stake: u64,
-    transaction: VersionedTransaction,
-) -> BankTxnProcessingResult {
-    // Slot and parent slot come from the clock sysvar.
-    let clock: Clock = sysvar_from_accounts(accounts, &sysvar::clock::id());
-    let slot = clock.slot;
-    let parent_slot = slot.saturating_sub(1);
-
-    let epoch_schedule: EpochSchedule =
-        sysvar_from_accounts(accounts, &sysvar::epoch_schedule::id());
-    let epoch = epoch_schedule.get_epoch(slot);
-
-    // Populate the accounts DB with the input accounts at the parent slot.
-    let bank_accounts = new_accounts_for_tests_single_threaded();
-    let ancestors = Ancestors::from(vec![parent_slot]);
-    bank_accounts.store_accounts((parent_slot, accounts), BankId::default(), None, &ancestors);
-    bank_accounts.accounts_db.add_root(parent_slot);
-    let bank_rc = BankRc::new(bank_accounts);
-
-    // Dummy epoch stakes with the provided total stake at the current and next epoch.
-    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
-    for key in [epoch, epoch.saturating_add(1)] {
-        let mut entry = VersionedEpochStakes::new(
-            SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
-            key,
-        );
-        entry.set_total_stake(total_epoch_stake);
-        epoch_stakes.insert(key, entry);
-    }
-
-    // `new_for_txn_tests` ignores `stakes`/`versioned_epoch_stakes`, but the
-    // struct still has to be constructed.
-    let stakes = DeserializableDelegationStakes {
-        vote_accounts: VoteAccounts::default(),
-        stake_delegations: vec![],
-        unused: 0,
-        epoch,
-        stake_history: StakeHistory::default(),
-    };
-
-    let bank_fields = BankFieldsToDeserialize {
-        blockhash_queue,
-        parent_slot,
-        tick_height: DEFAULT_TICKS_PER_SLOT.saturating_mul(slot),
-        max_tick_height: DEFAULT_TICKS_PER_SLOT.saturating_mul(slot.saturating_add(1)),
-        ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
-        slot,
-        block_height: slot,
-        fee_rate_governor,
-        epoch_schedule,
-        stakes,
-        ..BankFieldsToDeserialize::default()
-    };
-
-    // The bank must be wrapped in `BankForks` so the program cache has a fork graph;
-    // `_bank_forks` is kept alive for the duration of execution.
-    let bank = Bank::new_for_txn_tests(bank_rc, bank_fields, feature_set, epoch_stakes);
-    let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
-
-    let transaction_bytes = Bytes::from(wincode::serialize(&transaction).unwrap());
-    let Ok(transaction_view) = UnsanitizedTransactionView::try_new_unsanitized(transaction_bytes)
-    else {
-        return BankTxnProcessingResult::FailedVerification(TransactionError::SanitizeFailure);
-    };
-
-    let runtime_transaction = match bank.verify_transaction(
-        transaction_view,
-        TransactionVerificationMode::HashAndVerifyPrecompiles,
-    ) {
-        Ok(tx) => tx,
-        Err(err) => return BankTxnProcessingResult::FailedVerification(err),
-    };
-
-    let recording_config = ExecutionRecordingConfig {
-        enable_cpi_recording: false,
-        enable_log_recording: true,
-        enable_return_data_recording: true,
-        enable_transaction_balance_recording: false,
-    };
-    let processing_config = TransactionProcessingConfig {
-        recording_config,
-        limit_to_load_programs: true,
-        ..Default::default()
-    };
-
-    let mut timings = ExecuteTimings::default();
-    let mut metrics = TransactionErrorMetrics::default();
-    let result = {
-        let batch = bank.prepare_locked_batch_from_single_tx(&runtime_transaction);
-        bank.load_and_execute_transactions(
-            &batch,
-            MAX_PROCESSING_AGE,
-            &mut timings,
-            &mut metrics,
-            processing_config,
-        )
-        .processing_results
-        .into_iter()
-        .next()
-        .expect("single transaction execution must return one result")
-    };
-
-    BankTxnProcessingResult::Processed {
-        result,
-        runtime_transaction: Box::new(runtime_transaction),
-    }
-}
-
-#[cfg(feature = "conformance")]
 fn rollback_accounts_to_native(rollback_accounts: &RollbackAccounts) -> Vec<(Pubkey, Account)> {
     rollback_accounts
         .iter()
@@ -206,7 +62,6 @@ fn rollback_accounts_to_native(rollback_accounts: &RollbackAccounts) -> Vec<(Pub
         .collect()
 }
 
-#[cfg(feature = "conformance")]
 fn processed_transaction_effects(
     txn: &ProcessedTransaction,
     sanitized_message: &SanitizedMessage,
@@ -264,7 +119,15 @@ fn processed_transaction_effects(
     }
 }
 
-#[cfg(feature = "conformance")]
+/// Rejected before processing. Precompile error codes are not conformant, so
+/// the custom code is dropped.
+fn failed_verification_result(err: TransactionError) -> ProtoTxnResult {
+    ProtoTxnResult {
+        custom_error: 0,
+        ..unprocessed_txn_result(err)
+    }
+}
+
 fn unprocessed_txn_result(err: TransactionError) -> ProtoTxnResult {
     ProtoTxnResult {
         fee_details: None,
@@ -274,7 +137,6 @@ fn unprocessed_txn_result(err: TransactionError) -> ProtoTxnResult {
 
 /// Decode a `TxnContext` proto, run it through [`execute_txn`], and encode the
 /// effects as a `TxnResult` proto.
-#[cfg(feature = "conformance")]
 pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
     let txn_bank = context.bank.as_ref().unwrap();
 
@@ -305,25 +167,110 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
         transaction.signatures.push(Signature::default());
     }
 
-    let (result, runtime_transaction) = match execute_txn(
-        &accounts,
-        feature_set,
-        blockhash_queue,
-        fee_rate_governor,
-        txn_bank.total_epoch_stake,
-        transaction,
-    ) {
-        BankTxnProcessingResult::FailedVerification(err) => {
-            let mut txn_result = unprocessed_txn_result(err);
-            // Precompile error codes are not conformant, so they are ignored here.
-            txn_result.custom_error = 0;
-            return txn_result;
-        }
-        BankTxnProcessingResult::Processed {
-            result,
-            runtime_transaction,
-        } => (result, runtime_transaction),
+    // Slot and parent slot come from the clock sysvar.
+    let clock: Clock = sysvar_from_accounts(&accounts, &sysvar::clock::id());
+    let slot = clock.slot;
+    let parent_slot = slot.saturating_sub(1);
+
+    let epoch_schedule: EpochSchedule =
+        sysvar_from_accounts(&accounts, &sysvar::epoch_schedule::id());
+    let epoch = epoch_schedule.get_epoch(slot);
+
+    // Populate the accounts DB with the input accounts at the parent slot.
+    let bank_accounts = new_accounts_for_tests_single_threaded();
+    let ancestors = Ancestors::from(vec![parent_slot]);
+    bank_accounts.store_accounts(
+        (parent_slot, &accounts[..]),
+        BankId::default(),
+        None,
+        &ancestors,
+    );
+    bank_accounts.accounts_db.add_root(parent_slot);
+    let bank_rc = BankRc::new(bank_accounts);
+
+    // Dummy epoch stakes with the provided total stake at the current and next epoch.
+    let mut epoch_stakes: HashMap<Epoch, VersionedEpochStakes> = HashMap::new();
+    for key in [epoch, epoch.saturating_add(1)] {
+        let mut entry = VersionedEpochStakes::new(
+            SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
+            key,
+        );
+        entry.set_total_stake(txn_bank.total_epoch_stake);
+        epoch_stakes.insert(key, entry);
+    }
+
+    // `new_for_txn_tests` ignores `stakes`/`versioned_epoch_stakes`, but the
+    // struct still has to be constructed.
+    let stakes = DeserializableDelegationStakes {
+        vote_accounts: VoteAccounts::default(),
+        stake_delegations: vec![],
+        unused: 0,
+        epoch,
+        stake_history: StakeHistory::default(),
     };
+
+    let bank_fields = BankFieldsToDeserialize {
+        blockhash_queue,
+        parent_slot,
+        tick_height: DEFAULT_TICKS_PER_SLOT.saturating_mul(slot),
+        max_tick_height: DEFAULT_TICKS_PER_SLOT.saturating_mul(slot.saturating_add(1)),
+        ticks_per_slot: DEFAULT_TICKS_PER_SLOT,
+        slot,
+        block_height: slot,
+        fee_rate_governor,
+        epoch_schedule,
+        stakes,
+        ..BankFieldsToDeserialize::default()
+    };
+
+    // The bank must be wrapped in `BankForks` so the program cache has a fork graph;
+    // `_bank_forks` is kept alive for the duration of execution.
+    let bank = Bank::new_for_txn_tests(bank_rc, bank_fields, feature_set, epoch_stakes);
+    let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
+
+    let transaction_bytes = Bytes::from(wincode::serialize(&transaction).unwrap());
+    let Ok(transaction_view) = UnsanitizedTransactionView::try_new_unsanitized(transaction_bytes)
+    else {
+        return failed_verification_result(TransactionError::SanitizeFailure);
+    };
+
+    let runtime_transaction = match bank.verify_transaction(
+        transaction_view,
+        TransactionVerificationMode::HashAndVerifyPrecompiles,
+    ) {
+        Ok(tx) => tx,
+        Err(err) => return failed_verification_result(err),
+    };
+
+    let recording_config = ExecutionRecordingConfig {
+        enable_cpi_recording: false,
+        enable_log_recording: true,
+        enable_return_data_recording: true,
+        enable_transaction_balance_recording: false,
+    };
+    let processing_config = TransactionProcessingConfig {
+        recording_config,
+        limit_to_load_programs: true,
+        ..Default::default()
+    };
+
+    let mut timings = ExecuteTimings::default();
+    let mut metrics = TransactionErrorMetrics::default();
+    let result = {
+        let batch = bank.prepare_locked_batch_from_single_tx(&runtime_transaction);
+        bank.load_and_execute_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            &mut timings,
+            &mut metrics,
+            processing_config,
+        )
+        .processing_results
+        .into_iter()
+        .next()
+        .expect("single transaction execution must return one result")
+    };
+
     let sanitized_transaction = runtime_transaction.as_sanitized_transaction();
     let sanitized_message = sanitized_transaction.message();
 
@@ -376,7 +323,7 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
 // Excluded from `test` builds: the symbol would otherwise be defined both here
 // and in the `path = "."` dev-dependency rlib, producing a duplicate-symbol link
 // error. Tests call the native `execute_txn` directly.
-#[cfg(all(feature = "conformance", not(test)))]
+#[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sol_compat_txn_execute_v1(
     out_ptr: *mut u8,
@@ -408,7 +355,7 @@ pub unsafe extern "C" fn sol_compat_txn_execute_v1(
     1
 }
 
-#[cfg(all(test, feature = "conformance"))]
+#[cfg(test)]
 mod tests {
     use {
         super::{ProtoTxnResult, execute_txn_proto},

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -408,19 +408,24 @@ pub unsafe extern "C" fn sol_compat_txn_execute_v1(
     1
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "conformance"))]
 mod tests {
-    #[cfg(feature = "conformance")]
-    use std::collections::HashSet;
     use {
-        super::{BankTxnProcessingResult, execute_txn},
-        agave_feature_set::{FeatureSet, disable_sbpf_v0_execution, set_exempt_rent_epoch_max},
-        solana_account::{AccountSharedData, ReadableAccount},
-        solana_accounts_db::blockhash_queue::BlockhashQueue,
+        super::{ProtoTxnResult, execute_txn_proto},
+        agave_feature_set::{FEATURE_NAMES, disable_sbpf_v0_execution},
+        protosol::protos::{
+            BlockhashQueueEntry as ProtoBlockhashQueueEntry,
+            CompiledInstruction as ProtoCompiledInstruction, FeatureSet as ProtoFeatureSet,
+            FeeRateGovernor as ProtoFeeRateGovernor,
+            MessageAddressTableLookup as ProtoMessageAddressTableLookup,
+            MessageHeader as ProtoMessageHeader, SanitizedTransaction as ProtoSanitizedTransaction,
+            TransactionMessage as ProtoTransactionMessage, TxnBank as ProtoTxnBank,
+            TxnContext as ProtoTxnContext,
+        },
+        solana_account::AccountSharedData,
         solana_address_lookup_table_interface::state::{AddressLookupTable, LookupTableMeta},
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,
-        solana_fee_calculator::FeeRateGovernor,
         solana_hash::Hash,
         solana_loader_v3_interface::state::UpgradeableLoaderState,
         solana_message::{
@@ -430,48 +435,150 @@ mod tests {
             v0::{self, MessageAddressTableLookup},
         },
         solana_pubkey::Pubkey,
-        solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
         solana_sdk_ids::{bpf_loader_upgradeable, native_loader, sysvar},
         solana_signature::Signature,
         solana_slot_hashes::SlotHashes,
-        solana_svm::transaction_processing_result::{
-            ProcessedTransaction, TransactionProcessingResultExtensions,
+        solana_svm::{
+            conformance::account_state::account_to_proto,
+            transaction_processing_result::ProcessedTransaction,
         },
         solana_transaction::versioned::VersionedTransaction,
-        std::{borrow::Cow, env, fs, sync::Arc},
+        std::{borrow::Cow, collections::HashSet, env, fs, sync::Arc},
     };
 
-    /// All features enabled except `disable_sbpf_v0_execution`, so the v0
-    /// `complex-transfer` program loads. `set_exempt_rent_epoch_max` is forced on
-    /// to match the accounts' `u64::MAX` rent epoch.
-    fn feature_set() -> FeatureSet {
-        let mut feature_set = FeatureSet::all_enabled();
-        feature_set.activate(&set_exempt_rent_epoch_max::id(), 0);
-        feature_set.deactivate(&disable_sbpf_v0_execution::id());
-        feature_set
+    const LAMPORTS_PER_SIGNATURE: u64 = 5000;
+
+    /// A fixture addresses a feature by the first eight bytes of its pubkey.
+    fn feature_id(pubkey: &Pubkey) -> u64 {
+        u64::from_le_bytes(pubkey.to_bytes()[..8].try_into().unwrap())
     }
 
-    fn fee_rate_governor() -> FeeRateGovernor {
-        // Mirrors the proto path: only `lamports_per_signature` is set; the
-        // targets/burn are zeroed (unlike `FeeRateGovernor::default()`).
-        FeeRateGovernor {
-            lamports_per_signature: 5000,
-            target_lamports_per_signature: 0,
-            target_signatures_per_slot: 0,
-            min_lamports_per_signature: 0,
-            max_lamports_per_signature: 0,
-            burn_percent: 0,
+    /// Every feature except `disable_sbpf_v0_execution`, so the v0
+    /// `complex-transfer` program loads. `set_exempt_rent_epoch_max` is among
+    /// them, matching the accounts' `u64::MAX` rent epoch.
+    ///
+    /// Filtering happens in fixture-id space, not pubkey space:
+    /// `reenable_sbpf_v0_execution` shares its first eight bytes with
+    /// `disable_sbpf_v0_execution`, so leaving it in would re-add the same id
+    /// and `feature_set_from_proto` would resolve it to either feature.
+    fn proto_feature_set() -> ProtoFeatureSet {
+        let disabled = feature_id(&disable_sbpf_v0_execution::id());
+        ProtoFeatureSet {
+            features: FEATURE_NAMES
+                .keys()
+                .map(feature_id)
+                .filter(|id| *id != disabled)
+                .collect(),
         }
     }
 
     /// A blockhash queue with two registered hashes; returns the queue plus the
     /// most-recent blockhash to use as the message's `recent_blockhash`.
-    fn blockhash_queue() -> (BlockhashQueue, Hash) {
-        let mut queue = BlockhashQueue::default();
-        queue.register_hash(&Hash::new_unique(), 5000);
+    fn proto_blockhash_queue() -> (Vec<ProtoBlockhashQueueEntry>, Hash) {
         let recent = Hash::new_unique();
-        queue.register_hash(&recent, 5000);
-        (queue, recent)
+        let entries = [Hash::new_unique(), recent]
+            .iter()
+            .map(|blockhash| ProtoBlockhashQueueEntry {
+                blockhash: blockhash.to_bytes().to_vec(),
+                lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+            })
+            .collect();
+        (entries, recent)
+    }
+
+    /// The protobuf form of a transaction, as a fixture would carry it.
+    fn proto_transaction(transaction: &VersionedTransaction) -> ProtoSanitizedTransaction {
+        let message = &transaction.message;
+        let header = message.header();
+        // The fixture format only distinguishes legacy from v0.
+        let (is_legacy, address_table_lookups) = match message {
+            VersionedMessage::Legacy(_) => (true, vec![]),
+            VersionedMessage::V0(message) => (
+                false,
+                message
+                    .address_table_lookups
+                    .iter()
+                    .map(|lookup| ProtoMessageAddressTableLookup {
+                        account_key: lookup.account_key.to_bytes().to_vec(),
+                        writable_indexes: lookup
+                            .writable_indexes
+                            .iter()
+                            .copied()
+                            .map(u32::from)
+                            .collect(),
+                        readonly_indexes: lookup
+                            .readonly_indexes
+                            .iter()
+                            .copied()
+                            .map(u32::from)
+                            .collect(),
+                    })
+                    .collect(),
+            ),
+            VersionedMessage::V1(_) => panic!("v1 messages have no fixture representation"),
+        };
+
+        ProtoSanitizedTransaction {
+            message: Some(ProtoTransactionMessage {
+                is_legacy,
+                header: Some(ProtoMessageHeader {
+                    num_required_signatures: u32::from(header.num_required_signatures),
+                    num_readonly_signed_accounts: u32::from(header.num_readonly_signed_accounts),
+                    num_readonly_unsigned_accounts: u32::from(
+                        header.num_readonly_unsigned_accounts,
+                    ),
+                }),
+                account_keys: message
+                    .static_account_keys()
+                    .iter()
+                    .map(|key| key.to_bytes().to_vec())
+                    .collect(),
+                recent_blockhash: message.recent_blockhash().to_bytes().to_vec(),
+                instructions: message
+                    .instructions()
+                    .iter()
+                    .map(|instruction| ProtoCompiledInstruction {
+                        program_id_index: u32::from(instruction.program_id_index),
+                        accounts: instruction
+                            .accounts
+                            .iter()
+                            .copied()
+                            .map(u32::from)
+                            .collect(),
+                        data: instruction.data.clone(),
+                    })
+                    .collect(),
+                address_table_lookups,
+            }),
+            message_hash: vec![0; 32],
+            signatures: transaction
+                .signatures
+                .iter()
+                .map(|signature| signature.as_ref().to_vec())
+                .collect(),
+        }
+    }
+
+    fn txn_context(
+        accounts: Vec<(Pubkey, AccountSharedData)>,
+        transaction: VersionedTransaction,
+        blockhash_queue: Vec<ProtoBlockhashQueueEntry>,
+    ) -> ProtoTxnContext {
+        ProtoTxnContext {
+            tx: Some(proto_transaction(&transaction)),
+            account_shared_data: accounts
+                .into_iter()
+                .map(|(pubkey, account)| account_to_proto((pubkey, account.into())))
+                .collect(),
+            bank: Some(ProtoTxnBank {
+                blockhash_queue,
+                rbh_lamports_per_signature: LAMPORTS_PER_SIGNATURE as u32,
+                // Only the per-signature fee matters here; targets and burn are zeroed.
+                fee_rate_governor: Some(ProtoFeeRateGovernor::default()),
+                total_epoch_stake: 0,
+                features: Some(proto_feature_set()),
+            }),
+        }
     }
 
     fn account(lamports: u64, data: Vec<u8>, owner: Pubkey, executable: bool) -> AccountSharedData {
@@ -592,59 +699,20 @@ mod tests {
         ]
     }
 
-    /// Lamports of the writable account `pubkey` after execution, if the
-    /// transaction executed successfully.
-    fn writable_account_lamports(
-        execution: &BankTxnProcessingResult,
-        pubkey: &Pubkey,
-    ) -> Option<u64> {
-        match execution {
-            BankTxnProcessingResult::Processed {
-                result: Ok(ProcessedTransaction::Executed(executed_tx)),
-                runtime_transaction,
-            } => {
-                let sanitized_transaction = runtime_transaction.as_sanitized_transaction();
-                let sanitized_message = sanitized_transaction.message();
-                executed_tx
-                    .loaded_transaction
-                    .accounts
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| sanitized_message.is_writable(*index))
-                    .find(|(_, (key, _))| key == pubkey)
-                    .map(|(_, (_, account))| account.lamports())
-            }
-            _ => None,
-        }
+    /// Lamports of the writable account `pubkey` after execution.
+    fn writable_account_lamports(result: &ProtoTxnResult, pubkey: &Pubkey) -> Option<u64> {
+        result
+            .modified_accounts
+            .iter()
+            .find(|account| account.address.as_slice() == pubkey.as_ref())
+            .map(|account| account.lamports)
     }
 
-    fn return_data(execution: &BankTxnProcessingResult) -> Vec<u8> {
-        match execution {
-            BankTxnProcessingResult::Processed {
-                result: Ok(ProcessedTransaction::Executed(executed_tx)),
-                ..
-            } => executed_tx
-                .execution_details
-                .return_data
-                .as_ref()
-                .map(|info| info.data.clone())
-                .unwrap_or_default(),
-            _ => Vec::new(),
-        }
+    fn assert_executed_ok(result: &ProtoTxnResult) {
+        assert!(result.executed, "transaction was not processed");
+        assert_eq!(result.txn_error, 0, "transaction failed: {result:?}");
     }
 
-    fn assert_executed_ok(execution: &BankTxnProcessingResult) {
-        match execution {
-            BankTxnProcessingResult::Processed { result, .. } => {
-                assert!(result.was_processed_with_successful_result())
-            }
-            BankTxnProcessingResult::FailedVerification(err) => {
-                panic!("transaction failed verification: {err:?}")
-            }
-        }
-    }
-
-    #[cfg(feature = "conformance")]
     fn sanitized_message_with_program(program_id: Pubkey) -> solana_message::SanitizedMessage {
         solana_message::SanitizedMessage::try_from_legacy_message(
             legacy::Message {
@@ -666,7 +734,6 @@ mod tests {
         .unwrap()
     }
 
-    #[cfg(feature = "conformance")]
     #[test]
     fn noop_transaction_effects() {
         const COMPUTE_UNIT_LIMIT: u64 = 123_456;
@@ -716,7 +783,7 @@ mod tests {
         let [(program_id, program), (program_data_id, program_data)] =
             deploy_program("clock-sysvar");
         let fee_payer = Pubkey::new_unique();
-        let (blockhash_queue, recent_blockhash) = blockhash_queue();
+        let (blockhash_queue, recent_blockhash) = proto_blockhash_queue();
 
         let message = VersionedMessage::Legacy(legacy::Message {
             header: MessageHeader {
@@ -746,17 +813,10 @@ mod tests {
             rent_sysvar_account(),
         ];
 
-        let execution = execute_txn(
-            &accounts,
-            feature_set(),
-            blockhash_queue,
-            fee_rate_governor(),
-            0,
-            transaction,
-        );
+        let result = execute_txn_proto(&txn_context(accounts, transaction, blockhash_queue));
 
-        assert_executed_ok(&execution);
-        assert_eq!(return_data(&execution).len(), 8);
+        assert_executed_ok(&result);
+        assert_eq!(result.return_data.len(), 8);
     }
 
     #[test]
@@ -766,7 +826,7 @@ mod tests {
         let fee_payer = Pubkey::new_unique();
         let sender = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let (blockhash_queue, recent_blockhash) = blockhash_queue();
+        let (blockhash_queue, recent_blockhash) = proto_blockhash_queue();
 
         let message = VersionedMessage::V0(v0::Message {
             header: MessageHeader {
@@ -801,21 +861,11 @@ mod tests {
             slot_hashes_sysvar_account(),
         ];
 
-        let execution = execute_txn(
-            &accounts,
-            feature_set(),
-            blockhash_queue,
-            fee_rate_governor(),
-            0,
-            transaction,
-        );
+        let result = execute_txn_proto(&txn_context(accounts, transaction, blockhash_queue));
 
-        assert_executed_ok(&execution);
-        assert_eq!(writable_account_lamports(&execution, &sender), Some(899990));
-        assert_eq!(
-            writable_account_lamports(&execution, &recipient),
-            Some(900010)
-        );
+        assert_executed_ok(&result);
+        assert_eq!(writable_account_lamports(&result, &sender), Some(899990));
+        assert_eq!(writable_account_lamports(&result, &recipient), Some(900010));
     }
 
     #[test]
@@ -826,7 +876,7 @@ mod tests {
         let sender = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
         let extra_account = Pubkey::new_unique();
-        let (blockhash_queue, recent_blockhash) = blockhash_queue();
+        let (blockhash_queue, recent_blockhash) = proto_blockhash_queue();
 
         // The program adds this account's little-endian amount to the transfer.
         let extra_data = account(2, vec![5, 0, 0, 0, 0, 0, 0, 0], Pubkey::default(), false);
@@ -884,20 +934,10 @@ mod tests {
             slot_hashes_sysvar_account(),
         ];
 
-        let execution = execute_txn(
-            &accounts,
-            feature_set(),
-            blockhash_queue,
-            fee_rate_governor(),
-            0,
-            transaction,
-        );
+        let result = execute_txn_proto(&txn_context(accounts, transaction, blockhash_queue));
 
-        assert_executed_ok(&execution);
-        assert_eq!(writable_account_lamports(&execution, &sender), Some(899985));
-        assert_eq!(
-            writable_account_lamports(&execution, &recipient),
-            Some(900015)
-        );
+        assert_executed_ok(&result);
+        assert_eq!(writable_account_lamports(&result, &sender), Some(899985));
+        assert_eq!(writable_account_lamports(&result, &recipient), Some(900015));
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -15,7 +15,7 @@ pub mod bank_forks_controller;
 pub mod bank_utils;
 pub mod block_component_processor;
 pub mod commitment;
-#[cfg(any(feature = "conformance", feature = "dev-context-only-utils"))]
+#[cfg(feature = "conformance")]
 pub mod conformance;
 pub mod dependency_tracker;
 pub mod epoch_stakes;


### PR DESCRIPTION
#### Problem
Building on the back of #15076, we can factor the runtime txn harness even further before moving it to the new `agave-conformance` library.

#### Summary of Changes
Inline a few steps so that the primary harness is `execute_txn_proto`.

#### Testing
Existing tests, and when we finally have vector runs for runtime transactions we'll see any issues.