### PR TITLE
bench(core): move consensus off nightly test bencher to criterion

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,9 +41,17 @@ jobs:
               name: "solana-poh",
               commands: ["cargo +$rust_nightly bench -p solana-poh"],
             }
+          # split because consensus is a criterion bench, while shredder and
+          # sigverify_stage use the bencher harness, which would treat
+          # `--output-format` as a benchmark name filter and run nothing
           - {
               name: "solana-core",
-              commands: ["cargo +$rust_nightly bench -p solana-core"],
+              commands:
+                [
+                  "cargo bench -p solana-core --bench consensus -- --output-format bencher --noplot",
+                  "cargo bench -p solana-core --bench shredder",
+                  "cargo bench -p solana-core --bench sigverify_stage",
+                ],
             }
           # spliting solana-accounts-db because it includes criterion bench
           - {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -228,6 +228,10 @@ test-case = { workspace = true }
 jemallocator = { workspace = true }
 
 [[bench]]
+name = "consensus"
+harness = false
+
+[[bench]]
 name = "sigverify_stage"
 harness = false
 

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -1,8 +1,5 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
+    criterion::{Criterion, criterion_group, criterion_main},
     solana_core::{
         consensus::{Tower, tower_storage::FileTowerStorage},
         vote_simulator::VoteSimulator,
@@ -14,14 +11,13 @@ use {
     std::{
         collections::{HashMap, HashSet},
         sync::Arc,
+        time::Duration,
     },
     tempfile::TempDir,
-    test::Bencher,
     trees::tr,
 };
 
-#[bench]
-fn bench_save_tower(bench: &mut Bencher) {
+fn bench_save_tower(c: &mut Criterion) {
     let dir = TempDir::new().unwrap();
 
     let vote_account_pubkey = &Pubkey::default();
@@ -38,14 +34,14 @@ fn bench_save_tower(bench: &mut Bencher) {
         &heaviest_bank,
     );
 
-    bench.iter(move || {
-        tower.save(&tower_storage, &node_keypair).unwrap();
+    c.bench_function("bench_save_tower", |b| {
+        b.iter(|| {
+            tower.save(&tower_storage, &node_keypair).unwrap();
+        })
     });
 }
 
-#[bench]
-#[ignore]
-fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
+fn bench_generate_ancestors_descendants(c: &mut Criterion) {
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
     let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests())
@@ -72,10 +68,25 @@ fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
         &mut tower,
     );
 
-    bench.iter(move || {
-        for _ in 0..num_banks {
-            let _ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
-            let _descendants = vote_simulator.bank_forks.read().unwrap().descendants();
-        }
+    // One pass per iteration. Repeating it `num_banks` times over an unchanged
+    // fork tree only multiplied the cost; the harness picks the iteration count.
+    c.bench_function("bench_generate_ancestors_descendants", |b| {
+        b.iter(|| {
+            let bank_forks = vote_simulator.bank_forks.read().unwrap();
+            (bank_forks.ancestors(), bank_forks.descendants())
+        })
     });
 }
+
+criterion_group! {
+    name = benches;
+    // Trim criterion's defaults: both benches are dominated by a fixture that
+    // is built once, and neither needs a long window to settle.
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(750))
+        .sample_size(10)
+        .without_plots();
+    targets = bench_save_tower, bench_generate_ancestors_descendants
+}
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem
`consensus.rs` is the last nightly-only bench in solana-core, so the whole package's benchmark job has to run on the nightly toolchain even though shredder and sigverify_stage are already on stable harnesses.

`bench_generate_ancestors_descendants` was `#[ignore]`d and therefore never measured: one iteration recomputed ancestors and descendants `num_banks` times over a fork tree that does not change between calls, so an iteration cost seconds.

#### Summary of Changes
- port both benches to criterion, keeping the `#[bench]` fn names as the `bench_function` ids so the uploaded metric names do not change
- do one ancestors/descendants pass per iteration instead of 500, and drop the `#[ignore]` - the harness picks the iteration count
- trim criterion's sampling windows
- point the solana-core benchmark job at stable

The job has to list benches individually: `benchmark_main!` from bencher takes the first extra argument as a name filter, so a package-wide `-- --output-format bencher` would silently run zero benchmarks in shredder and sigverify_stage.

#### Testing
bench_save_tower moves 63.8us -> 64.3us with deviation down from 12.2% to 3.1%. Run-only wall time 4.8s -> 2.5s, now covering both benches rather than one.
