### PR TITLE
bench(precompiles): move off nightly test bencher to criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "agave-precompiles",
  "bincode",
  "bytemuck",
+ "criterion",
  "ed25519-dalek 1.0.1",
  "hex",
  "libsecp256k1",

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -37,10 +37,23 @@ solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-precompiles = { path = ".", features = ["agave-unstable-api"] }
 bytemuck = { workspace = true }
+criterion = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 solana-instruction = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
+
+[[bench]]
+name = "ed25519_instructions"
+harness = false
+
+[[bench]]
+name = "secp256k1_instructions"
+harness = false
+
+[[bench]]
+name = "secp256r1_instructions"
+harness = false
 
 [lints]
 workspace = true

--- a/precompiles/benches/ed25519_instructions.rs
+++ b/precompiles/benches/ed25519_instructions.rs
@@ -1,28 +1,35 @@
-#![feature(test)]
-
-extern crate test;
 use {
-    agave_feature_set::FeatureSet, agave_precompiles::ed25519::verify,
-    ed25519_dalek::ed25519::signature::Signer, rand::Rng,
+    agave_feature_set::FeatureSet,
+    agave_precompiles::ed25519::verify,
+    criterion::{Criterion, criterion_group, criterion_main},
+    ed25519_dalek::ed25519::signature::Signer,
+    rand::Rng,
     solana_ed25519_program::new_ed25519_instruction_with_signature,
-    solana_instruction::Instruction, test::Bencher,
+    solana_instruction::Instruction,
+    std::time::Duration,
 };
 
-// 5K instructions should be enough for benching loop
-const IX_COUNT: u16 = 5120;
+// Cap the corpus by total message bytes rather than instruction count: the
+// large-message cases otherwise allocate hundreds of MiB and spend most of the
+// setup signing it, without verifying anything extra.
+const IX_BYTES_BUDGET: usize = 32 << 20;
+const IX_COUNT_MAX: usize = 1024;
 
 // prepare a bunch of unique txs
 fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
     let mut rng = rand::rng();
-    (0..IX_COUNT)
+    let ix_count = IX_BYTES_BUDGET
+        .checked_div(usize::from(message_length))
+        .unwrap_or(IX_COUNT_MAX)
+        .clamp(1, IX_COUNT_MAX);
+    (0..ix_count)
         .map(|_| {
             let secret_bytes: [u8; 32] = rand::random();
             let secret = ed25519_dalek::SecretKey::from_bytes(&secret_bytes).unwrap();
             let public: ed25519_dalek::PublicKey = (&secret).into();
             let privkey = ed25519_dalek::Keypair { secret, public };
-            let message: Vec<u8> = (0..message_length)
-                .map(|_| rng.random_range(0..255))
-                .collect();
+            let mut message = vec![0u8; usize::from(message_length)];
+            rng.fill(message.as_mut_slice());
             let signature = privkey.sign(&message).to_bytes();
             let pubkey = privkey.public.to_bytes();
             new_ed25519_instruction_with_signature(&message, &signature, &pubkey)
@@ -30,47 +37,36 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
-fn bench_ed25519_len_032(b: &mut Bencher) {
+fn bench_verify(c: &mut Criterion, name: &str, message_length: u16) {
     let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32);
+    let ixs = create_test_instructions(message_length);
     let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let instruction = ix_iter.next().unwrap();
+            verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+        })
     });
 }
 
-#[bench]
-fn bench_ed25519_len_128(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(128);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_ed25519_len_32k(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32 * 1024);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_ed25519_len_max(b: &mut Bencher) {
+fn bench_ed25519(c: &mut Criterion) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(u16::MAX - required_extra_space);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
+    bench_verify(c, "bench_ed25519_len_032", 32);
+    bench_verify(c, "bench_ed25519_len_128", 128);
+    bench_verify(c, "bench_ed25519_len_32k", 32 * 1024);
+    bench_verify(c, "bench_ed25519_len_max", u16::MAX - required_extra_space);
 }
+
+criterion_group! {
+    name = benches;
+    // Trim criterion's defaults to keep the suite near its libtest wall time.
+    // A single verify is tens of microseconds, so these windows still fit
+    // thousands of iterations per sample.
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(750))
+        .sample_size(20)
+        .without_plots();
+    targets = bench_ed25519
+}
+criterion_main!(benches);

