### PR TITLE
ci(fix): support toml 1.1.0 in msrv check

### DIFF
--- a/ci/xtask/src/commands.rs
+++ b/ci/xtask/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod channel_info;
+pub mod check_msrv;
 pub mod conformance_table;
 pub mod generate_pipeline;
 pub mod hello;

--- a/ci/xtask/src/commands/check_msrv.rs
+++ b/ci/xtask/src/commands/check_msrv.rs
@@ -1,0 +1,133 @@
+use {
+    anyhow::{Context, Result, ensure},
+    serde::Deserialize,
+    std::fs,
+};
+
+#[derive(Deserialize)]
+struct ToolchainManifest {
+    toolchain: Toolchain,
+}
+
+#[derive(Deserialize)]
+struct Toolchain {
+    channel: String,
+}
+
+#[derive(Deserialize)]
+struct CargoManifest {
+    workspace: Workspace,
+}
+
+#[derive(Deserialize)]
+struct Workspace {
+    package: Package,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Package {
+    rust_version: String,
+}
+
+pub fn run() -> Result<()> {
+    let toolchain =
+        fs::read_to_string("rust-toolchain.toml").context("failed to read rust-toolchain.toml")?;
+    let manifest = fs::read_to_string("Cargo.toml").context("failed to read Cargo.toml")?;
+    check_versions(&toolchain, &manifest)
+}
+
+fn check_versions(toolchain: &str, manifest: &str) -> Result<()> {
+    let toolchain: ToolchainManifest =
+        toml::from_str(toolchain).context("failed to parse rust-toolchain.toml")?;
+    let manifest: CargoManifest = toml::from_str(manifest).context("failed to parse Cargo.toml")?;
+    let rust_toolchain = toolchain.toolchain.channel;
+    let rust_version = manifest.workspace.package.rust_version;
+    ensure!(
+        rust_toolchain == rust_version,
+        "Toolchain {rust_toolchain} and rust-version {rust_version} are out of sync, they must be \
+         changed together"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOOLCHAIN: &str = "[toolchain]\nchannel = '1.98.0'";
+    const MANIFEST: &str = "[workspace.package]\nrust-version = '1.98.0'";
+
+    #[test]
+    fn accepts_matching_versions() {
+        check_versions(TOOLCHAIN, MANIFEST).unwrap();
+    }
+
+    #[test]
+    fn supports_toml_1_1_multiline_inline_tables() {
+        // Newlines between inline-table entries and trailing commas require TOML 1.1.
+        let toolchain = r#"
+            toolchain = {
+                channel = "1.98.0",
+                components = ["rustfmt", "clippy"],
+            }
+        "#;
+        let manifest = r#"
+            [workspace]
+            package = {
+                rust-version = "1.98.0",
+                edition = "2024",
+            }
+
+            [workspace.dependencies]
+            serde = {
+                version = "1.0",
+                features = [
+                    "derive",
+                ],
+            }
+        "#;
+
+        check_versions(toolchain, manifest).unwrap();
+
+        // A version mismatch must still be detected after parsing TOML 1.1.
+        let error = check_versions(toolchain, &manifest.replace("1.98.0", "1.97.0")).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Toolchain 1.98.0 and rust-version 1.97.0 are out of sync, they must be changed \
+             together"
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_versions() {
+        let error = check_versions(TOOLCHAIN, &MANIFEST.replace("1.98.0", "1.97.0")).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Toolchain 1.98.0 and rust-version 1.97.0 are out of sync, they must be changed \
+             together"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_invalid_and_malformed_fields() {
+        for toolchain in [
+            "",
+            "[toolchain]",
+            "[toolchain]\nchannel = 198",
+            "[toolchain",
+        ] {
+            let error = check_versions(toolchain, MANIFEST).unwrap_err();
+            assert_eq!(error.to_string(), "failed to parse rust-toolchain.toml");
+        }
+        for manifest in [
+            "",
+            "[workspace.package]",
+            "[workspace.package]\nrust-version = 198",
+            "[workspace",
+        ] {
+            let error = check_versions(TOOLCHAIN, manifest).unwrap_err();
+            assert_eq!(error.to_string(), "failed to parse Cargo.toml");
+        }
+    }
+}

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -21,6 +21,8 @@ struct Xtask {
 enum Commands {
     #[command(about = "Hello")]
     Hello,
+    #[command(about = "Check that the toolchain and workspace Rust versions match")]
+    CheckMsrv,
     #[command(about = "Bump version")]
     BumpVersion(xtask_shared::commands::bump_version::CommandArgs),
     #[command(about = "Update crate version")]
@@ -73,6 +75,7 @@ async fn try_main(xtask: Xtask) -> Result<()> {
     // run the command
     match xtask.command {
         Commands::Hello => commands::hello::run()?,
+        Commands::CheckMsrv => commands::check_msrv::run()?,
         Commands::BumpVersion(args) => {
             xtask_shared::commands::bump_version::run(args)?;
         }

--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -6,15 +6,4 @@
 set -eo pipefail
 cd "$(dirname "$0")/.."
 
-if ! command -v toml &>/dev/null; then
-  echo "not found toml-cli"
-  cargo install toml-cli
-fi
-
-rust_toolchain=$(toml get rust-toolchain.toml toolchain.channel)
-rust_version=$(toml get Cargo.toml workspace.package.rust-version)
-
-if [[ "$rust_toolchain" != "$rust_version" ]]; then
-  echo "Toolchain $rust_toolchain and rust-version $rust_version are out of sync, they must be changed together"
-  exit 1
-fi
+exec cargo xtask check-msrv


### PR DESCRIPTION
#### Problem
`toml-cli` which is currently used for the msrv check is not updated in last 4 yers, and doesn't support toml 1.1.0 which means CI can break when formatting with newer toml features such as multi-line inline tables.

Example: https://buildkite.com/anza/agave/builds/59529/list?jid=01a07ff4-8e8b-4fb1-8282-66fa0d434e81&tab=output

#### Summary of Changes
- Added msrv check to xtask CLI tool for CI checks.
- check-msrv script now dispacthes check to `xtask` instead of toml-cli.


#### Testing
- added unit tests
- explicit unit test to check multi-line inline tables are supported.
