### PR TITLE
Resolve a bug where squash re-ordering can cause tombstones to become live again

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -170,9 +170,36 @@ impl AccountStorageEntry {
 
     /// True if every alive account in this storage is a tombstone. Such a storage holds no live
     /// index entries (tombstones were removed from the index when created), so it is fully dead.
+    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn has_only_tombstones(&self) -> bool {
         let num_tombstones = self.num_tombstones();
         num_tombstones > 0 && self.count() == num_tombstones
+    }
+
+    /// Converts every tombstone in this storage into an obsolete account marked at `slot`.
+    /// The caller must have established that `slot` covers all of them, i.e. that no snapshot
+    /// still needs to observe these zero-lamport accounts. Zero-lamport accounts store no data,
+    /// so each one occupies the stored size of a data-less account, and their bytes stop
+    /// counting as alive.
+    /// Returns the number of tombstones converted.
+    pub(crate) fn mark_tombstones_obsolete(&self, slot: Slot) -> usize {
+        // Both locks are held so a tombstone is never absent from both lists.
+        let mut obsolete_accounts = self.obsolete_accounts.write().unwrap();
+        let mut tombstone_offsets = self.tombstone_offsets.write().unwrap();
+        let num_tombstones = tombstone_offsets.len();
+        if num_tombstones == 0 {
+            return 0;
+        }
+
+        obsolete_accounts
+            .mark_accounts_obsolete(tombstone_offsets.iter().map(|offset| (*offset, 0)), slot);
+        tombstone_offsets.clear();
+        self.remove_accounts(
+            self.accounts
+                .dead_bytes_due_to_zero_lamport_accounts(num_tombstones),
+            num_tombstones,
+        );
+        num_tombstones
     }
 
     /// Return the "alive_bytes" minus the bytes of this storage's tombstones
@@ -376,5 +403,70 @@ mod tests {
             .unwrap();
         assert_eq!(num_excluded, 2);
         assert_eq!(visited, expected);
+    }
+
+    /// mark_tombstones_obsolete moves every tombstone into the obsolete accounts list stamped at
+    /// the given slot, empties the tombstone list, and stops counting those bytes as alive.
+    #[test]
+    fn test_mark_tombstones_obsolete() {
+        let slot = 7;
+        let temp_dir = TempDir::new().unwrap();
+        let storage = AccountStorageEntry::new(
+            temp_dir.path(),
+            slot,
+            0,
+            1024 * 1024,
+            AccountsFileProvider::AppendVec,
+        );
+
+        // Two funded accounts and two zero-lamport accounts.
+        let funded = AccountSharedData::new(1, 10, &Pubkey::default());
+        let zero_lamport = AccountSharedData::new(0, 0, &Pubkey::default());
+        let accounts = [
+            (Pubkey::new_unique(), funded.clone()),
+            (Pubkey::new_unique(), zero_lamport.clone()),
+            (Pubkey::new_unique(), funded),
+            (Pubkey::new_unique(), zero_lamport),
+        ];
+        let offsets = storage
+            .accounts
+            .write_accounts(&(slot, &accounts[..]))
+            .unwrap()
+            .offsets;
+        storage.add_accounts(accounts.len(), storage.written_bytes() as usize);
+
+        // The zero-lamport accounts are tombstones, and count as alive until converted.
+        storage.batch_insert_tombstone_offsets([offsets[1], offsets[3]]);
+        assert_eq!(storage.num_tombstones(), 2);
+        assert_eq!(storage.count(), 4);
+        let alive_bytes_before = storage.alive_bytes();
+
+        let marked_obsolete_slot = 99;
+        assert_eq!(storage.mark_tombstones_obsolete(marked_obsolete_slot), 2);
+
+        // The tombstone list is empty and the two accounts no longer count as alive.
+        assert_eq!(storage.num_tombstones(), 0);
+        assert_eq!(storage.count(), 2);
+        let tombstone_bytes = storage.accounts.dead_bytes_due_to_zero_lamport_accounts(2);
+        assert_eq!(storage.alive_bytes(), alive_bytes_before - tombstone_bytes);
+
+        // Both are obsolete as of `marked_obsolete_slot`, and not before it.
+        let mut obsolete_offsets: Vec<_> = storage
+            .obsolete_accounts_read_lock()
+            .filter_obsolete_accounts(Some(marked_obsolete_slot))
+            .map(|(offset, _data_len)| offset)
+            .collect();
+        obsolete_offsets.sort_unstable();
+        assert_eq!(obsolete_offsets, vec![offsets[1], offsets[3]]);
+        assert_eq!(
+            storage
+                .obsolete_accounts_read_lock()
+                .filter_obsolete_accounts(Some(marked_obsolete_slot - 1))
+                .count(),
+            0,
+        );
+
+        // Converting again is a no-op.
+        assert_eq!(storage.mark_tombstones_obsolete(marked_obsolete_slot), 0);
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -817,6 +817,7 @@ struct CleanKeyTimings {
     collect_delta_keys_us: u64,
     zero_lamport_single_ref_slots_added_to_shrink_count: u64,
     zero_lamport_sweep_us: u64,
+    num_tombstones_marked_obsolete: u64,
 }
 
 pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<PathBuf>)> {
@@ -1429,11 +1430,13 @@ impl AccountsDb {
         {
             let last_swept_full_snapshot_slot =
                 self.last_swept_full_snapshot_slot.load(Ordering::Relaxed);
-            let (added_to_shrink_count, sweep_us) = measure_us!(self.sweep_slots_after_snapshot(
-                last_swept_full_snapshot_slot,
-                latest_full_snapshot_slot
-            ));
+            let ((added_to_shrink_count, num_tombstones_marked_obsolete), sweep_us) =
+                measure_us!(self.sweep_slots_after_snapshot(
+                    last_swept_full_snapshot_slot,
+                    latest_full_snapshot_slot
+                ));
             timings.zero_lamport_single_ref_slots_added_to_shrink_count += added_to_shrink_count;
+            timings.num_tombstones_marked_obsolete += num_tombstones_marked_obsolete;
             timings.zero_lamport_sweep_us += sweep_us;
         }
 
@@ -1442,20 +1445,23 @@ impl AccountsDb {
 
     /// Loop through slots in `[last_swept_full_snapshot_slot + 1, latest_full_snapshot_slot]` and
     /// re-examine each storage now that a full snapshot has advanced past its slot:
-    /// 1) if it holds only tombstones, purge it directly; or
-    /// 2) if its dead zero-lamport accounts made it shrinkable, add it to the shrink candidates.
+    /// 1) mark its tombstones obsolete, since no snapshot needs them any more; then
+    /// 2) if no alive accounts remain, purge it directly; or
+    /// 3) if its dead zero-lamport accounts made it shrinkable, add it to the shrink candidates.
     ///
     /// Advances `last_swept_full_snapshot_slot` to `latest_full_snapshot_slot` on completion.
     ///
-    /// Returns the count of storages that were added to the shrink candidates set.
+    /// Returns the count of storages that were added to the shrink candidates set, and the
+    /// number of tombstones marked obsolete.
     fn sweep_slots_after_snapshot(
         &self,
         last_swept_full_snapshot_slot: Slot,
         latest_full_snapshot_slot: Slot,
-    ) -> u64 {
+    ) -> (u64, u64) {
         let start = last_swept_full_snapshot_slot.saturating_add(1);
 
         let mut added_to_shrink_count = 0;
+        let mut num_tombstones_marked_obsolete = 0;
         {
             // Held for the scan. Safe because the only paths that take this lock in production
             // validator code run in earlier/later phases of the same AccountsBackgroundService
@@ -1463,8 +1469,14 @@ impl AccountsDb {
             let mut shrink_candidates = self.shrink_candidate_slots.lock().unwrap();
             for slot in start..=latest_full_snapshot_slot {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot) {
-                    if store.has_only_tombstones() {
-                        // Now just contains tombstones and no live index entries: purge
+                    // The full snapshot covers this slot, so its zero-lamport accounts no
+                    // longer need to be observable by an incremental snapshot taken against
+                    // that full snapshot.
+                    num_tombstones_marked_obsolete +=
+                        store.mark_tombstones_obsolete(latest_full_snapshot_slot) as u64;
+
+                    if !store.has_accounts() {
+                        // Every account is obsolete and no live index entries remain: purge
                         self.purge_dead_slots_from_storage(
                             iter::once(&slot),
                             &self.clean_accounts_stats.purge_stats,
@@ -1481,7 +1493,7 @@ impl AccountsDb {
 
         self.last_swept_full_snapshot_slot
             .store(latest_full_snapshot_slot, Ordering::Relaxed);
-        added_to_shrink_count
+        (added_to_shrink_count, num_tombstones_marked_obsolete)
     }
 
     /// called with cli argument to verify the index is correct for all accounts
@@ -1758,6 +1770,11 @@ impl AccountsDb {
             (
                 "zero_lamport_single_ref_slots_added_to_shrink_count",
                 key_timings.zero_lamport_single_ref_slots_added_to_shrink_count,
+                i64
+            ),
+            (
+                "num_tombstones_marked_obsolete",
+                key_timings.num_tombstones_marked_obsolete,
                 i64
             ),
             (
@@ -4483,6 +4500,13 @@ impl AccountsDb {
                 let remaining_accounts = if is_tombstone_reclaim {
                     // Tombstones stay alive in the storage; only record their offsets
                     store.batch_insert_tombstone_offsets(offsets);
+                    // Unless the latest full snapshot already covers this slot, in which case
+                    // no snapshot needs to observe these zero-lamport accounts
+                    if let Some(latest_full_snapshot_slot) = self.latest_full_snapshot_slot()
+                        && slot <= latest_full_snapshot_slot
+                    {
+                        store.mark_tombstones_obsolete(latest_full_snapshot_slot);
+                    }
                     store.count()
                 } else if offsets.len() == store.count() {
                     // all remaining alive accounts in the storage are being removed, so the entire storage/slot is dead

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1163,6 +1163,97 @@ fn test_clean_reclaim_tombstones_zero_lamport_single_ref() {
     );
 }
 
+/// A zero-lamport account whose slot the latest full snapshot already covers is recorded as an
+/// obsolete account rather than as a tombstone: no snapshot still needs to observe it.
+#[test]
+fn test_clean_marks_covered_zero_lamport_account_obsolete() {
+    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+    let zero_lamport_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+    accounts.store_for_tests((10, [(&pubkey1, &account)].as_slice()));
+    accounts.add_root(10);
+    accounts.store_for_tests((
+        11,
+        [(&pubkey1, &zero_lamport_account), (&pubkey2, &account)].as_slice(),
+    ));
+    accounts.add_root(11);
+    accounts.flush_rooted_accounts_cache_without_clean();
+
+    // The latest full snapshot covers slot 11, so no snapshot needs pubkey1's zero-lamport
+    // version to be observable
+    accounts.set_latest_full_snapshot_slot(11);
+    accounts.clean_accounts_for_tests();
+
+    assert!(!accounts.accounts_index.contains(&pubkey1));
+    let storage = accounts.storage.get_slot_storage_entry(11).unwrap();
+
+    // Recorded as obsolete at the full snapshot slot instead of as a tombstone
+    assert_eq!(storage.num_tombstones(), 0);
+    assert_eq!(
+        storage
+            .obsolete_accounts_read_lock()
+            .filter_obsolete_accounts(Some(11))
+            .count(),
+        1,
+    );
+
+    // Only pubkey2 still counts as alive
+    assert_eq!(storage.count(), 1);
+}
+
+/// Once a full snapshot advances past a slot, the sweep converts that slot's retained tombstones
+/// into obsolete accounts so later snapshots skip them.
+#[test]
+fn test_sweep_marks_tombstones_obsolete_after_full_snapshot() {
+    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+    let zero_lamport_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+    accounts.store_for_tests((10, [(&pubkey1, &account)].as_slice()));
+    accounts.add_root(10);
+    accounts.store_for_tests((
+        11,
+        [(&pubkey1, &zero_lamport_account), (&pubkey2, &account)].as_slice(),
+    ));
+    accounts.add_root(11);
+    accounts.flush_rooted_accounts_cache_without_clean();
+
+    // The latest full snapshot predates slot 11, so pubkey1's zero-lamport version is retained
+    // as a tombstone for an incremental snapshot taken against that full snapshot
+    accounts.set_latest_full_snapshot_slot(10);
+    accounts.clean_accounts_for_tests();
+    let storage = accounts.storage.get_slot_storage_entry(11).unwrap();
+    assert_eq!(storage.num_tombstones(), 1);
+    assert_eq!(storage.get_obsolete_bytes(None), 0);
+    let alive_bytes_with_tombstone = storage.alive_bytes();
+
+    // A full snapshot at slot 11 covers the tombstone, so the sweep converts it
+    accounts.set_latest_full_snapshot_slot(11);
+    accounts.clean_accounts_for_tests();
+
+    let storage = accounts.storage.get_slot_storage_entry(11).unwrap();
+    assert_eq!(storage.num_tombstones(), 0);
+    assert_eq!(
+        storage
+            .obsolete_accounts_read_lock()
+            .filter_obsolete_accounts(Some(11))
+            .count(),
+        1,
+    );
+
+    // The tombstone bytes stopped counting as alive, leaving only pubkey2
+    assert_eq!(storage.count(), 1);
+    assert_eq!(
+        storage.alive_bytes(),
+        alive_bytes_with_tombstone - storage.accounts.dead_bytes_due_to_zero_lamport_accounts(1),
+    );
+}
+
 /// A pubkey whose account has died must stay dead when a storage holding a clean-reclaimed
 /// older version of it is later shrunk.
 #[test]


### PR DESCRIPTION
#### Problem
Squash can put accounts into newer slots freely as long as the new slots are still ancient. There is a possibility that tombstones are still present in ancient slots (if the slots are not shrunk in the intervening 250,000 slots, which is very unlikely), and an account could be moved from older than a tombstone to newer than a tombstone.

This would cause the account to revive. This was previously prevented by https://github.com/anza-xyz/agave/pull/13851, but that needed to be reverted by https://github.com/anza-xyz/agave/pull/14867

#### Summary of Changes
- Change tombstones to obsolete accounts when a full snapshot occurs. 

#### Testing


Fixes #