--- a/precompiles/benches/secp256k1_instructions.rs
+++ b/precompiles/benches/secp256k1_instructions.rs
@@ -1,30 +1,34 @@
-#![feature(test)]
-
-extern crate test;
 use {
     agave_feature_set::FeatureSet,
     agave_precompiles::secp256k1::verify,
+    criterion::{Criterion, criterion_group, criterion_main},
     rand::Rng,
     solana_instruction::Instruction,
     solana_secp256k1_program::{
         eth_address_from_pubkey, new_secp256k1_instruction_with_signature, sign_message,
     },
-    test::Bencher,
+    std::time::Duration,
 };
 
-// 5K transactions should be enough for benching loop
-const TX_COUNT: u16 = 5120;
+// Cap the corpus by total message bytes rather than instruction count: the
+// large-message cases otherwise allocate hundreds of MiB and spend most of the
+// setup signing it, without verifying anything extra.
+const IX_BYTES_BUDGET: usize = 32 << 20;
+const IX_COUNT_MAX: usize = 1024;
 
 // prepare a bunch of unique ixs
 fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
     let mut rng = rand::rng();
-    (0..TX_COUNT)
+    let ix_count = IX_BYTES_BUDGET
+        .checked_div(usize::from(message_length))
+        .unwrap_or(IX_COUNT_MAX)
+        .clamp(1, IX_COUNT_MAX);
+    (0..ix_count)
         .map(|_| {
             let secret_bytes: [u8; 32] = rand::random();
             let secp_privkey = libsecp256k1::SecretKey::parse(&secret_bytes).unwrap();
-            let message: Vec<u8> = (0..message_length)
-                .map(|_| rng.random_range(0..255))
-                .collect();
+            let mut message = vec![0u8; usize::from(message_length)];
+            rng.fill(message.as_mut_slice());
             let secp_pubkey = libsecp256k1::PublicKey::from_secret_key(&secp_privkey);
             let eth_address =
                 eth_address_from_pubkey(&secp_pubkey.serialize()[1..].try_into().unwrap());
@@ -40,47 +44,40 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
-fn bench_secp256k1_len_032(b: &mut Bencher) {
+fn bench_verify(c: &mut Criterion, name: &str, message_length: u16) {
     let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32);
+    let ixs = create_test_instructions(message_length);
     let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let instruction = ix_iter.next().unwrap();
+            verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+        })
     });
 }
 
-#[bench]
-fn bench_secp256k1_len_256(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(256);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_secp256k1_len_32k(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32 * 1024);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_secp256k1_len_max(b: &mut Bencher) {
+fn bench_secp256k1(c: &mut Criterion) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(u16::MAX - required_extra_space);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
+    bench_verify(c, "bench_secp256k1_len_032", 32);
+    bench_verify(c, "bench_secp256k1_len_256", 256);
+    bench_verify(c, "bench_secp256k1_len_32k", 32 * 1024);
+    bench_verify(
+        c,
+        "bench_secp256k1_len_max",
+        u16::MAX - required_extra_space,
+    );
 }
+
+criterion_group! {
+    name = benches;
+    // Trim criterion's defaults to keep the suite near its libtest wall time.
+    // A single verify is tens of microseconds, so these windows still fit
+    // thousands of iterations per sample.
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(750))
+        .sample_size(20)
+        .without_plots();
+    targets = bench_secp256k1
+}
+criterion_main!(benches);

