### PR TITLE
metrics: drop the trailing semicolon from the datapoint macros

### DIFF
--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -171,35 +171,35 @@ macro_rules! datapoint {
 #[macro_export]
 macro_rules! datapoint_error {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Error, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Error, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_warn {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Warn, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Warn, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_info {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Info, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Info, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_debug {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Debug, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Debug, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_trace {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Trace, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Trace, $name, $($fields)+)
     };
 }
 


### PR DESCRIPTION
#### Problem
The datapoint_* wrappers expand to `datapoint!(..);`, so using one in expression position trips the deny-by-default `semicolon_in_expressions_from_macros`, a future-incompatibility lint that fires on newer nightlies.

#### Summary of Changes
- expand the datapoint_* wrappers without the trailing semicolon

`datapoint!` itself expands to an `if` of type `()`, so both statement and expression uses keep working.

#### Testing
checked on nightly 2026-07-16