### PR TITLE
ci(tombi): use toml version 1.0.0

### DIFF
--- a/tombi.toml
+++ b/tombi.toml
@@ -1,5 +1,3 @@
-toml-version = "v1.1.0"
-
 [format.rules]
 comment-style = "preserve"
 date-time-delimiter = "preserve"
@@ -8,6 +6,7 @@ key-quote-style = "preserve"
 string-quote-style = "preserve"
 
 [[schemas]]
+toml-version = "v1.0.0"
 path = "tombi://www.schemastore.org/cargo.json"
 include = ["Cargo.toml", "**/Cargo.toml"]
 


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/15062#issuecomment-5581450273

Our toolchain can't parse TOML 1.1.0, so tombi should format with toml version 1.0.0.

#### Summary of Changes
Change tombi to format cargo files with version 1.0.0.


#### Testing
CI