### PR TITLE
tpu-client-next: wrap broadcast with cancel/cert-update

### DIFF
--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -145,6 +145,10 @@ pub trait WorkersBroadcaster: Send + Sync {
     /// Returns error if a critical issue occurs, e.g. the implementation
     /// encounters an unrecoverable error. In this case, it will trigger
     /// stopping the scheduler and cleaning all the data.
+    ///
+    /// The scheduler may drop this future on shutdown, client identity updates, or identity-update
+    /// channel closure. Except on shutdown, when broadcast is interrupted, the scheduler tries to
+    /// broadcast the same transaction again.
     async fn send_to_workers(
         &self,
         workers: &mut WorkersCache,
@@ -195,14 +199,15 @@ impl ConnectionWorkersScheduler {
     }
 
     /// Starts the scheduler, which manages the distribution of transactions to the network's
-    /// upcoming leaders. `broadcaster` allows customizing how transactions are sent to the
-    /// leaders, see [`WorkersBroadcaster`].
+    /// upcoming leaders. `broadcaster` allows customizing how transactions are sent to the leaders,
+    /// see [`WorkersBroadcaster`].
     ///
     /// Runs the main loop that handles worker scheduling and management for connections. Returns
     /// [`SendTransactionStats`] or an error.
     ///
-    /// Importantly, if some transactions were not delivered due to network problems, they will not
-    /// be retried when the problem is resolved.
+    /// Pending broadcasts interrupted by client identity updates or identity-update channel closure
+    /// are retried with refreshed targets. Shutdown discards the pending transaction. Network
+    /// delivery failures after enqueueing do not trigger scheduler retries.
     pub async fn run_with_broadcaster(
         self,
         ConnectionWorkersSchedulerConfig {
@@ -238,9 +243,14 @@ impl ConnectionWorkersScheduler {
         let mut connect_leaders = Vec::with_capacity(leaders_fanout.connect);
         let mut send_leaders = Vec::with_capacity(leaders_fanout.send);
 
+        let mut pending_transaction = None;
         loop {
             let transaction: WireTransaction = tokio::select! {
-                recv_res = transaction_receiver.recv() => match recv_res {
+                // Retry a pending transaction before receiving a new one.
+                () = std::future::ready(()), if pending_transaction.is_some() => {
+                    pending_transaction.take().unwrap()
+                },
+                recv_res = transaction_receiver.recv(), if pending_transaction.is_none() => match recv_res {
                     Some(transaction) => transaction,
                     None => {
                         debug!("End of `transaction_receiver`: shutting down.");
@@ -257,16 +267,12 @@ impl ConnectionWorkersScheduler {
                         identity_updater_is_active = false;
                         continue;
                     };
-
-                    let client_config = build_client_config(
-                        update_identity_receiver.borrow_and_update().as_ref(),
+                    update_identity(
+                        &mut endpoint,
+                        &mut workers,
+                        &mut update_identity_receiver,
                         initial_congestion_window,
                     );
-                    endpoint.set_default_client_config(client_config);
-                    // Flush workers since they are handling connections created
-                    // with outdated certificate.
-                    workers.flush();
-                    debug!("Updated certificate.");
                     continue;
                 },
                 () = cancel.cancelled() => {
@@ -274,6 +280,8 @@ impl ConnectionWorkersScheduler {
                     break;
                 }
             };
+
+            pending_transaction = Some(transaction.clone());
 
             next_leaders.clear();
             leader_updater.next_leaders(leaders_fanout.connect, &mut next_leaders);
@@ -295,12 +303,27 @@ impl ConnectionWorkersScheduler {
 
             select_unique_leaders(&next_leaders, leaders_fanout.send, &mut send_leaders);
 
-            if let Err(error) = broadcaster
-                .send_to_workers(&mut workers, &send_leaders, transaction)
-                .await
-            {
-                last_error = Some(error);
-                break;
+            tokio::select! {
+                result = broadcaster.send_to_workers(&mut workers, &send_leaders, transaction) => {
+                    pending_transaction = None;
+                    if let Err(error) = result {
+                        last_error = Some(error);
+                        break;
+                    }
+                }
+                result = update_identity_receiver.changed(), if identity_updater_is_active => {
+                    if result.is_err() {
+                        identity_updater_is_active = false;
+                        continue;
+                    }
+                    update_identity(
+                        &mut endpoint,
+                        &mut workers,
+                        &mut update_identity_receiver,
+                        initial_congestion_window,
+                    );
+                }
+                () = cancel.cancelled() => break,
             }
         }
 
@@ -334,6 +357,23 @@ fn build_client_config(
         None => &QuicClientCertificate::new(None),
     };
     create_client_config(client_certificate, initial_congestion_window)
+}
+
+fn update_identity(
+    endpoint: &mut Endpoint,
+    workers: &mut WorkersCache,
+    update_identity_receiver: &mut watch::Receiver<Option<StakeIdentity>>,
+    initial_congestion_window: Option<u64>,
+) {
+    let client_config = build_client_config(
+        update_identity_receiver.borrow_and_update().as_ref(),
+        initial_congestion_window,
+    );
+    endpoint.set_default_client_config(client_config);
+    // Flush workers since they are handling connections created
+    // with outdated certificate.
+    workers.flush();
+    debug!("Updated certificate.");
 }
 
 /// [`NonblockingBroadcaster`] attempts to immediately send transactions to all the workers. If a


### PR DESCRIPTION
#### Problem

The broadcaster provided by user might be blocking, in this case if something is wrong with the network it can potentially hang the loop and will not react for the cancellation signal or certificate update.

#### Summary of Changes

Wraps broadcast call with the `select!` to handle cancellation or certificate update.

