### PR TITLE
runtime: Make `reward_epoch_delegated_stakes` a ref for SIMD-0123

### DIFF
--- a/runtime/src/alpenglow_epoch_type.rs
+++ b/runtime/src/alpenglow_epoch_type.rs
@@ -13,7 +13,7 @@ use {
 /// For this prior epoch we need to know the delegated stake for each vote account.
 /// Note that this is not the same as `epoch_stakes`, which is calculated an epoch
 /// in advance.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct RewardEpochDelegatedStakes {
     pub(crate) epoch: Epoch,
     pub(crate) delegated_stakes: HashMap<Pubkey, u64>,
@@ -116,6 +116,16 @@ impl RewardEpochDelegatedStakes {
             );
             account.into()
         })
+    }
+}
+
+#[cfg(test)]
+impl RewardEpochDelegatedStakes {
+    pub(crate) fn new_for_tests(epoch: u64) -> Self {
+        Self {
+            epoch,
+            delegated_stakes: HashMap::new(),
+        }
     }
 }
 

--- a/runtime/src/alpenglow_epoch_type.rs
+++ b/runtime/src/alpenglow_epoch_type.rs
@@ -13,7 +13,7 @@ use {
 /// For this prior epoch we need to know the delegated stake for each vote account.
 /// Note that this is not the same as `epoch_stakes`, which is calculated an epoch
 /// in advance.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct RewardEpochDelegatedStakes {
     pub(crate) epoch: Epoch,
     pub(crate) delegated_stakes: HashMap<Pubkey, u64>,
@@ -133,7 +133,7 @@ impl From<RewardEpochDelegatedStakesAccount> for RewardEpochDelegatedStakes {
 }
 
 #[derive(Debug)]
-pub(crate) enum AlpenglowEpochType {
+pub(crate) enum AlpenglowEpochType<'a> {
     /// This is a full tower epoch.
     Tower,
     /// The epoch started in tower and then switched to alpenglow
@@ -141,16 +141,16 @@ pub(crate) enum AlpenglowEpochType {
         num_tower_slots: Slot,
         num_ag_slots: Slot,
         migration_epoch: Epoch,
-        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+        reward_epoch_delegated_stakes: &'a RewardEpochDelegatedStakes,
     },
     /// This is a full alpenglow epoch
     Alpenglow {
         migration_epoch: Epoch,
-        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+        reward_epoch_delegated_stakes: &'a RewardEpochDelegatedStakes,
     },
 }
 
-impl AlpenglowEpochType {
+impl<'a> AlpenglowEpochType<'a> {
     pub(crate) fn is_alpenglow_or_migration_epoch(bank: &Bank, epoch: Epoch) -> bool {
         debug_assert!(epoch < bank.epoch());
         bank.get_alpenglow_migration_slot()
@@ -162,13 +162,10 @@ impl AlpenglowEpochType {
     ///
     /// Calling this function with an epoch >= `Bank::epoch` can return false information as it is
     /// possible that we have not observed the genesis cert yet but will in the upcoming slots.
-    ///
-    /// We pass `reward_epoch_delegated_stakes` as a closure to avoid the potential deserialization
-    /// of `REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT` in the Tower case.
     pub(crate) fn get(
         bank: &Bank,
         epoch: Epoch,
-        reward_epoch_delegated_stakes: impl FnOnce() -> Option<RewardEpochDelegatedStakes>,
+        reward_epoch_delegated_stakes: Option<&'a RewardEpochDelegatedStakes>,
     ) -> Self {
         debug_assert!(epoch < bank.epoch());
         let Some(migration_slot) = bank.get_alpenglow_migration_slot() else {
@@ -178,7 +175,7 @@ impl AlpenglowEpochType {
         match migration_epoch.cmp(&epoch) {
             Ordering::Less => {
                 let reward_epoch_delegated_stakes =
-                    reward_epoch_delegated_stakes().unwrap_or_else(|| {
+                    reward_epoch_delegated_stakes.unwrap_or_else(|| {
                         panic!(
                             "Missing reward epoch delegated stakes for non-Tower reward epoch \
                              {epoch}"
@@ -204,7 +201,7 @@ impl AlpenglowEpochType {
                 let num_ag_slots = slots_in_epoch - num_tower_slots;
                 assert_eq!(slots_in_epoch, num_tower_slots + num_ag_slots);
                 let reward_epoch_delegated_stakes =
-                    reward_epoch_delegated_stakes().unwrap_or_else(|| {
+                    reward_epoch_delegated_stakes.unwrap_or_else(|| {
                         panic!(
                             "Missing reward epoch delegated stakes for non-Tower reward epoch \
                              {epoch}"

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -41,7 +41,7 @@ pub use {
 use {
     crate::{
         account_saver::collect_accounts_to_store,
-        alpenglow_epoch_type::AlpenglowEpochType,
+        alpenglow_epoch_type::{AlpenglowEpochType, RewardEpochDelegatedStakes},
         bank::{
             entry_bytes_budget::EntryBytesBudget,
             metrics::*,
@@ -1251,6 +1251,8 @@ struct NewEpochBundle {
     unfiltered_distribution_vote_accounts: VoteAccounts,
     /// Current effective stake delegated to each vote account pubkey.
     delegated_stakes: DelegatedStakes,
+    /// Stake amounts for the end of the rewarded epoch
+    reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
     /// Vote accounts computed from the stakes cache for the current
     /// (distribution) epoch *after* applying VAT filtering.
     filtered_distribution_vote_accounts: VoteAccounts,
@@ -1852,7 +1854,7 @@ impl Bank {
                 stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
-                reward_epoch_delegated_stakes,
+                &reward_epoch_delegated_stakes,
                 reward_calc_tracer,
                 thread_pool,
                 rewards_metrics,
@@ -1861,6 +1863,7 @@ impl Bank {
             stake_history,
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
+            reward_epoch_delegated_stakes,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1890,6 +1893,7 @@ impl Bank {
             stake_history,
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
+            reward_epoch_delegated_stakes,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1923,6 +1927,7 @@ impl Bank {
                 parent_slot,
                 parent_height,
                 &rewards_calculation,
+                &reward_epoch_delegated_stakes,
                 &mut rewards_metrics,
                 thread_pool,
             ));

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -240,6 +240,7 @@ impl Bank {
         parent_slot: Slot,
         parent_block_height: u64,
         rewards_calculation: &PartitionedRewardsCalculation,
+        reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         rewards_metrics: &mut RewardsMetrics,
         thread_pool: &ThreadPool,
     ) -> u64 {
@@ -250,6 +251,7 @@ impl Bank {
         } = self.distribute_reward_commissions(
             parent_epoch,
             rewards_calculation,
+            reward_epoch_delegated_stakes,
             rewards_metrics,
             thread_pool,
         );
@@ -298,7 +300,7 @@ impl Bank {
         stake_delegations: Vec<(&Pubkey, &StakeAccount<Delegation>)>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
-        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+        reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
@@ -350,6 +352,7 @@ impl Bank {
         &mut self,
         prev_epoch: Epoch,
         rewards_calculation: &PartitionedRewardsCalculation,
+        reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         rewards_metrics: &mut RewardsMetrics,
         thread_pool: &ThreadPool,
     ) -> RewardCommissionLamportAmounts {
@@ -367,7 +370,11 @@ impl Bank {
         // intervening account mutations (e.g. VAT burns in
         // `update_epoch_stakes`) are reflected.
         let (reward_commission_accounts, load_and_reward_commission_accounts_us) =
-            measure_us!(self.load_and_reward_commission_accounts(reward_commissions, thread_pool));
+            measure_us!(self.load_and_reward_commission_accounts(
+                reward_commissions,
+                reward_epoch_delegated_stakes,
+                thread_pool
+            ));
         rewards_metrics.load_and_reward_commission_accounts_us =
             load_and_reward_commission_accounts_us;
         info!(
@@ -470,7 +477,7 @@ impl Bank {
         stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
-        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+        reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
@@ -536,13 +543,13 @@ impl Bank {
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         epoch_inflation_rewards: u64,
-        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+        reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<CalculateValidatorRewardsResult> {
         let ag_epoch_type =
-            AlpenglowEpochType::get(self, rewarded_epoch, || Some(reward_epoch_delegated_stakes));
+            AlpenglowEpochType::get(self, rewarded_epoch, Some(reward_epoch_delegated_stakes));
         self.calculate_reward_points_partitioned(
             stake_history,
             &stake_delegations,
@@ -1043,9 +1050,9 @@ impl Bank {
             stake_delegations,
             cached_vote_accounts,
         } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
-        let ag_epoch_type = AlpenglowEpochType::get(self, rewarded_epoch, || {
-            RewardEpochDelegatedStakes::get(self)
-        });
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes::get(self);
+        let ag_epoch_type =
+            AlpenglowEpochType::get(self, rewarded_epoch, reward_epoch_delegated_stakes.as_ref());
 
         // On recalculation, only the `StakeRewardCalculation::stake_rewards`
         // field is relevant. It is assumed that reward commission accounts have
@@ -1089,6 +1096,7 @@ impl Bank {
     fn load_and_reward_commission_accounts(
         &self,
         reward_commissions: &RewardCommissions,
+        _reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         thread_pool: &ThreadPool,
     ) -> RewardCommissionAccounts {
         let reserved_account_keys = &self.reserved_account_keys;
@@ -1509,7 +1517,7 @@ mod tests {
             cached_vote_accounts,
             rewarded_epoch,
             expected_rewards,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+            &reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -1655,6 +1663,10 @@ mod tests {
             },
             num_filtered_vote_accounts: 1,
         };
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: bank.epoch().saturating_sub(1),
+            ..Default::default()
+        };
         let mut rewards_metrics = RewardsMetrics::default();
 
         let rewards = bank.begin_partitioned_rewards(
@@ -1662,6 +1674,7 @@ mod tests {
             bank.parent_slot(),
             bank.block_height(),
             &rewards_calculation,
+            &reward_epoch_delegated_stakes,
             &mut rewards_metrics,
             &thread_pool,
         );
@@ -2440,7 +2453,7 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+            &reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -2562,7 +2575,7 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
-            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
+            &reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -3593,7 +3606,15 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let reward_commissions = RewardCommissions::default();
-        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: bank.epoch().saturating_sub(1),
+            ..Default::default()
+        };
+        let result = bank.load_and_reward_commission_accounts(
+            &reward_commissions,
+            &reward_epoch_delegated_stakes,
+            &thread_pool,
+        );
         assert!(result.accounts_with_rewards.is_empty());
     }
 
@@ -3616,7 +3637,15 @@ mod tests {
                 is_vote_account: true,
             },
         );
-        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: bank.epoch().saturating_sub(1),
+            ..Default::default()
+        };
+        let result = bank.load_and_reward_commission_accounts(
+            &reward_commissions,
+            &reward_epoch_delegated_stakes,
+            &thread_pool,
+        );
         assert!(result.accounts_with_rewards.is_empty());
     }
 
@@ -3652,7 +3681,16 @@ mod tests {
         burned_account.set_lamports(post_burn_balance);
         bank.store_account_and_update_capitalization(&pubkey, &burned_account);
 
-        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: bank.epoch().saturating_sub(1),
+            ..Default::default()
+        };
+
+        let result = bank.load_and_reward_commission_accounts(
+            &reward_commissions,
+            &reward_epoch_delegated_stakes,
+            &thread_pool,
+        );
 
         assert_eq!(result.accounts_with_rewards.len(), 1);
         let (pubkey_result, reward_info, account) = &result.accounts_with_rewards[0];
@@ -3694,8 +3732,15 @@ mod tests {
                         is_vote_account: true,
                     },
                 );
-                let result =
-                    bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+                let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+                    epoch: bank.epoch().saturating_sub(1),
+                    ..Default::default()
+                };
+                let result = bank.load_and_reward_commission_accounts(
+                    &reward_commissions,
+                    &reward_epoch_delegated_stakes,
+                    &thread_pool,
+                );
                 assert_eq!(result.accounts_with_rewards.len(), 1);
                 let (pubkey_result, rewards, account) = &result.accounts_with_rewards[0];
                 _ = commission_account.checked_add_lamports(commission_lamports);
@@ -4049,7 +4094,15 @@ mod tests {
                 is_vote_account: false,
             },
         );
-        let result = bank.load_and_reward_commission_accounts(&reward_commissions, &thread_pool);
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: bank.epoch().saturating_sub(1),
+            ..Default::default()
+        };
+        let result = bank.load_and_reward_commission_accounts(
+            &reward_commissions,
+            &reward_epoch_delegated_stakes,
+            &thread_pool,
+        );
         assert_eq!(
             result.amounts.distributed_to_incinerator_lamports,
             commission_lamports
@@ -4265,7 +4318,7 @@ mod tests {
             .collect();
         let ag_epoch_type = AlpenglowEpochType::Alpenglow {
             migration_epoch: 0,
-            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+            reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes {
                 epoch: rewarded_epoch,
                 delegated_stakes: [(voter_pubkey, total_stake)].into_iter().collect(),
             },

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1096,6 +1096,7 @@ impl Bank {
     fn load_and_reward_commission_accounts(
         &self,
         reward_commissions: &RewardCommissions,
+        // This field will be used with SIMD-0123, do not remove
         _reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
         thread_pool: &ThreadPool,
     ) -> RewardCommissionAccounts {
@@ -1663,10 +1664,8 @@ mod tests {
             },
             num_filtered_vote_accounts: 1,
         };
-        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-            epoch: bank.epoch().saturating_sub(1),
-            ..Default::default()
-        };
+        let reward_epoch_delegated_stakes =
+            RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
         let mut rewards_metrics = RewardsMetrics::default();
 
         let rewards = bank.begin_partitioned_rewards(
@@ -3606,10 +3605,8 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let reward_commissions = RewardCommissions::default();
-        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-            epoch: bank.epoch().saturating_sub(1),
-            ..Default::default()
-        };
+        let reward_epoch_delegated_stakes =
+            RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
         let result = bank.load_and_reward_commission_accounts(
             &reward_commissions,
             &reward_epoch_delegated_stakes,
@@ -3637,10 +3634,8 @@ mod tests {
                 is_vote_account: true,
             },
         );
-        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-            epoch: bank.epoch().saturating_sub(1),
-            ..Default::default()
-        };
+        let reward_epoch_delegated_stakes =
+            RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
         let result = bank.load_and_reward_commission_accounts(
             &reward_commissions,
             &reward_epoch_delegated_stakes,
@@ -3681,10 +3676,8 @@ mod tests {
         burned_account.set_lamports(post_burn_balance);
         bank.store_account_and_update_capitalization(&pubkey, &burned_account);
 
-        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-            epoch: bank.epoch().saturating_sub(1),
-            ..Default::default()
-        };
+        let reward_epoch_delegated_stakes =
+            RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
 
         let result = bank.load_and_reward_commission_accounts(
             &reward_commissions,
@@ -3732,10 +3725,8 @@ mod tests {
                         is_vote_account: true,
                     },
                 );
-                let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-                    epoch: bank.epoch().saturating_sub(1),
-                    ..Default::default()
-                };
+                let reward_epoch_delegated_stakes =
+                    RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
                 let result = bank.load_and_reward_commission_accounts(
                     &reward_commissions,
                     &reward_epoch_delegated_stakes,
@@ -4094,10 +4085,8 @@ mod tests {
                 is_vote_account: false,
             },
         );
-        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
-            epoch: bank.epoch().saturating_sub(1),
-            ..Default::default()
-        };
+        let reward_epoch_delegated_stakes =
+            RewardEpochDelegatedStakes::new_for_tests(bank.epoch.saturating_sub(1));
         let result = bank.load_and_reward_commission_accounts(
             &reward_commissions,
             &reward_epoch_delegated_stakes,

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -456,42 +456,55 @@ mod tests {
         }
     }
 
+    fn get_reward_epoch_delegated_stakes() -> RewardEpochDelegatedStakes {
+        RewardEpochDelegatedStakes {
+            epoch: 1,
+            delegated_stakes: [(Pubkey::default(), 1_000)].into_iter().collect(),
+        }
+    }
+
     /// Returns an instance of `AlpenglowEpochType`, total stake, and first AG epoch.
-    fn get_ag_epoch_type() -> (AlpenglowEpochType, u64, Epoch) {
-        let total_stake = 1_000;
-        let migration_epoch = 0;
-        let first_ag_epoch = migration_epoch + 1;
+    fn get_ag_epoch_type<'a>(
+        reward_epoch_delegated_stakes: &'a RewardEpochDelegatedStakes,
+    ) -> (AlpenglowEpochType<'a>, u64, Epoch) {
+        let total_stake = reward_epoch_delegated_stakes
+            .delegated_stakes
+            .values()
+            .sum::<u64>();
         (
             AlpenglowEpochType::Alpenglow {
-                migration_epoch,
-                reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
-                    epoch: first_ag_epoch,
-                    delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
-                },
+                migration_epoch: reward_epoch_delegated_stakes.epoch - 1,
+                reward_epoch_delegated_stakes,
             },
             total_stake,
-            first_ag_epoch,
+            reward_epoch_delegated_stakes.epoch,
         )
     }
 
-    fn make_ag_epoch_type_for_test(
-        ag_enabled: bool,
+    fn make_reward_epoch_delegated_stakes_for_test(
         vote_state: &VoteStateV4,
         ag_total_stake_multiplier: u64,
-    ) -> AlpenglowEpochType {
+    ) -> RewardEpochDelegatedStakes {
+        RewardEpochDelegatedStakes {
+            epoch: vote_state
+                .epoch_credits
+                .last()
+                .map(|(epoch, _final_epoch_credits, _initial_epoch_credits)| *epoch)
+                .unwrap_or(1),
+            delegated_stakes: [(Pubkey::default(), ag_total_stake_multiplier)]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    fn make_ag_epoch_type_for_test<'a>(
+        ag_enabled: bool,
+        reward_epoch_delegated_stakes: &'a RewardEpochDelegatedStakes,
+    ) -> AlpenglowEpochType<'a> {
         if ag_enabled {
             AlpenglowEpochType::Alpenglow {
                 migration_epoch: 0,
-                reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
-                    epoch: vote_state
-                        .epoch_credits
-                        .last()
-                        .map(|(epoch, _final_epoch_credits, _initial_epoch_credits)| *epoch)
-                        .unwrap_or(1),
-                    delegated_stakes: [(Pubkey::default(), ag_total_stake_multiplier)]
-                        .into_iter()
-                        .collect(),
-                },
+                reward_epoch_delegated_stakes,
             }
         } else {
             AlpenglowEpochType::Tower
@@ -514,9 +527,11 @@ mod tests {
         let new_rate_activation_epoch = None;
         let commission_rate_in_basis_points = true;
 
+        let reward_epoch_delegated_stakes = get_reward_epoch_delegated_stakes();
         // epoch credits work differently in AG, so we need a multiplier to account for that.
         let ag_total_stake_multiplier = if ag_enabled {
-            let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+            let (_, ag_total_stake_multiplier, _) =
+                get_ag_epoch_type(&reward_epoch_delegated_stakes);
             ag_total_stake_multiplier
         } else {
             1
@@ -524,7 +539,7 @@ mod tests {
 
         let inc_credits = |handler: &mut VoteStateHandler, epoch: Epoch, credits: u64| {
             if ag_enabled {
-                let (_, _, first_ag_epoch) = get_ag_epoch_type();
+                let (_, _, first_ag_epoch) = get_ag_epoch_type(&reward_epoch_delegated_stakes);
                 handler
                     .increment_credits(epoch + first_ag_epoch, credits * ag_total_stake_multiplier);
             } else {
@@ -541,6 +556,10 @@ mod tests {
         let new_minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
 
         // this one can't collect now, credits_observed == vote_state.credits()
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             None,
             redeem_stake_rewards(
@@ -559,11 +578,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier,
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 stake_lamports + minimum_balance,
                 new_minimum_balance,
             )
@@ -573,6 +588,10 @@ mod tests {
         inc_credits(&mut vote_state, 0, 2);
 
         // this one should be able to collect exactly 2
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some((stake_lamports * 2, 0)),
             redeem_stake_rewards(
@@ -591,11 +610,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier,
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 stake_lamports + minimum_balance,
                 new_minimum_balance,
             )
@@ -620,9 +635,11 @@ mod tests {
         let commission_rate_in_basis_points = true;
         let adjust_delegations_for_rent = true;
 
+        let reward_epoch_delegated_stakes = get_reward_epoch_delegated_stakes();
         // epoch credits work differently in AG, so we need a multiplier to account for that.
         let ag_total_stake_multiplier = if ag_enabled {
-            let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+            let (_, ag_total_stake_multiplier, _) =
+                get_ag_epoch_type(&reward_epoch_delegated_stakes);
             ag_total_stake_multiplier
         } else {
             1
@@ -630,7 +647,7 @@ mod tests {
 
         let inc_credits = |handler: &mut VoteStateHandler, epoch: Epoch, credits: u64| {
             if ag_enabled {
-                let (_, _, first_ag_epoch) = get_ag_epoch_type();
+                let (_, _, first_ag_epoch) = get_ag_epoch_type(&reward_epoch_delegated_stakes);
                 handler
                     .increment_credits(epoch + first_ag_epoch, credits * ag_total_stake_multiplier);
             } else {
@@ -638,6 +655,10 @@ mod tests {
             }
         };
         // this one can't collect now, credits_observed == vote_state.credits()
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             None,
             calculate_stake_rewards(
@@ -656,11 +677,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -669,6 +686,10 @@ mod tests {
         inc_credits(&mut vote_state, 0, 2);
 
         // this one should be able to collect exactly 2
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: stake.delegation.stake * 2,
@@ -691,17 +712,17 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
 
         stake.credits_observed = ag_total_stake_multiplier;
         // this one should be able to collect exactly 1 (already observed one)
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: stake.delegation.stake,
@@ -724,11 +745,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -738,6 +755,10 @@ mod tests {
 
         stake.credits_observed = 2 * ag_total_stake_multiplier;
         // this one should be able to collect the one just added
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: stake.delegation.stake,
@@ -760,11 +781,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -778,6 +795,10 @@ mod tests {
         } else {
             stake.delegation.stake * 2
         };
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: expected_staker_rewards,
@@ -800,11 +821,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -819,6 +836,10 @@ mod tests {
                 + stake.delegation.stake // epoch 1
                 + stake.delegation.stake // epoch 2
         };
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: expected_staker_rewards,
@@ -841,11 +862,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -862,6 +879,10 @@ mod tests {
         // zero after the Tower commission split. Tower defers; AG assigns the
         // remainder to the voter and advances credits.
         vote_state.set_inflation_rewards_commission_bps(100);
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             small_redemption_result(),
             calculate_stake_rewards(
@@ -880,15 +901,15 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
         vote_state.set_inflation_rewards_commission_bps(9900);
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             small_redemption_result(),
             calculate_stake_rewards(
@@ -907,11 +928,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -919,6 +936,10 @@ mod tests {
         // now one with inflation disabled. no one gets paid, but we still need
         // to advance the stake state's credits_observed field to prevent back-
         // paying rewards when inflation is turned on.
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: 0,
@@ -941,11 +962,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -953,6 +970,10 @@ mod tests {
         // credits_observed remains at previous level when vote_state credits are
         // not advancing and inflation is disabled
         stake.credits_observed = 4 * ag_total_stake_multiplier;
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: 0,
@@ -975,15 +996,15 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
 
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             CalculatedStakePoints {
                 tower_points: 0,
@@ -997,11 +1018,7 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
             )
         );
 
@@ -1009,6 +1026,10 @@ mod tests {
         // recreated
         stake.credits_observed = 1000 * ag_total_stake_multiplier;
         // this is new behavior 1; return the post-recreation rewound credits from the vote account
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             CalculatedStakePoints {
                 tower_points: 0,
@@ -1022,15 +1043,15 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
             )
         );
         // this is new behavior 2; don't hint when credits both from stake and vote are identical
         stake.credits_observed = 4 * ag_total_stake_multiplier;
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             CalculatedStakePoints {
                 tower_points: 0,
@@ -1044,11 +1065,7 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
             )
         );
 
@@ -1056,6 +1073,10 @@ mod tests {
         vote_state.set_inflation_rewards_commission_bps(0);
         stake.credits_observed = 3 * ag_total_stake_multiplier;
         stake.delegation.activation_epoch = 1;
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: stake.delegation.stake, // epoch 2
@@ -1078,11 +1099,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective(stake.delegation.stake),
             )
         );
@@ -1091,6 +1108,10 @@ mod tests {
         // and no rewards are perceived
         stake.delegation.activation_epoch = 2;
         stake.credits_observed = 3 * ag_total_stake_multiplier;
+        let reward_epoch_delegated_stakes = make_reward_epoch_delegated_stakes_for_test(
+            vote_state.as_ref_v4(),
+            ag_total_stake_multiplier,
+        );
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: 0,
@@ -1113,11 +1134,7 @@ mod tests {
                     adjust_delegations_for_rent,
                 },
                 null_tracer(),
-                &make_ag_epoch_type_for_test(
-                    ag_enabled,
-                    vote_state.as_ref_v4(),
-                    ag_total_stake_multiplier
-                ),
+                &make_ag_epoch_type_for_test(ag_enabled, &reward_epoch_delegated_stakes,),
                 StakeActivationStatus::with_effective_and_activating(0, stake.delegation.stake),
             )
         );
@@ -1172,8 +1189,9 @@ mod tests {
         let commission_rate_in_basis_points = true;
         let adjust_delegations_for_rent = true;
 
+        let reward_epoch_delegated_stakes = get_reward_epoch_delegated_stakes();
         let ag_stake_state = if ag_enabled {
-            let (state, _, _) = get_ag_epoch_type();
+            let (state, _, _) = get_ag_epoch_type(&reward_epoch_delegated_stakes);
             state
         } else {
             AlpenglowEpochType::Tower
@@ -1206,7 +1224,8 @@ mod tests {
 
     #[test]
     fn test_migration_epoch_dust_split_advances_credits() {
-        let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+        let reward_epoch_delegated_stakes = get_reward_epoch_delegated_stakes();
+        let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type(&reward_epoch_delegated_stakes);
         let mut vote_state = VoteStateV4 {
             inflation_rewards_commission_bps: 100,
             epoch_credits: vec![
@@ -1236,7 +1255,7 @@ mod tests {
             num_tower_slots: 0,
             num_ag_slots: 1,
             migration_epoch: 0,
-            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+            reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes {
                 epoch: 0,
                 delegated_stakes: [(Pubkey::default(), ag_total_stake_multiplier)]
                     .into_iter()
@@ -1282,7 +1301,8 @@ mod tests {
 
     #[test]
     fn test_alpenglow_excludes_inactive_stake() {
-        let (ag_epoch_type, _, first_ag_epoch) = get_ag_epoch_type();
+        let reward_epoch_delegated_stakes = get_reward_epoch_delegated_stakes();
+        let (ag_epoch_type, _, first_ag_epoch) = get_ag_epoch_type(&reward_epoch_delegated_stakes);
         let vote_state = VoteStateV4 {
             epoch_credits: vec![(first_ag_epoch, 4, 0)],
             ..VoteStateV4::default()

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -724,7 +724,7 @@ mod tests {
 
         let ag_epoch_type = AlpenglowEpochType::Alpenglow {
             migration_epoch: 0,
-            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+            reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes {
                 epoch: 64,
                 delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
             },
@@ -781,7 +781,7 @@ mod tests {
 
         let ag_epoch_type = AlpenglowEpochType::Alpenglow {
             migration_epoch: 0,
-            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+            reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes {
                 epoch: 1,
                 delegated_stakes: [(Pubkey::default(), current_delegated_total)]
                     .into_iter()


### PR DESCRIPTION
#### Problem

As part of the vote account sweeping logic being implemented for SIMD-0123 in #14946, we need to know how much stake each vote account had at the end of the epoch, and whether they paid the VAT.

Although some part of that is cached at the start of each epoch, these cached values are dangerous and hard to implement correctly.

#### Summary of changes

Pipe `reward_epoch_delegated_stakes` down to the vote account sweeping, which happens in `begin_partitioned_epoch_rewards`. This requires holding a reference to the delegated stakes in `AgEpochType`.

No functionality change, just updating types and adding some parameters where needed.

#### Testing

This is a refactor, so existing tests should be enough.