### PR TITLE
Remove separated lists

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -142,17 +142,6 @@ pub(crate) struct AliveAccounts<'a> {
     pub(crate) bytes: usize,
 }
 
-/// separate alive accounts by whether a newer duplicate of the account exists
-#[derive(Debug)]
-pub(crate) struct AliveAccountsSeparated<'a> {
-    /// can be packed into any slot
-    pub(crate) no_duplicates: AliveAccounts<'a>,
-    /// can only be packed into a slot >= this one
-    pub(crate) newest_duplicate: AliveAccounts<'a>,
-    /// must stay in this slot
-    pub(crate) not_newest_duplicate: AliveAccounts<'a>,
-}
-
 pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
@@ -186,55 +175,6 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     }
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         &self.accounts
-    }
-}
-
-impl<'a> ShrinkCollector<'a> for AliveAccountsSeparated<'a> {
-    fn collect(&mut self, other: Self) {
-        self.no_duplicates.collect(other.no_duplicates);
-        self.newest_duplicate.collect(other.newest_duplicate);
-        self.not_newest_duplicate
-            .collect(other.not_newest_duplicate);
-    }
-    fn with_capacity(capacity: usize, slot: Slot) -> Self {
-        Self {
-            no_duplicates: AliveAccounts::with_capacity(capacity, slot),
-            newest_duplicate: AliveAccounts::with_capacity(0, slot),
-            not_newest_duplicate: AliveAccounts::with_capacity(0, slot),
-        }
-    }
-    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]) {
-        assert!(!slot_list.is_empty());
-        let slot = self.no_duplicates.slot;
-        let other = if slot_list.len() == 1 {
-            &mut self.no_duplicates
-        } else if !slot_list
-            .iter()
-            .any(|(slot_list_slot, _info)| slot_list_slot > &slot)
-        {
-            // this entry is alive but is newer than any other slot in the index
-            &mut self.newest_duplicate
-        } else {
-            // This entry is alive but is older than at least one other slot in the index.
-            // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
-            &mut self.not_newest_duplicate
-        };
-        other.add(account, slot_list);
-    }
-    fn len(&self) -> usize {
-        self.no_duplicates
-            .len()
-            .saturating_add(self.not_newest_duplicate.len())
-            .saturating_add(self.newest_duplicate.len())
-    }
-    fn alive_bytes(&self) -> usize {
-        self.no_duplicates
-            .alive_bytes()
-            .saturating_add(self.not_newest_duplicate.alive_bytes())
-            .saturating_add(self.newest_duplicate.alive_bytes())
-    }
-    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
-        unimplemented!("illegal use");
     }
 }
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -314,9 +314,6 @@ pub struct ShrinkAncientStats {
     pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
     pub bytes_from_newest_storages: AtomicU64,
-    pub many_ref_slots_skipped: AtomicU64,
-    pub slots_cannot_move_count: AtomicU64,
-    pub many_refs_old_alive: AtomicU64,
     pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
@@ -339,8 +336,6 @@ pub struct SquashStatsSub {
     pub store_accounts_stats: StoreAccountsForSquashStats,
     pub rewrite_elapsed_us: Saturating<u64>,
     pub create_and_insert_store_elapsed_us: Saturating<u64>,
-    pub unpackable_slots_count: Saturating<usize>,
-    pub newest_alive_packed_count: Saturating<usize>,
 }
 
 impl SquashStatsSub {
@@ -349,8 +344,6 @@ impl SquashStatsSub {
             .accumulate(&other.store_accounts_stats);
         self.rewrite_elapsed_us += other.rewrite_elapsed_us;
         self.create_and_insert_store_elapsed_us += other.create_and_insert_store_elapsed_us;
-        self.unpackable_slots_count += other.unpackable_slots_count;
-        self.newest_alive_packed_count += other.newest_alive_packed_count;
     }
 }
 
@@ -369,8 +362,6 @@ pub struct ShrinkStats {
     pub tombstone_carry_forward_us: AtomicU64,
     /// number of zero-lamport accounts carried forward to the new storage as tombstones
     pub num_tombstones_carried_forward: AtomicU64,
-    pub unpackable_slots_count: AtomicU64,
-    pub newest_alive_packed_count: AtomicU64,
     pub drop_storage_entries_elapsed: AtomicU64,
     pub accounts_removed: AtomicUsize,
     pub bytes_removed: AtomicU64,
@@ -561,13 +552,6 @@ impl ShrinkAncientStats {
         shrink_stats
             .rewrite_elapsed
             .fetch_add(stats_sub.rewrite_elapsed_us.0, Ordering::Relaxed);
-        shrink_stats
-            .unpackable_slots_count
-            .fetch_add(stats_sub.unpackable_slots_count.0 as u64, Ordering::Relaxed);
-        shrink_stats.newest_alive_packed_count.fetch_add(
-            stats_sub.newest_alive_packed_count.0 as u64,
-            Ordering::Relaxed,
-        );
         let StoreAccountsForSquashStats {
             store_accounts_for_shrink_stats,
             flush_read_cache_us,
@@ -659,20 +643,6 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "unpackable_slots_count",
-                self.shrink_stats
-                    .unpackable_slots_count
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "newest_alive_packed_count",
-                self.shrink_stats
-                    .newest_alive_packed_count
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "drop_storage_entries_elapsed",
                 self.shrink_stats
                     .drop_storage_entries_elapsed
@@ -757,21 +727,6 @@ impl ShrinkAncientStats {
             (
                 "bytes_from_newest_storages",
                 self.bytes_from_newest_storages.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "many_ref_slots_skipped",
-                self.many_ref_slots_skipped.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "slots_cannot_move_count",
-                self.slots_cannot_move_count.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "many_refs_old_alive",
-                self.many_refs_old_alive.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("slot", self.slot.load(Ordering::Relaxed), i64),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -490,7 +490,6 @@ impl AccountsDb {
             store_accounts_stats,
             rewrite_elapsed_us: Saturating(rewrite_elapsed_us),
             create_and_insert_store_elapsed_us: Saturating(create_and_insert_store_elapsed_us),
-            ..SquashStatsSub::default()
         });
 
         write_ancient_accounts

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -256,8 +256,7 @@ impl AncientSlotInfos {
             // It will take a lot of time for the pack algorithm to create that many, and that is bad for system performance.
             // This should be a limit that only affects extreme testing environments.
             // We do not stop including entries until we have dealt with all the high slot #s. This allows the algorithm to continue
-            // to make progress each time it is called. There are exceptions that can cause the pack to fail, such as accounts with multiple
-            // refs.
+            // to make progress each time it is called.
             if !info.is_high_slot
                 && (storages_remaining + ancient_storages_required < low_threshold
                     || ancient_storages_required as u64 > u64::from(tuning.max_resulting_storages))
@@ -405,8 +404,8 @@ impl AccountsDb {
 
         let mut accounts_to_combine = self.calc_accounts_to_combine(&mut accounts_per_storage);
 
-        // for the accounts which are one ref and can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
-        // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other normal one ref accounts.
+        // Put the accounts from the LARGEST storages at the end.
+        // This causes us to keep the accounts we're re-packing from already existing ancient storages together.
         // The alternative could cause us to mix newly ancient slots produced by flush (containing accounts touched more recently) with previously
         // packed ancient storages which over time contained enough dead accounts that the storage needed to be shrunk by being re-packed.
         // The end result of this sort should cause older, colder accounts (previously packed into large storages and then re-packed/shrunk) to
@@ -415,8 +414,7 @@ impl AccountsDb {
             .accounts_to_combine
             .sort_unstable_by_key(|a| a.written_bytes);
 
-        // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
-        // Note the `chain` below combining the 2 types of refs.
+        // Pack the accounts into storages of size 'ideal_storage_size'.
         let pack = PackedAncientStorage::pack(
             accounts_to_combine
                 .accounts_to_combine
@@ -688,23 +686,15 @@ impl AccountsDb {
         metrics.accumulate(&write_ancient_accounts.metrics);
     }
 
-    /// given all accounts per ancient slot, in slots that we want to combine together:
-    /// 1. Look up each pubkey in the index
-    /// 2. separate, by slot, into:
-    ///    2a. pubkeys with refcount = 1. This means this pubkey exists NOWHERE else in accounts db.
-    ///    2b. pubkeys with refcount > 1
-    ///
-    /// Note that the return value can contain fewer items than 'accounts_per_storage' if we find storages which won't be affected.
-    /// 'accounts_per_storage' should be sorted by slot
+    /// given all accounts per ancient slot, in slots that we want to combine together: get a list
+    /// of all the accounts that should be combined into new storages and the slots that should be
+    /// used for the new storages.
     fn calc_accounts_to_combine<'a>(
         &self,
         accounts_per_storage: &'a mut [(&'a SlotInfo, GetUniqueAccountsResult)],
     ) -> AccountsToCombine<'a> {
-        let len = accounts_per_storage.len();
-        let mut target_slots_sorted = Vec::with_capacity(len);
-
         // `shrink_collect` all accounts in the storages we want to combine.
-        let mut accounts_to_combine = accounts_per_storage
+        let accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
                 self.shrink_collect::<AliveAccounts<'_>>(
@@ -715,15 +705,10 @@ impl AccountsDb {
             })
             .collect::<Vec<_>>();
 
-        let mut last_slot = None;
-        for (_, shrink_collect) in accounts_to_combine.iter_mut().enumerate() {
-            // assert that iteration is in descending slot order since the code below relies on this.
-            if let Some(last_slot) = last_slot {
-                assert!(last_slot > shrink_collect.slot);
-            }
-            last_slot = Some(shrink_collect.slot);
-            target_slots_sorted.push(shrink_collect.slot);
-        }
+        let mut target_slots_sorted = accounts_to_combine
+            .iter()
+            .map(|shrink_collect| shrink_collect.slot)
+            .collect::<Vec<_>>();
 
         target_slots_sorted.sort_unstable();
         AccountsToCombine {
@@ -760,15 +745,10 @@ impl AccountsDb {
 /// hold all alive accounts to be shrunk and/or combined
 #[derive(Debug, Default)]
 struct AccountsToCombine<'a> {
-    /// all the rest of alive accounts that can move slots and should be combined
-    /// This includes all accounts with ref_count = 1 from the slots in 'accounts_keep_slots'.
-    /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
+    /// All alive accounts to be combined into new storages, along with the slot the accounts are currently stored in
     accounts_to_combine: Vec<ShrinkCollect<AliveAccounts<'a>>>,
-    /// slots that contain alive accounts that can move into ANY other ancient slot
-    /// these slots will NOT be in 'accounts_keep_slots'
-    /// Some of these slots will have ancient append vecs created at them to contain everything in 'accounts_to_combine'
-    /// The rest will become dead slots with no accounts in them.
-    /// Sort order is lowest to highest.
+    /// slots that contain alive accounts that can be reused for the new storages
+    /// sort order is lowest to highest
     target_slots_sorted: Vec<Slot>,
 }
 
@@ -1447,7 +1427,6 @@ mod tests {
     fn test_finish_combine_ancient_slots_packed_internal(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref
         // nothing shrunk, so all storages and roots should be removed
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -9,8 +9,7 @@ use {
         account_storage::ShrinkInProgress,
         account_storage_entry::AccountStorageEntry,
         accounts_db::{
-            AccountFromStorage, AccountsDb, AliveAccounts, AliveAccountsSeparated,
-            GetUniqueAccountsResult, ShrinkCollect,
+            AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
             stats::{ShrinkAncientStats, SquashStatsSub},
         },
         active_stats::ActiveStatItem,
@@ -22,7 +21,6 @@ use {
     solana_clock::Slot,
     solana_measure::measure_us,
     std::{
-        cmp,
         collections::{HashMap, VecDeque},
         num::{NonZeroU64, Saturating},
         sync::{Arc, Mutex, atomic::Ordering},
@@ -334,15 +332,6 @@ struct WriteAncientAccounts<'a> {
     metrics: SquashStatsSub,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
-/// specify what to do with slots with accounts with many refs
-enum IncludeManyRefSlots {
-    /// include them in packing
-    Include,
-    // skip them. ie. don't include them until sufficient slots of single refs have been created
-    Skip,
-}
-
 impl AccountsDb {
     /// Combine account data from storages in 'sorted_slots' into packed storages.
     /// This keeps us from accumulating storages for each slot older than an epoch.
@@ -383,37 +372,6 @@ impl AccountsDb {
         self.shrink_ancient_stats.report();
     }
 
-    /// return false if `newest_duplicate` accounts cannot be moved into `target_slots_sorted`.
-    /// The slot # would be violated.
-    /// accounts in `newest_duplicate` must be moved a slot >= each account's current slot.
-    /// If that can be done, this fn returns true
-    fn newest_duplicate_can_be_moved(
-        newest_duplicate: &[AliveAccounts<'_>],
-        target_slots_sorted: &[Slot],
-        tuning: &PackedAncientStorageTuning,
-    ) -> bool {
-        let alive_bytes = newest_duplicate
-            .iter()
-            .map(|alive| alive.bytes)
-            .sum::<usize>();
-        let required_ideal_packed = (alive_bytes as u64 / tuning.ideal_storage_size + 1) as usize;
-        if alive_bytes == 0 {
-            // nothing required, so no problem moving nothing
-            return true;
-        }
-        if target_slots_sorted.len() < required_ideal_packed {
-            return false;
-        }
-        let i_last = target_slots_sorted
-            .len()
-            .saturating_sub(required_ideal_packed);
-
-        let highest_slot = target_slots_sorted[i_last];
-        newest_duplicate
-            .iter()
-            .all(|many| many.slot <= highest_slot)
-    }
-
     fn combine_ancient_slots_packed_internal(
         &self,
         sorted_slots: Vec<Slot>,
@@ -445,40 +403,7 @@ impl AccountsDb {
                 &ancient_slot_infos.all_infos[..],
             );
 
-        let mut accounts_to_combine = self.calc_accounts_to_combine(
-            &mut accounts_per_storage,
-            &tuning,
-            IncludeManyRefSlots::Skip,
-        );
-        metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
-
-        let mut newest_duplicate = accounts_to_combine
-            .accounts_to_combine
-            .iter_mut()
-            .filter_map(|alive| {
-                let newest_alive = std::mem::take(&mut alive.alive_accounts.newest_duplicate);
-                (!newest_alive.accounts.is_empty()).then_some(newest_alive)
-            })
-            .collect::<Vec<_>>();
-
-        // Sort highest slot to lowest slot. This way, we will put the multi ref accounts with the highest slots in the highest
-        // packed slot.
-        newest_duplicate.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
-        metrics.newest_alive_packed_count += newest_duplicate.len();
-
-        if !Self::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &accounts_to_combine.target_slots_sorted,
-            &tuning,
-        ) {
-            datapoint_info!("shrink_ancient_stats", ("high_slot", 1, i64));
-            log::info!(
-                "unable to ancient pack: highest available slot: {:?}, lowest required slot: {:?}",
-                accounts_to_combine.target_slots_sorted.last(),
-                newest_duplicate.last().map(|accounts| accounts.slot)
-            );
-            return;
-        }
+        let mut accounts_to_combine = self.calc_accounts_to_combine(&mut accounts_per_storage);
 
         // for the accounts which are one ref and can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
         // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other normal one ref accounts.
@@ -493,12 +418,10 @@ impl AccountsDb {
         // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
         // Note the `chain` below combining the 2 types of refs.
         let pack = PackedAncientStorage::pack(
-            newest_duplicate.iter().chain(
-                accounts_to_combine
-                    .accounts_to_combine
-                    .iter()
-                    .map(|shrink_collect| &shrink_collect.alive_accounts.no_duplicates),
-            ),
+            accounts_to_combine
+                .accounts_to_combine
+                .iter()
+                .map(|shrink_collect| &shrink_collect.alive_accounts),
             tuning.ideal_storage_size,
         );
 
@@ -689,14 +612,7 @@ impl AccountsDb {
             });
         });
 
-        let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
-
-        // write new storages where contents were unable to move because ref_count > 1
-        self.write_ancient_accounts_to_same_slot(
-            accounts_to_combine.accounts_keep_slots.values(),
-            &mut write_ancient_accounts,
-        );
-        write_ancient_accounts
+        write_ancient_accounts.into_inner().unwrap()
     }
 
     /// for each slot in 'ancient_slots', collect all accounts in that slot
@@ -783,12 +699,7 @@ impl AccountsDb {
     fn calc_accounts_to_combine<'a>(
         &self,
         accounts_per_storage: &'a mut [(&'a SlotInfo, GetUniqueAccountsResult)],
-        tuning: &PackedAncientStorageTuning,
-        mut many_ref_slots: IncludeManyRefSlots,
     ) -> AccountsToCombine<'a> {
-        // reverse sort by slot #
-        accounts_per_storage.sort_unstable_by_key(|b| cmp::Reverse(b.0.slot));
-        let mut accounts_keep_slots = HashMap::default();
         let len = accounts_per_storage.len();
         let mut target_slots_sorted = Vec::with_capacity(len);
 
@@ -796,7 +707,7 @@ impl AccountsDb {
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
-                self.shrink_collect::<AliveAccountsSeparated<'_>>(
+                self.shrink_collect::<AliveAccounts<'_>>(
                     &info.storage,
                     unique_accounts,
                     &self.shrink_ancient_stats.shrink_stats,
@@ -804,121 +715,20 @@ impl AccountsDb {
             })
             .collect::<Vec<_>>();
 
-        let mut alive_bytes = accounts_to_combine
-            .iter()
-            .map(|a| a.alive_total_bytes)
-            .sum::<usize>();
-
-        let mut not_newest_duplicate_count = 0;
-
-        let mut remove = Vec::default();
         let mut last_slot = None;
-        for (i, shrink_collect) in accounts_to_combine.iter_mut().enumerate() {
-            // If 0 < alive_bytes < `ideal_storage_size`, then `min_resulting_packed_slots` = 0.
-            // We obviously require 1 packed slot if we have at least 1 alive byte.
-            // We want ceiling, so we add 1.
-            let min_resulting_packed_slots =
-                alive_bytes.saturating_sub(1) as u64 / u64::from(tuning.ideal_storage_size) + 1;
+        for (_, shrink_collect) in accounts_to_combine.iter_mut().enumerate() {
             // assert that iteration is in descending slot order since the code below relies on this.
             if let Some(last_slot) = last_slot {
                 assert!(last_slot > shrink_collect.slot);
             }
             last_slot = Some(shrink_collect.slot);
-
-            let not_newest_duplicate = &mut shrink_collect.alive_accounts.not_newest_duplicate;
-            if many_ref_slots == IncludeManyRefSlots::Skip
-                && !shrink_collect
-                    .alive_accounts
-                    .newest_duplicate
-                    .accounts
-                    .is_empty()
-            {
-                let mut required_packed_slots = min_resulting_packed_slots;
-                if not_newest_duplicate.accounts.is_empty() {
-                    // if THIS slot can be used as a target slot, then even if we have multi refs
-                    // this is ok.
-                    required_packed_slots = required_packed_slots.saturating_sub(1);
-                }
-
-                if (target_slots_sorted.len() as u64) >= required_packed_slots {
-                    // we have prepared to pack enough normal target slots, that form now on we can safely pack
-                    // any 'many ref' slots.
-                    many_ref_slots = IncludeManyRefSlots::Include;
-                } else {
-                    // Skip this because too few valid slots have been processed so far.
-                    // There are 'many ref newest' accounts in this slot. They must be packed into slots that are >= the current slot value.
-                    // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `many ref newest` accounts, then keep trying.
-                    // On the next pass, THIS slot will be older relative to newly ancient slot #s, so those newly ancient slots will be higher in this list.
-                    self.shrink_ancient_stats
-                        .many_ref_slots_skipped
-                        .fetch_add(1, Ordering::Relaxed);
-                    // since we're skipping this one, we don't count it as required target storages
-                    alive_bytes = alive_bytes.saturating_sub(shrink_collect.alive_total_bytes);
-                    remove.push(i);
-                    continue;
-                }
-            }
-
-            if !not_newest_duplicate.accounts.is_empty() {
-                not_newest_duplicate_count += not_newest_duplicate.accounts.len();
-                not_newest_duplicate.accounts.iter().for_each(|account| {
-                    // these accounts could indicate clean bugs or low memory conditions where we are forced to flush non-roots
-                    log::info!(
-                        "ancient append vec: found unpackable account: {}, {}",
-                        not_newest_duplicate.slot,
-                        account.pubkey()
-                    );
-                });
-                // There are alive accounts with a newer duplicate. (`not_newest_duplicate`)
-                // This means this account must remain IN this slot. There could be alive or dead references to this same account in any older slot.
-                // Moving it to a lower slot could move it before an alive or dead entry to this same account.
-                // Moving it to a higher slot could move it ahead of other slots where this account is also alive. We know a higher slot exists that contains this account.
-                // So, moving this account to a different slot could result in the moved account being before or after other instances of this account newer or older.
-                // This would fail the invariant that the highest slot # where an account exists defines the most recent account.
-                // It could be a clean error or a transient condition that will resolve if we encounter this situation.
-                // The count of these accounts per call will be reported by metrics in `unpackable_slots_count`
-                if shrink_collect
-                    .alive_accounts
-                    .no_duplicates
-                    .accounts
-                    .is_empty()
-                    && shrink_collect
-                        .alive_accounts
-                        .newest_duplicate
-                        .accounts
-                        .is_empty()
-                {
-                    // all accounts in this append vec are alive and have > 1 ref, so nothing to be done for this append vec
-                    remove.push(i);
-                    continue;
-                }
-                accounts_keep_slots
-                    .insert(shrink_collect.slot, std::mem::take(not_newest_duplicate));
-            } else {
-                // No alive accounts in this slot have a ref_count > 1. So, ALL alive accounts in this slot can be written to any other slot
-                // we find convenient. There is NO other instance of any account to conflict with.
-                target_slots_sorted.push(shrink_collect.slot);
-            }
-        }
-        let unpackable_slots_count = remove.len();
-
-        // Remove skipped slots
-        for i in remove.iter().rev() {
-            accounts_to_combine.remove(*i);
+            target_slots_sorted.push(shrink_collect.slot);
         }
 
         target_slots_sorted.sort_unstable();
-        self.shrink_ancient_stats
-            .slots_cannot_move_count
-            .fetch_add(accounts_keep_slots.len() as u64, Ordering::Relaxed);
-        self.shrink_ancient_stats
-            .many_refs_old_alive
-            .fetch_add(not_newest_duplicate_count as u64, Ordering::Relaxed);
         AccountsToCombine {
             accounts_to_combine,
-            accounts_keep_slots,
             target_slots_sorted,
-            unpackable_slots_count,
         }
     }
 
@@ -945,53 +755,21 @@ impl AccountsDb {
             .fetch_add(1, Ordering::Relaxed);
         self.write_ancient_accounts(*bytes_total, accounts_to_write, write_ancient_accounts)
     }
-
-    /// For each slot and alive accounts in 'accounts_to_combine'
-    /// create a PackedAncientStorage that only contains the given alive accounts.
-    /// This will represent only the accounts with ref_count > 1 from the original storage.
-    /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
-    /// Other accounts would have ref_count = 1.
-    /// ref_count = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
-    fn write_ancient_accounts_to_same_slot<'a, 'b: 'a>(
-        &'b self,
-        accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
-        write_ancient_accounts: &mut WriteAncientAccounts<'b>,
-    ) {
-        for alive_accounts in accounts_to_combine {
-            let packed = PackedAncientStorage {
-                bytes: alive_accounts.bytes as u64,
-                accounts: vec![(alive_accounts.slot, &alive_accounts.accounts[..])],
-            };
-
-            self.write_one_packed_storage(&packed, alive_accounts.slot, write_ancient_accounts);
-        }
-    }
 }
 
 /// hold all alive accounts to be shrunk and/or combined
 #[derive(Debug, Default)]
 struct AccountsToCombine<'a> {
-    /// slots and alive accounts that must remain in the slot they are currently in
-    /// because the account exists in more than 1 slot in accounts db
-    /// This hashmap contains an entry for each slot that contains at least one account with ref_count > 1.
-    /// The value of the entry is all alive accounts in that slot whose ref_count > 1.
-    /// Any OTHER accounts in that slot whose ref_count = 1 are in 'accounts_to_combine' because they can be moved
-    /// to any slot.
-    /// We want to keep the ref_count > 1 accounts by themselves, expecting the multiple ref_counts will be resolved
-    /// soon and we can clean the duplicates up (which maybe THIS one).
-    accounts_keep_slots: HashMap<Slot, AliveAccounts<'a>>,
     /// all the rest of alive accounts that can move slots and should be combined
     /// This includes all accounts with ref_count = 1 from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
-    accounts_to_combine: Vec<ShrinkCollect<AliveAccountsSeparated<'a>>>,
+    accounts_to_combine: Vec<ShrinkCollect<AliveAccounts<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
     /// these slots will NOT be in 'accounts_keep_slots'
     /// Some of these slots will have ancient append vecs created at them to contain everything in 'accounts_to_combine'
     /// The rest will become dead slots with no accounts in them.
     /// Sort order is lowest to highest.
     target_slots_sorted: Vec<Slot>,
-    /// when scanning, this many slots contained accounts that could not be packed because accounts with ref_count > 1 existed.
-    unpackable_slots_count: usize,
 }
 
 #[derive(Default)]
@@ -1121,7 +899,7 @@ mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                AccountsDbConfig, ShrinkCollector,
+                AccountsDbConfig,
                 tests::{ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash},
             },
             accounts_index::{ReclaimsSlotList, UpsertReclaim},
@@ -1218,27 +996,6 @@ mod tests {
                     .expect("must scan accounts storage");
             }
         })
-    }
-
-    /// Give every account backing `storages` a second index entry at slot 0. Sample-storage
-    /// slots start at 1, so slot 0 is older than all of them: each account ends up with
-    /// slot_list.len() == 2 while its storage slot stays newest
-    fn add_older_ref(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
-        storages.iter().for_each(|storage| {
-            db.get_unique_accounts_from_storage(storage)
-                .stored_accounts
-                .iter()
-                .for_each(|account| {
-                    db.accounts_index.upsert(
-                        0,
-                        0,
-                        account.pubkey(),
-                        AccountInfo::new(StorageLocation::AccountsFile(0, 0), false),
-                        &mut ReclaimsSlotList::new(),
-                        UpsertReclaim::IgnoreReclaims,
-                    );
-                });
-        });
     }
 
     fn unique_to_accounts<'a>(
@@ -1399,18 +1156,6 @@ mod tests {
             accounts: vec![(slots.start, &accounts[..])],
         }];
         db.write_packed_storages(&accounts_to_combine, packed_contents);
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_write_ancient_accounts_to_same_slot_empty(accounts_db_config: AccountsDbConfig) {
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
-        let (_storages, _slots, _infos) = get_sample_storages(&db, 0, None);
-        let mut write_ancient_accounts = WriteAncientAccounts::default();
-        db.write_ancient_accounts_to_same_slot(
-            AccountsToCombine::default().accounts_keep_slots.values(),
-            &mut write_ancient_accounts,
-        );
-        assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -1722,11 +1467,8 @@ mod tests {
                         )
                         .collect::<Vec<_>>();
 
-                    let accounts_to_combine = db.calc_accounts_to_combine(
-                        &mut accounts_per_storage,
-                        &default_tuning(),
-                        IncludeManyRefSlots::Include,
-                    );
+                    let accounts_to_combine =
+                        db.calc_accounts_to_combine(&mut accounts_per_storage);
                     let mut stats = SquashStatsSub::default();
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
 
@@ -1772,625 +1514,6 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_many_refs(accounts_db_config: AccountsDbConfig) {
-        // n storages
-        // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
-        let data_size = 48;
-        let alive_bytes_per_slot = AppendVec::calculate_stored_size(data_size as usize) as u64;
-
-        // pack 2.5 ancient slots into 1 packed slot ideally
-        let tuning = PackedAncientStorageTuning {
-            ideal_storage_size: NonZeroU64::new(alive_bytes_per_slot * 2 + 1).unwrap(),
-            ..default_tuning()
-        };
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
-            for num_slots in 0..6 {
-                for unsorted_slots in [false, true] {
-                    for two_refs in [false, true] {
-                        let db = AccountsDb::new_for_tests_with_config(
-                            Vec::new(),
-                            accounts_db_config.clone(),
-                        );
-                        let (mut storages, _slots, mut infos) =
-                            get_sample_storages(&db, num_slots, Some(data_size));
-
-                        infos.iter_mut().for_each(|a| {
-                            a.alive_bytes += alive_bytes_per_slot;
-                        });
-
-                        if unsorted_slots {
-                            storages = storages.into_iter().rev().collect();
-                            infos = infos.into_iter().rev().collect();
-                        }
-
-                        if two_refs {
-                            add_older_ref(&db, &storages);
-                        }
-
-                        let original_results = storages
-                            .iter()
-                            .map(|store| db.get_unique_accounts_from_storage(store))
-                            .collect::<Vec<_>>();
-
-                        let mut accounts_per_storage =
-                            infos.iter().zip(original_results).collect::<Vec<_>>();
-
-                        let accounts_to_combine = db.calc_accounts_to_combine(
-                            &mut accounts_per_storage,
-                            &tuning,
-                            many_ref_slots,
-                        );
-                        let expected_accounts_to_combine = if num_slots >= 3
-                            && two_refs
-                            && many_ref_slots == IncludeManyRefSlots::Skip
-                        {
-                            // In this test setup, 2.5 regular slots fits into 1 ancient slot.
-                            // When there are two_refs and when slots < 3, all regular slots can fit into one ancient slots.
-                            // Therefore, we should have all slots that can be combined for slots < 3.
-                            // However, when slots >=3, we need more than one ancient slots. The pack algorithm will need to first
-                            // find at least [ceiling(num_slots/2.5) - 1] slots that's don't have many_refs before we can pack slots with many_refs.
-                            // Since we decrease the number of alive bytes we'll be writing, when we encounter slots that can't be packed,
-                            // we now reduce the number required ideal packed storages. As a result, the last
-                            // slot can be packed, and the number of accounts to combine should be 2.
-                            2
-                        } else {
-                            num_slots
-                        };
-                        (0..accounts_to_combine
-                            .target_slots_sorted
-                            .len()
-                            .saturating_sub(1))
-                            .for_each(|i| {
-                                let slots = &accounts_to_combine.target_slots_sorted;
-                                assert!(slots[i] < slots[i + 1]);
-                            });
-
-                        log::debug!(
-                            "output slots: {:?}, num_slots: {num_slots}, two_refs: {two_refs}, \
-                             many_refs: {many_ref_slots:?}, expected accounts to combine: \
-                             {expected_accounts_to_combine}, target slots: {:?}, \
-                             accounts_to_combine: {}",
-                            accounts_to_combine.target_slots_sorted,
-                            accounts_to_combine.target_slots_sorted,
-                            accounts_to_combine.accounts_to_combine.len(),
-                        );
-                        assert_eq!(
-                            accounts_to_combine.accounts_to_combine.len(),
-                            expected_accounts_to_combine,
-                            "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
-                             {many_ref_slots:?}"
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_simple(accounts_db_config: AccountsDbConfig) {
-        // n storages
-        // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
-        let data_size = 48;
-        let alive_bytes_per_account = AppendVec::calculate_stored_size(data_size as usize) as u64;
-
-        // pack 1 account into a slot ideally
-        let tuning = PackedAncientStorageTuning {
-            ideal_storage_size: NonZeroU64::new(alive_bytes_per_account).unwrap(),
-            ..default_tuning()
-        };
-
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
-            for add_dead_account in [true, false] {
-                for num_slots in 0..3 {
-                    for unsorted_slots in [false, true] {
-                        for two_refs in [false, true] {
-                            let db = AccountsDb::new_for_tests_with_config(
-                                Vec::new(),
-                                accounts_db_config.clone(),
-                            );
-                            let (mut storages, slots, mut infos) =
-                                get_sample_storages(&db, num_slots, Some(data_size));
-                            infos
-                                .iter_mut()
-                                .for_each(|a| a.alive_bytes += alive_bytes_per_account);
-
-                            let slots_vec;
-                            if unsorted_slots {
-                                slots_vec = slots.rev().collect::<Vec<_>>();
-                                storages = storages.into_iter().rev().collect();
-                                infos = infos.into_iter().rev().collect();
-                            } else {
-                                slots_vec = slots.collect::<Vec<_>>()
-                            }
-
-                            if two_refs {
-                                add_older_ref(&db, &storages);
-                            }
-
-                            if add_dead_account {
-                                storages.iter().for_each(|storage| {
-                                    let pk = solana_pubkey::new_rand();
-                                    let alive = false;
-                                    append_single_account_with_default_hash(
-                                        storage,
-                                        &pk,
-                                        &AccountSharedData::default(),
-                                        alive,
-                                        Some(&db.accounts_index),
-                                    );
-                                    // mark the account obsolete and remove it from the index,
-                                    // as clean does when it reclaims an account
-                                    let account_offset =
-                                        db.accounts_index.get_and_then(&pk, |entry| {
-                                            let slot_list = entry.unwrap().slot_list_read_lock();
-                                            (false, slot_list.first().unwrap().1.offset())
-                                        });
-                                    storage
-                                        .obsolete_accounts
-                                        .write()
-                                        .unwrap()
-                                        .mark_accounts_obsolete(
-                                            std::iter::once((account_offset, 0)),
-                                            storage.slot(),
-                                        );
-                                    assert!(
-                                        db.accounts_index.purge_exact(
-                                            &pk,
-                                            [storage.slot()]
-                                                .into_iter()
-                                                .collect::<std::collections::HashSet<Slot>>(),
-                                            &mut ReclaimsSlotList::new()
-                                        )
-                                    );
-                                });
-                            }
-                            let original_results = storages
-                                .iter()
-                                .map(|store| db.get_unique_accounts_from_storage(store))
-                                .collect::<Vec<_>>();
-
-                            let mut accounts_per_storage =
-                                infos.iter().zip(original_results).collect::<Vec<_>>();
-
-                            let accounts_to_combine = db.calc_accounts_to_combine(
-                                &mut accounts_per_storage,
-                                &tuning,
-                                many_ref_slots,
-                            );
-                            // if we are only trying to pack a single slot of multi-refs, it will succeed
-                            // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
-                            // one element (storage), because we don't count alive bytes of skipped accounts
-                            // when we compute required target storages, and the second slot can be combined.
-                            let expected_number_accounts_to_combine = if !two_refs
-                                || many_ref_slots == IncludeManyRefSlots::Include
-                                || num_slots == 1
-                                || (num_slots == 2 && many_ref_slots != IncludeManyRefSlots::Skip)
-                            {
-                                num_slots
-                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
-                            {
-                                1
-                            } else {
-                                0
-                            };
-                            assert_eq!(
-                                accounts_to_combine.accounts_to_combine.len(),
-                                expected_number_accounts_to_combine,
-                                "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
-                                 {many_ref_slots:?}"
-                            );
-
-                            let expected_target_slots_sorted = if !two_refs
-                                || many_ref_slots == IncludeManyRefSlots::Include
-                                || num_slots == 1
-                            {
-                                if unsorted_slots {
-                                    slots_vec.iter().cloned().rev().collect::<Vec<_>>()
-                                } else {
-                                    slots_vec.clone()
-                                }
-                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
-                            {
-                                vec![1]
-                            } else {
-                                vec![]
-                            };
-                            // all accounts should be in no_duplicates and all slots are available as target slots
-                            assert_eq!(
-                                accounts_to_combine.target_slots_sorted,
-                                expected_target_slots_sorted,
-                            );
-                            assert!(accounts_to_combine.accounts_keep_slots.is_empty());
-                            assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                |shrink_collect| {
-                                    shrink_collect
-                                        .alive_accounts
-                                        .not_newest_duplicate
-                                        .accounts
-                                        .is_empty()
-                                }
-                            ));
-                            if two_refs {
-                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                    |shrink_collect| {
-                                        shrink_collect
-                                            .alive_accounts
-                                            .no_duplicates
-                                            .accounts
-                                            .is_empty()
-                                    }
-                                ));
-                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                    |shrink_collect| {
-                                        !shrink_collect
-                                            .alive_accounts
-                                            .newest_duplicate
-                                            .accounts
-                                            .is_empty()
-                                    }
-                                ));
-                            } else {
-                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                    |shrink_collect| {
-                                        !shrink_collect
-                                            .alive_accounts
-                                            .no_duplicates
-                                            .accounts
-                                            .is_empty()
-                                    }
-                                ));
-                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                    |shrink_collect| {
-                                        shrink_collect
-                                            .alive_accounts
-                                            .newest_duplicate
-                                            .accounts
-                                            .is_empty()
-                                    }
-                                ));
-                            }
-
-                            let packed_contents = Vec::default();
-                            let write_ancient_accounts =
-                                db.write_packed_storages(&accounts_to_combine, packed_contents);
-
-                            assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_older_dup(accounts_db_config: AccountsDbConfig) {
-        // looking at 1 storage
-        // with 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs (and the other ref is from a newer slot)
-        // So, the newer duplicate will put this account into not_newest_duplicate and then accounts_keep_slots
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
-        let num_slots = 1;
-        // creating 1 more sample slot/storage, but effectively act like 1 slot
-        let (mut storages, slots, infos) = get_sample_storages(&db, num_slots + 1, None);
-        let slots = slots.start..slots.start + 1;
-        let storage = storages.first().unwrap().clone();
-        let ignored_storage = storages.pop().unwrap();
-        let original_results = storages
-            .iter()
-            .map(|store| db.get_unique_accounts_from_storage(store))
-            .collect::<Vec<_>>();
-        let pk_with_1_ref = solana_pubkey::new_rand();
-        let slot1 = slots.start;
-        let account_with_2_refs = original_results
-            .first()
-            .unwrap()
-            .stored_accounts
-            .first()
-            .unwrap();
-        let account_shared_data_with_2_refs =
-            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-        let pk_with_2_refs = account_with_2_refs.pubkey();
-        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-        account_with_1_ref.checked_add_lamports(1).unwrap();
-        append_single_account_with_default_hash(
-            &storage,
-            &pk_with_1_ref,
-            &account_with_1_ref,
-            true,
-            Some(&db.accounts_index),
-        );
-        // add the account with 2 refs into the storage we're ignoring.
-        // The storage we're ignoring has a higher slot.
-        // The index entry for pk_with_2_refs will have both slots in it.
-        // The slot of `storage` is lower than the slot of `ignored_storage`.
-        // But, both are 'alive', aka in the index.
-        append_single_account_with_default_hash(
-            &ignored_storage,
-            pk_with_2_refs,
-            &account_shared_data_with_2_refs,
-            true,
-            Some(&db.accounts_index),
-        );
-
-        // update to get both accounts in the storage
-        let original_results = storages
-            .iter()
-            .map(|store| db.get_unique_accounts_from_storage(store))
-            .collect::<Vec<_>>();
-        assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-        let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
-
-        let accounts_to_combine = db.calc_accounts_to_combine(
-            &mut accounts_per_storage,
-            &default_tuning(),
-            IncludeManyRefSlots::Include,
-        );
-        let slots_vec = slots.collect::<Vec<_>>();
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-        // all accounts should be in many_refs
-        let mut accounts_keep = accounts_to_combine
-            .accounts_keep_slots
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        accounts_keep.sort_unstable();
-        assert_eq!(accounts_keep, slots_vec);
-        assert!(accounts_to_combine.target_slots_sorted.is_empty());
-        assert_eq!(accounts_to_combine.accounts_keep_slots.len(), num_slots);
-        assert_eq!(
-            accounts_to_combine
-                .accounts_keep_slots
-                .get(&slot1)
-                .unwrap()
-                .accounts
-                .iter()
-                .map(|meta| meta.pubkey())
-                .collect::<Vec<_>>(),
-            vec![pk_with_2_refs]
-        );
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-        let one_ref_accounts = &accounts_to_combine
-            .accounts_to_combine
-            .first()
-            .unwrap()
-            .alive_accounts
-            .no_duplicates
-            .accounts;
-        let one_ref_accounts_account_shared_data = one_ref_accounts
-            .iter()
-            .map(|account| get_account_from_account_from_storage(account, &db, slot1))
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            one_ref_accounts
-                .iter()
-                .map(|meta| meta.pubkey())
-                .collect::<Vec<_>>(),
-            vec![&pk_with_1_ref]
-        );
-        assert_eq!(
-            one_ref_accounts_account_shared_data
-                .iter()
-                .map(create_account_shared_data)
-                .collect::<Vec<_>>(),
-            vec![account_with_1_ref]
-        );
-        assert!(
-            accounts_to_combine
-                .accounts_to_combine
-                .iter()
-                .all(|shrink_collect| shrink_collect
-                    .alive_accounts
-                    .newest_duplicate
-                    .accounts
-                    .is_empty())
-        );
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-
-        assert!(
-            accounts_to_combine
-                .accounts_to_combine
-                .iter()
-                .all(|shrink_collect| shrink_collect
-                    .alive_accounts
-                    .not_newest_duplicate
-                    .accounts
-                    .is_empty())
-        );
-
-        let packed_contents = Vec::default();
-        let write_ancient_accounts =
-            db.write_packed_storages(&accounts_to_combine, packed_contents);
-        assert_eq!(write_ancient_accounts.shrinks_in_progress.len(), num_slots);
-        let mut shrinks_in_progress = write_ancient_accounts
-            .shrinks_in_progress
-            .iter()
-            .collect::<Vec<_>>();
-        shrinks_in_progress.sort_unstable_by(|a, b| a.0.cmp(b.0));
-        assert_eq!(
-            shrinks_in_progress
-                .iter()
-                .map(|(slot, _)| **slot)
-                .collect::<Vec<_>>(),
-            slots_vec
-        );
-        assert_eq!(
-            shrinks_in_progress
-                .iter()
-                .map(|(_, shrink_in_progress)| shrink_in_progress.old_storage().id())
-                .collect::<Vec<_>>(),
-            storages
-                .iter()
-                .map(|storage| storage.id())
-                .collect::<Vec<_>>()
-        );
-        let mut reader = append_vec::new_scan_accounts_reader();
-
-        // assert that we wrote the 2_ref account to the newly shrunk append vec
-        let shrink_in_progress = shrinks_in_progress.first().unwrap().1;
-        let mut count = 0;
-        shrink_in_progress
-            .new_storage()
-            .accounts
-            .scan_accounts(&mut reader, |_offset, _| {
-                count += 1;
-            })
-            .expect("must scan accounts storage");
-        assert_eq!(count, 1);
-        let account = shrink_in_progress
-            .new_storage()
-            .accounts
-            .get_stored_account_callback(0, |account| {
-                assert_eq!(account.pubkey(), pk_with_2_refs);
-                create_account_shared_data(&account)
-            })
-            .unwrap();
-        assert_eq!(account, account_shared_data_with_2_refs);
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_opposite(accounts_db_config: AccountsDbConfig) {
-        // 1 storage
-        // 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs, with the idea that the other ref is from an older slot, so this one is the newer index entry
-        // The result will be that the account, even though it has refcount > 1, can be moved to a newer slot.
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
-        let num_slots = 1;
-        let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
-        let original_results = storages
-            .iter()
-            .map(|store| db.get_unique_accounts_from_storage(store))
-            .collect::<Vec<_>>();
-        let storage = storages.first().unwrap().clone();
-        let pk_with_1_ref = solana_pubkey::new_rand();
-        let slot1 = slots.start;
-        let account_with_2_refs = original_results
-            .first()
-            .unwrap()
-            .stored_accounts
-            .first()
-            .unwrap();
-        let account_shared_data_with_2_refs =
-            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-        let pk_with_2_refs = account_with_2_refs.pubkey();
-        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-        _ = account_with_1_ref.checked_add_lamports(1);
-        // only pk_with_2_refs is in the storage so far, so only it gets the older entry
-        add_older_ref(&db, &storages);
-        append_single_account_with_default_hash(
-            &storage,
-            &pk_with_1_ref,
-            &account_with_1_ref,
-            true,
-            Some(&db.accounts_index),
-        );
-
-        // update to get both accounts in the storage
-        let original_results = storages
-            .iter()
-            .map(|store| db.get_unique_accounts_from_storage(store))
-            .collect::<Vec<_>>();
-        assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-        let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
-
-        let accounts_to_combine = db.calc_accounts_to_combine(
-            &mut accounts_per_storage,
-            &default_tuning(),
-            IncludeManyRefSlots::Include,
-        );
-        let slots_vec = slots.collect::<Vec<_>>();
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-        // all accounts should be in newest_duplicate
-        let mut accounts_keep = accounts_to_combine
-            .accounts_keep_slots
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        accounts_keep.sort_unstable();
-        assert_eq!(accounts_to_combine.target_slots_sorted, slots_vec);
-        assert!(accounts_keep.is_empty());
-        assert!(!accounts_to_combine.target_slots_sorted.is_empty());
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-        assert_eq!(
-            accounts_to_combine
-                .accounts_to_combine
-                .first()
-                .unwrap()
-                .alive_accounts
-                .newest_duplicate
-                .accounts
-                .iter()
-                .map(|meta| meta.pubkey())
-                .collect::<Vec<_>>(),
-            vec![pk_with_2_refs]
-        );
-        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-        let one_ref_accounts = &accounts_to_combine
-            .accounts_to_combine
-            .first()
-            .unwrap()
-            .alive_accounts
-            .no_duplicates
-            .accounts;
-        let one_ref_accounts_account_shared_data = one_ref_accounts
-            .iter()
-            .map(|account| get_account_from_account_from_storage(account, &db, slot1))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            one_ref_accounts
-                .iter()
-                .map(|meta| meta.pubkey())
-                .collect::<Vec<_>>(),
-            vec![&pk_with_1_ref]
-        );
-        assert_eq!(
-            one_ref_accounts_account_shared_data
-                .iter()
-                .map(create_account_shared_data)
-                .collect::<Vec<_>>(),
-            vec![account_with_1_ref]
-        );
-        assert!(
-            accounts_to_combine
-                .accounts_to_combine
-                .iter()
-                .all(|shrink_collect| !shrink_collect
-                    .alive_accounts
-                    .newest_duplicate
-                    .accounts
-                    .is_empty())
-        );
-
-        let packed_contents = Vec::default();
-        let write_ancient_accounts =
-            db.write_packed_storages(&accounts_to_combine, packed_contents);
-        assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
-        // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
-        let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
-        let accounts_shrunk_same_slot = storage
-            .accounts
-            .get_stored_account_callback(0, |account| {
-                (*account.pubkey(), create_account_shared_data(&account))
-            })
-            .unwrap();
-        let mut reader = append_vec::new_scan_accounts_reader();
-        let mut count = 0;
-        storage
-            .accounts
-            .scan_accounts(&mut reader, |_, _| {
-                count += 1;
-            })
-            .expect("must scan accounts storage");
-        assert_eq!(count, 2);
-        assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
-        assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -3730,162 +2853,6 @@ mod tests {
 
             starting_slot = max_slot_inclusive + 1;
         }
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_shrink_collect_alive_add(accounts_db_config: AccountsDbConfig) {
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
-        let num_slots = 1;
-        let data_size = None;
-        let (storages, _slots, _infos) = get_sample_storages(&db, num_slots, data_size);
-        let offset = 0;
-
-        storages[0]
-            .accounts
-            .get_stored_account_without_data_callback(offset, |stored_account| {
-                let account = AccountFromStorage::new(offset, &stored_account);
-                let slot = 1;
-                let capacity = 0;
-                for i in 0..3usize {
-                    let mut alive_accounts = AliveAccountsSeparated::with_capacity(capacity, slot);
-                    let lamports = 1;
-
-                    match i {
-                        0 => {
-                            // single slot list, so no_duplicates
-                            let slot_list = vec![(
-                                slot,
-                                AccountInfo::new(
-                                    StorageLocation::AccountsFile(0, 0),
-                                    lamports == 0,
-                                ),
-                            )];
-                            alive_accounts.add(&account, &slot_list);
-                            assert!(!alive_accounts.no_duplicates.accounts.is_empty());
-                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
-                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
-                        }
-                        1 => {
-                            // multiple slot list, this is not the newest, so not_newest_duplicate
-                            let slot_list = vec![
-                                (
-                                    slot,
-                                    AccountInfo::new(
-                                        StorageLocation::AccountsFile(0, 0),
-                                        lamports == 0,
-                                    ),
-                                ),
-                                (
-                                    slot + 1,
-                                    AccountInfo::new(
-                                        StorageLocation::AccountsFile(0, 0),
-                                        lamports == 0,
-                                    ),
-                                ),
-                            ];
-                            alive_accounts.add(&account, &slot_list);
-                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
-                            assert!(!alive_accounts.not_newest_duplicate.accounts.is_empty());
-                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
-                        }
-                        2 => {
-                            // multiple slot list, this is the newest, so newest_duplicate
-                            let slot_list = vec![
-                                (
-                                    slot,
-                                    AccountInfo::new(
-                                        StorageLocation::AccountsFile(0, 0),
-                                        lamports == 0,
-                                    ),
-                                ),
-                                (
-                                    slot - 1,
-                                    AccountInfo::new(
-                                        StorageLocation::AccountsFile(0, 0),
-                                        lamports == 0,
-                                    ),
-                                ),
-                            ];
-                            alive_accounts.add(&account, &slot_list);
-                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
-                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
-                            assert!(!alive_accounts.newest_duplicate.accounts.is_empty());
-                        }
-                        _ => {
-                            panic!("unexpected");
-                        }
-                    }
-                }
-            });
-    }
-
-    #[test]
-    fn test_newest_duplicate_can_be_moved() {
-        let tuning = PackedAncientStorageTuning {
-            // only allow 10k slots old enough to be ancient
-            max_ancient_slots: 10_000,
-            percent_of_alive_shrunk_data: 0,
-            ideal_storage_size: NonZeroU64::new(1000).unwrap(),
-            can_randomly_shrink: false,
-            ..default_tuning()
-        };
-
-        // nothing to move, so no problem fitting it
-        let newest_duplicate = vec![];
-        let target_slots_sorted = vec![];
-        assert!(AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
-        // something to move, no target slots, so can't fit
-        let slot = 1;
-        let newest_duplicate = vec![AliveAccounts {
-            bytes: 1,
-            slot,
-            accounts: Vec::default(),
-        }];
-        assert!(!AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
-
-        // something to move, 1 target slot, so can fit
-        let target_slots_sorted = vec![slot];
-        assert!(AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
-
-        // too much to move to 1 target slot, so can't fit
-        let newest_duplicate = vec![AliveAccounts {
-            bytes: tuning.ideal_storage_size.get() as usize,
-            slot,
-            accounts: Vec::default(),
-        }];
-        assert!(!AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
-
-        // more than 1 slot to move, 2 target slots, so can fit
-        let target_slots_sorted = vec![slot, slot + 1];
-        assert!(AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
-
-        // lowest target slot is below required slot
-        let target_slots_sorted = vec![slot - 1, slot];
-        assert!(!AccountsDb::newest_duplicate_can_be_moved(
-            &newest_duplicate,
-            &target_slots_sorted,
-            &tuning
-        ));
     }
 
     /// The purpose of this test is to ensure the correct control flow


### PR DESCRIPTION
#### Problem
As of https://github.com/anza-xyz/agave/pull/15065, squash can never receive AliveAccountsSeparated that actually need to be separated or stored in specific slots. It is guaranteed that each account only has a single ancient copy. With only a single slot in the ancient range, accounts can be stored in any storage, and there are no hazards between storages. 

#### Summary of Changes
- Remove all the code that separates storages and their respective tests. 
- With regards to the commits, the second one is the most interesting, as it contains most of the new content (which is just comment updates). 

#### Testing
Running a validator. It looks fine. 

Fixes #
