### PR TITLE
chore(deps): bump solana-message from 4.5.0 to 4.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9056,9 +9056,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188f4df6f4f4d5bd8b9d82aee0f053b6c37826dcd96933f7b59f684b406a7b3c"
+checksum = "ef4b58f6d685adebefc945f28cf051cf3c11e295233e6dd3adfc0a71c3c6fb76"
 dependencies = [
  "blake3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,7 +420,7 @@ solana-loader-v4-interface = "3.1.0"
 solana-local-cluster = { path = "local-cluster", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
-solana-message = "4.5.0"
+solana-message = "4.6.0"
 solana-metrics = { path = "metrics", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -373,8 +373,13 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
         let instruction = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
-        let message =
-            v1::Message::try_compile(&payer.pubkey(), &[instruction], Hash::new_unique()).unwrap();
+        let message = v1::Message::try_compile_with_config(
+            &payer.pubkey(),
+            &[instruction],
+            Hash::new_unique(),
+            v1::TransactionConfig::empty(),
+        )
+        .unwrap();
 
         VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap()
     }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7111,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188f4df6f4f4d5bd8b9d82aee0f053b6c37826dcd96933f7b59f684b406a7b3c"
+checksum = "ef4b58f6d685adebefc945f28cf051cf3c11e295233e6dd3adfc0a71c3c6fb76"
 dependencies = [
  "blake3",
  "serde",

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -42,7 +42,7 @@ solana-cli-config = { workspace = true }
 solana-derivation-path = { workspace = true }
 solana-instruction = { version = "=3.5.0", features = ["bincode"] }
 solana-keypair = "=3.1.2"
-solana-message = { version = "=4.5.0", features = ["wincode"] }
+solana-message = { version = "=4.6.0", features = ["wincode"] }
 solana-pubkey = { version = "=4.3.0", default-features = false }
 solana-remote-wallet = { workspace = true, features = ["keystone"] }
 solana-seed-derivable = { workspace = true }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -200,10 +200,11 @@ mod tests {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
         let instruction = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
-        let message = solana_message::v1::Message::try_compile(
+        let message = solana_message::v1::Message::try_compile_with_config(
             &payer.pubkey(),
             &[instruction],
             Hash::new_unique(),
+            solana_message::v1::TransactionConfig::empty(),
         )
         .unwrap();
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7213,9 +7213,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188f4df6f4f4d5bd8b9d82aee0f053b6c37826dcd96933f7b59f684b406a7b3c"
+checksum = "ef4b58f6d685adebefc945f28cf051cf3c11e295233e6dd3adfc0a71c3c6fb76"
 dependencies = [
  "blake3",
  "serde",

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -5241,7 +5241,13 @@ mod tests {
         let ix = system_instruction::transfer(&key.pubkey(), &to, 50);
         let tx = VersionedTransaction::try_new(
             VersionedMessage::V1(
-                v1::Message::try_compile(&key.pubkey(), &[ix], blockhash).unwrap(),
+                v1::Message::try_compile_with_config(
+                    &key.pubkey(),
+                    &[ix],
+                    blockhash,
+                    v1::TransactionConfig::empty(),
+                )
+                .unwrap(),
             ),
             &[key],
         )

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3472,7 +3472,7 @@ impl Bank {
             blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
         }
         .or_else(|| {
-            let nonce_address = message.get_durable_nonce()?;
+            let nonce_address = SVMMessage::get_durable_nonce(message)?;
             let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
             verify_nonce_account(&nonce_account, message.recent_blockhash())
                 .map(|nonce_data| nonce_data.get_lamports_per_signature())

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -636,7 +636,13 @@ mod tests {
                 v0::Message::try_compile(&payer.pubkey(), &[ix], &[], recent_blockhash).unwrap(),
             ),
             TransactionVersion::Number(1) => VersionedMessage::V1(
-                v1::Message::try_compile(&payer.pubkey(), &[ix], recent_blockhash).unwrap(),
+                v1::Message::try_compile_with_config(
+                    &payer.pubkey(),
+                    &[ix],
+                    recent_blockhash,
+                    v1::TransactionConfig::empty(),
+                )
+                .unwrap(),
             ),
             TransactionVersion::Number(other) => {
                 panic!("unsupported test transaction version: {other}")

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9661,7 +9661,13 @@ fn test_verify_transactions_tx_v1_size_gate_does_not_relax_legacy_or_v0() {
     };
     let make_v1_transaction = |size| {
         let ixs = make_instructions(size);
-        let message = v1::Message::try_compile(&pubkey, &ixs, recent_blockhash).unwrap();
+        let message = v1::Message::try_compile_with_config(
+            &pubkey,
+            &ixs,
+            recent_blockhash,
+            v1::TransactionConfig::empty(),
+        )
+        .unwrap();
         VersionedTransaction::try_new(VersionedMessage::V1(message), &[&keypair]).unwrap()
     };
     let oversized_but_tx_v1_sized = |make_transaction: &dyn Fn(usize) -> VersionedTransaction| {


### PR DESCRIPTION
#### Summary of Changes

- bump solana-message from 4.5.0 to 4.6.0
- try_compile -> try_compile_with_config
- use SVMMessage::getdurable_nonce