--- a/precompiles/benches/secp256r1_instructions.rs
+++ b/precompiles/benches/secp256r1_instructions.rs
@@ -1,9 +1,7 @@
-#![feature(test)]
-
-extern crate test;
 use {
     agave_feature_set::FeatureSet,
     agave_precompiles::secp256r1::verify,
+    criterion::{Criterion, criterion_group, criterion_main},
     openssl::{
         bn::BigNumContext,
         ec::{EcGroup, EcKey},
@@ -12,22 +10,28 @@ use {
     rand::Rng,
     solana_instruction::Instruction,
     solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message},
-    test::Bencher,
+    std::time::Duration,
 };
 
-// 5k transactions should be enough for benching loop
-const TX_COUNT: u16 = 5120;
+// Cap the corpus by total message bytes rather than instruction count: the
+// large-message cases otherwise allocate hundreds of MiB and spend most of the
+// setup signing it, without verifying anything extra.
+const IX_BYTES_BUDGET: usize = 32 << 20;
+const IX_COUNT_MAX: usize = 1024;
 
 // prepare a bunch of unique ixs
 fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
     let mut rng = rand::rng();
-    (0..TX_COUNT)
+    let ix_count = IX_BYTES_BUDGET
+        .checked_div(usize::from(message_length))
+        .unwrap_or(IX_COUNT_MAX)
+        .clamp(1, IX_COUNT_MAX);
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    (0..ix_count)
         .map(|_| {
-            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
             let secp_privkey = EcKey::generate(&group).unwrap();
-            let message: Vec<u8> = (0..message_length)
-                .map(|_| rng.random_range(0..255))
-                .collect();
+            let mut message = vec![0u8; usize::from(message_length)];
+            rng.fill(message.as_mut_slice());
             let signature =
                 sign_message(&message, &secp_privkey.private_key_to_der().unwrap()).unwrap();
             let mut ctx = BigNumContext::new().unwrap();
@@ -48,47 +52,40 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
-fn bench_secp256r1_len_032(b: &mut Bencher) {
+fn bench_verify(c: &mut Criterion, name: &str, message_length: u16) {
     let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32);
+    let ixs = create_test_instructions(message_length);
     let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let instruction = ix_iter.next().unwrap();
+            verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
+        })
     });
 }
 
-#[bench]
-fn bench_secp256r1_len_256(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(256);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_secp256r1_len_32k(b: &mut Bencher) {
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(32 * 1024);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
-}
-
-#[bench]
-fn bench_secp256r1_len_max(b: &mut Bencher) {
+fn bench_secp256r1(c: &mut Criterion) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
-    let feature_set = FeatureSet::all_enabled();
-    let ixs = create_test_instructions(u16::MAX - required_extra_space);
-    let mut ix_iter = ixs.iter().cycle();
-    b.iter(|| {
-        let instruction = ix_iter.next().unwrap();
-        verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
-    });
+    bench_verify(c, "bench_secp256r1_len_032", 32);
+    bench_verify(c, "bench_secp256r1_len_256", 256);
+    bench_verify(c, "bench_secp256r1_len_32k", 32 * 1024);
+    bench_verify(
+        c,
+        "bench_secp256r1_len_max",
+        u16::MAX - required_extra_space,
+    );
 }
+
+criterion_group! {
+    name = benches;
+    // Trim criterion's defaults to keep the suite near its libtest wall time.
+    // A single verify is tens of microseconds, so these windows still fit
+    // thousands of iterations per sample.
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(750))
+        .sample_size(20)
+        .without_plots();
+    targets = bench_secp256r1
+}
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem
The three precompile benches are the last thing keeping `cargo bench -p agave-precompiles` on nightly, and they are never exercised in CI, so nothing catches them rotting.

They also generate a fixed 5120-instruction corpus per case. For the 32k and 64k message cases that is 168MB and 335MB of message data signed on every run, which is all setup cost and buys no extra coverage - one verify per iteration only ever walks a few hundred of them.

#### Summary of Changes
- port all three benches to criterion, keeping the `#[bench]` fn names as the `bench_function` ids so `--output-format bencher` still emits the `ns/iter` lines ci/upload-benchmark.sh parses, under the same metric names
- cap the corpus by total message bytes instead of instruction count
- fill messages with `Rng::fill` instead of a per-byte `random_range`
- hoist the secp256r1 `EcGroup` out of the generator loop
- trim criterion's sampling windows so wall time does not grow

Deliberately not `bencher`: bencher 0.1.5 re-executes the whole benchmark fn - so all setup - up to 501 times per benchmark, where libtest and criterion run it once. On these setup-heavy benches that measured 129.7s.

#### Testing
Numbers move by at most +3% and the reported deviation drops from 3.5-16.6% to 1.1-3.3%. Run-only wall time for all 12 benches goes 17.9s -> 14.8s.

