### PR TITLE
perf(gossip): Task fair RW lock + critical section optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8522,6 +8522,7 @@ dependencies = [
  "log",
  "num-traits",
  "num_cpus",
+ "parking_lot 0.12.3",
  "qualifier_attr",
  "rand 0.9.4",
  "rand_chacha 0.9.0",

--- a/core/src/cluster_slots_service.rs
+++ b/core/src/cluster_slots_service.rs
@@ -231,7 +231,7 @@ mod test {
         ClusterSlotsService::update_lowest_slot(5, &cluster_info);
         cluster_info.flush_push_queue();
         let lowest = {
-            let gossip_crds = cluster_info.gossip.crds.read().unwrap();
+            let gossip_crds = cluster_info.gossip.crds.read();
             gossip_crds.get::<&LowestSlot>(pubkey).unwrap().clone()
         };
         assert_eq!(lowest.lowest, 5);

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6741,6 +6741,7 @@ dependencies = [
  "lazy-lru",
  "log",
  "num-traits",
+ "parking_lot 0.12.5",
  "qualifier_attr",
  "rand 0.9.4",
  "rand_chacha 0.9.0",

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -57,6 +57,7 @@ itertools = { workspace = true }
 lazy-lru = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
+parking_lot = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/gossip/benches/crds_gossip_pull.rs
+++ b/gossip/benches/crds_gossip_pull.rs
@@ -1,5 +1,6 @@
 use {
     criterion::{Criterion, criterion_group, criterion_main},
+    parking_lot::RwLock,
     rand::{Rng, rng},
     rayon::ThreadPoolBuilder,
     solana_gossip::{
@@ -8,7 +9,6 @@ use {
         crds_value::CrdsValue,
     },
     solana_hash::Hash,
-    std::sync::RwLock,
 };
 
 fn bench_hash_as_u64(c: &mut Criterion) {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2538,7 +2538,7 @@ fn discard_different_shred_version(
         CrdsData::ContactInfo(ci) => ci.shred_version() == self_shred_version,
         // for any other CRDS types we check if we store anything already
         // for this pubkey, if we do we allow more values in
-        _ => crds.get_records(&value.pubkey()).next().is_some(),
+        _ => crds.contains_pubkey(&value.pubkey()),
     });
     let num_skipped = num_values - values.len();
     if num_skipped != 0 {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -45,6 +45,7 @@ use {
     arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, TrySendError},
     itertools::{Either, Itertools},
+    parking_lot::RwLockReadGuard,
     rand::{CryptoRng, Rng, prelude::IndexedMutRandom},
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
     solana_clock::{DEFAULT_SLOTS_PER_EPOCH, Slot},
@@ -87,7 +88,7 @@ use {
         rc::Rc,
         result::Result,
         sync::{
-            Arc, Mutex, OnceLock, RwLock, RwLockReadGuard,
+            Arc, Mutex, OnceLock, RwLock,
             atomic::{AtomicBool, Ordering},
         },
         thread::{Builder, JoinHandle, sleep},
@@ -297,7 +298,7 @@ impl ClusterInfo {
     pub fn insert_info(&self, node: ContactInfo) {
         let entry = CrdsValue::new(CrdsData::ContactInfo(node), &self.keypair());
         if let Err(err) = {
-            let mut gossip_crds = self.gossip.crds.write().unwrap();
+            let mut gossip_crds = self.gossip.crds.write();
             gossip_crds.insert(entry, timestamp(), GossipRoute::LocalMessage)
         } {
             error!("ClusterInfo.insert_info: {err:?}");
@@ -329,11 +330,7 @@ impl ClusterInfo {
     /// at least one Geyser plugin has opted into contact info
     /// notifications; leaving it unset is the zero-cost default.
     pub fn set_contact_info_sender(&self, sender: crate::contact_info_notifier::ContactInfoSender) {
-        self.gossip
-            .crds
-            .write()
-            .unwrap()
-            .set_contact_info_sender(sender);
+        self.gossip.crds.write().set_contact_info_sender(sender);
     }
 
     pub fn save_contact_info(&self) {
@@ -347,7 +344,7 @@ impl ClusterInfo {
                 .filter_map(ContactInfo::gossip)
                 .collect::<HashSet<_>>();
             let self_pubkey = self.id();
-            let gossip_crds = self.gossip.crds.read().unwrap();
+            let gossip_crds = self.gossip.crds.read();
             gossip_crds
                 .get_nodes()
                 .filter_map(|v| {
@@ -453,7 +450,7 @@ impl ClusterInfo {
         );
         let now = timestamp();
         let self_shred_version = self.my_shred_version();
-        let mut gossip_crds = self.gossip.crds.write().unwrap();
+        let mut gossip_crds = self.gossip.crds.write();
         for node in nodes {
             if node
                 .contact_info()
@@ -539,7 +536,7 @@ impl ClusterInfo {
         id: &Pubkey,
         query: impl ContactInfoQuery<R>,
     ) -> Option<R> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds.get(*id).map(query)
     }
 
@@ -550,7 +547,7 @@ impl ClusterInfo {
         peers: impl IntoIterator<Item = &'a Pubkey>,
         query: impl ContactInfoQuery<R>,
     ) -> Vec<(Pubkey, Option<R>)> {
-        let read_guard = self.gossip.crds.read().unwrap();
+        let read_guard = self.gossip.crds.read();
         peers
             .into_iter()
             .map(|id| (*id, read_guard.get(*id).map(|ci: &ContactInfo| query(ci))))
@@ -561,7 +558,7 @@ impl ClusterInfo {
         &self,
         gossip_addr: &SocketAddr,
     ) -> Option<ContactInfo> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         let mut nodes = gossip_crds.get_nodes_contact_info();
         nodes
             .find(|node| node.gossip() == Some(*gossip_addr))
@@ -579,7 +576,7 @@ impl ClusterInfo {
     fn lookup_epoch_slots(&self, ix: EpochSlotsIndex) -> EpochSlots {
         let self_pubkey = self.id();
         let label = CrdsValueLabel::EpochSlots(ix, self_pubkey);
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get::<&CrdsValue>(&label)
             .and_then(|v| v.epoch_slots())
@@ -771,7 +768,7 @@ impl ClusterInfo {
         let self_keypair = self.keypair();
         let self_pubkey = self_keypair.pubkey();
         let last = {
-            let gossip_crds = self.gossip.crds.read().unwrap();
+            let gossip_crds = self.gossip.crds.read();
             gossip_crds
                 .get::<&LowestSlot>(self_pubkey)
                 .map(|x| x.lowest)
@@ -846,7 +843,7 @@ impl ClusterInfo {
             epoch_slot_index = (epoch_slot_index + 1) % crds_data::MAX_EPOCH_SLOTS;
             reset = true;
         }
-        let mut gossip_crds = self.gossip.crds.write().unwrap();
+        let mut gossip_crds = self.gossip.crds.write();
         let now = timestamp();
         for entry in entries {
             if let Err(err) = gossip_crds.insert(entry, now, GossipRoute::LocalMessage) {
@@ -860,7 +857,7 @@ impl ClusterInfo {
         label: &'static str,
         counter: &'a Counter,
     ) -> TimedGuard<'a, RwLockReadGuard<'a, Crds>> {
-        TimedGuard::new(self.gossip.crds.read().unwrap(), label, counter)
+        TimedGuard::new(self.gossip.crds.read(), label, counter)
     }
 
     fn push_message(&self, message: CrdsValue) {
@@ -899,7 +896,7 @@ impl ClusterInfo {
         let vote = Vote::new(self_pubkey, vote, now).unwrap();
         let vote = CrdsData::Vote(vote_index, vote);
         let vote = CrdsValue::new(vote, self_keypair);
-        let mut gossip_crds = self.gossip.crds.write().unwrap();
+        let mut gossip_crds = self.gossip.crds.write();
         if let Err(err) = gossip_crds.insert(vote, now, GossipRoute::LocalMessage) {
             error!("push_vote failed: {err:?}");
         }
@@ -1079,14 +1076,13 @@ impl ClusterInfo {
         self.gossip
             .crds
             .read()
-            .unwrap()
             .get::<&SnapshotHashes>(*pubkey)
             .cloned()
     }
 
     /// Returns epoch-slots inserted since the given cursor.
     pub fn get_epoch_slots(&self, cursor: &mut Cursor) -> Vec<EpochSlots> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_epoch_slots(cursor)
             .map(|entry| match entry.value.data() {
@@ -1098,7 +1094,7 @@ impl ClusterInfo {
 
     /// Returns duplicate-shreds inserted since the given cursor.
     pub(crate) fn get_duplicate_shreds(&self, cursor: &mut Cursor) -> Vec<DuplicateShred> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_duplicate_shreds(cursor)
             .map(|entry| match entry.value.data() {
@@ -1109,7 +1105,7 @@ impl ClusterInfo {
     }
 
     pub fn get_node_version(&self, pubkey: &Pubkey) -> Option<solana_version::Version> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get::<&ContactInfo>(*pubkey)
             .map(ContactInfo::version)
@@ -1125,7 +1121,7 @@ impl ClusterInfo {
     /// all validators that have a valid rpc port.
     pub fn rpc_peers(&self) -> Vec<ContactInfo> {
         let self_pubkey = self.id();
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_nodes_contact_info()
             .filter(|node| {
@@ -1137,7 +1133,7 @@ impl ClusterInfo {
 
     // All nodes in gossip (including spy nodes) and the last time we heard about them
     pub fn all_peers(&self) -> Vec<(ContactInfo, u64)> {
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_nodes()
             .filter_map(|node| {
@@ -1149,7 +1145,7 @@ impl ClusterInfo {
 
     pub fn gossip_peers(&self) -> Vec<ContactInfo> {
         let me = self.id();
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_nodes_contact_info()
             .filter(|node| node.pubkey() != &me && self.check_socket_addr_space(&node.gossip()))
@@ -1174,7 +1170,7 @@ impl ClusterInfo {
     pub fn repair_peers(&self, slot: Slot) -> Vec<ContactInfo> {
         let _st = ScopedTimer::from(&self.stats.repair_peers);
         let self_pubkey = self.id();
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_nodes_contact_info()
             .filter(|node| {
@@ -1206,7 +1202,7 @@ impl ClusterInfo {
     /// compute broadcast table
     pub fn tpu_peers(&self) -> Vec<ContactInfo> {
         let self_pubkey = self.id();
-        let gossip_crds = self.gossip.crds.read().unwrap();
+        let gossip_crds = self.gossip.crds.read();
         gossip_crds
             .get_nodes_contact_info()
             .filter(|node| {
@@ -1226,7 +1222,7 @@ impl ClusterInfo {
         };
         let node = CrdsValue::new(CrdsData::ContactInfo(node), &keypair);
         if let Err(err) = {
-            let mut gossip_crds = self.gossip.crds.write().unwrap();
+            let mut gossip_crds = self.gossip.crds.write();
             gossip_crds.insert(node, timestamp(), GossipRoute::LocalMessage)
         } {
             error!("refresh_my_gossip_contact_info failed: {err:?}");
@@ -1329,7 +1325,7 @@ impl ClusterInfo {
         let entries: Vec<CrdsValue> =
             std::mem::take(&mut *self.local_message_pending_push_queue.lock().unwrap());
         if !entries.is_empty() {
-            let mut gossip_crds = self.gossip.crds.write().unwrap();
+            let mut gossip_crds = self.gossip.crds.write();
             let now = timestamp();
             for entry in entries {
                 let _ = gossip_crds.insert(entry, now, GossipRoute::LocalMessage);
@@ -1483,7 +1479,7 @@ impl ClusterInfo {
     // Trims the CRDS table by dropping all values associated with the pubkeys
     // with the lowest stake, so that the number of unique pubkeys are bounded.
     fn trim_crds_table(&self, cap: usize, stakes: &HashMap<Pubkey, u64>) {
-        if !self.gossip.crds.read().unwrap().should_trim(cap) {
+        if !self.gossip.crds.read().should_trim(cap) {
             return;
         }
         let keep: HashSet<_> = self
@@ -1497,7 +1493,7 @@ impl ClusterInfo {
             .chain(self.known_validators.get().into_iter().flatten().copied())
             .collect();
         self.stats.trim_crds_table.add_relaxed(1);
-        let mut gossip_crds = self.gossip.crds.write().unwrap();
+        let mut gossip_crds = self.gossip.crds.write();
         let num_purged = gossip_crds.trim(cap, &keep, stakes, timestamp());
         self.stats
             .trim_crds_table_purged_values_count
@@ -1974,7 +1970,7 @@ impl ClusterInfo {
             SocketAddr,  // gossip socket-addr of peer
             Vec<Pubkey>, // CRDS value origins
         )> = {
-            let gossip_crds = self.gossip.crds.read().unwrap();
+            let gossip_crds = self.gossip.crds.read();
             thread_pool.install(|| {
                 prunes
                     .into_par_iter()
@@ -2031,7 +2027,7 @@ impl ClusterInfo {
         // Filter out values if the shred-versions are different.
         let self_shred_version = self.my_shred_version();
         {
-            let gossip_crds = self.gossip.crds.read().unwrap();
+            let gossip_crds = self.gossip.crds.read();
             let discard_different_shred_version = |msg| {
                 discard_different_shred_version(msg, self_shred_version, &gossip_crds, &self.stats)
             };
@@ -2996,7 +2992,7 @@ mod tests {
         let d = ContactInfo::new_localhost(&solana_pubkey::new_rand(), timestamp());
         let label = CrdsValueLabel::ContactInfo(*d.pubkey());
         cluster_info.insert_info(d);
-        let gossip_crds = cluster_info.gossip.crds.read().unwrap();
+        let gossip_crds = cluster_info.gossip.crds.read();
         assert!(gossip_crds.get::<&CrdsValue>(&label).is_some());
     }
 
@@ -3025,7 +3021,7 @@ mod tests {
             ClusterInfo::new(other_ci, other_keypair, SocketAddrSpace::Unspecified);
         cluster_info_b.restore_contact_info(tmpdir.path(), 0);
 
-        let gossip_crds = cluster_info_b.gossip.crds.read().unwrap();
+        let gossip_crds = cluster_info_b.gossip.crds.read();
         assert!(
             gossip_crds
                 .get::<&CrdsValue>(&CrdsValueLabel::ContactInfo(peer1_pubkey))
@@ -3422,7 +3418,7 @@ mod tests {
     fn test_push_votes_with_tower() {
         let get_vote_slots = |cluster_info: &ClusterInfo| -> Vec<Slot> {
             let (labels, _) = cluster_info.get_votes_with_labels(&mut Cursor::default());
-            let gossip_crds = cluster_info.gossip.crds.read().unwrap();
+            let gossip_crds = cluster_info.gossip.crds.read();
             let mut vote_slots = HashSet::new();
             for label in labels {
                 let CrdsData::Vote(_, vote) = &gossip_crds.get::<&CrdsData>(&label).unwrap() else {
@@ -3514,12 +3510,11 @@ mod tests {
             .gossip
             .crds
             .write()
-            .unwrap()
             .insert(value, timestamp(), GossipRoute::LocalMessage)
             .unwrap();
         cluster_info.push_epoch_slots(&[next_slot]);
 
-        let crds = cluster_info.gossip.crds.read().unwrap();
+        let crds = cluster_info.gossip.crds.read();
         let label = CrdsValueLabel::EpochSlots(0, pubkey);
         let value = crds.get::<&CrdsValue>(&label).unwrap();
         assert!(value.sanitize().is_ok());
@@ -3695,7 +3690,7 @@ mod tests {
                 0,
                 LowestSlot::new(other_node_pubkey, peer_lowest, timestamp()),
             ));
-            let mut gossip_crds = cluster_info.gossip.crds.write().unwrap();
+            let mut gossip_crds = cluster_info.gossip.crds.write();
             let _ = gossip_crds.insert(value, timestamp(), GossipRoute::LocalMessage);
         }
         // only half the visible peers should be eligible to serve this repair

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -213,7 +213,7 @@ pub(crate) fn submit_gossip_stats(
     stakes: &HashMap<Pubkey, u64>,
 ) {
     let (crds_stats, table_size, num_nodes, num_pubkeys, purged_values_size, failed_inserts_size) = {
-        let gossip_crds = gossip.crds.read().unwrap();
+        let gossip_crds = gossip.crds.read();
         (
             gossip_crds.take_stats(),
             gossip_crds.len(),

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -267,7 +267,8 @@ impl Crds {
         let label = value.label();
         let pubkey = value.pubkey();
         let value = VersionedCrdsValue::new(value, self.cursor, now, route);
-        let mut stats = self.stats.lock().unwrap();
+        // insert() has exclusive access to Crds, so this mutex cannot contend.
+        let stats = self.stats.get_mut().unwrap();
         match self.table.entry(label) {
             Entry::Vacant(entry) => {
                 stats.record_insert(&value, route);
@@ -454,6 +455,12 @@ impl Crds {
             .into_iter()
             .flat_map(|records| records.into_iter())
             .map(move |i| self.table.index(*i))
+    }
+
+    /// Returns whether CRDS contains any record for the given pubkey.
+    #[inline]
+    pub(crate) fn contains_pubkey(&self, pubkey: &Pubkey) -> bool {
+        self.records.contains_key(pubkey)
     }
 
     /// Returns number of known contact-infos (network size).

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -18,6 +18,7 @@ use {
         duplicate_shred::{self, DuplicateShredIndex, MAX_DUPLICATE_SHREDS},
         protocol::{Ping, PingCache},
     },
+    parking_lot::RwLock,
     rand::{CryptoRng, Rng},
     rayon::ThreadPool,
     solana_clock::Slot,
@@ -32,7 +33,7 @@ use {
         cmp,
         collections::{HashMap, HashSet},
         net::SocketAddr,
-        sync::{Mutex, RwLock},
+        sync::Mutex,
         time::{Duration, Instant},
     },
 };
@@ -101,7 +102,7 @@ impl CrdsGossip {
         let pubkey = keypair.pubkey();
         // Skip if there are already records of duplicate shreds for this slot.
         let shred_slot = shred.slot();
-        let mut crds = self.crds.write().unwrap();
+        let mut crds = self.crds.write();
         if crds
             .get_records(&pubkey)
             .any(|value| match value.value.data() {
@@ -304,7 +305,6 @@ impl CrdsGossip {
         let rv = CrdsGossipPull::purge_active(thread_pool, &self.crds, now, timeouts);
         self.crds
             .write()
-            .unwrap()
             .trim_purged(now.saturating_sub(5 * self.pull.crds_timeout));
         self.pull.purge_failed_inserts(now);
         rv
@@ -333,7 +333,7 @@ pub(crate) fn get_gossip_nodes<R: Rng>(
     // Exclude nodes which have not been active for this long.
     const ACTIVE_TIMEOUT: Duration = Duration::from_secs(60);
     let active_cutoff = now.saturating_sub(ACTIVE_TIMEOUT.as_millis() as u64);
-    let crds = crds.read().unwrap();
+    let crds = crds.read();
     crds.get_nodes()
         .filter_map(|value| {
             let node = value.value.contact_info()?;
@@ -411,7 +411,6 @@ mod test {
         crds_gossip
             .crds
             .write()
-            .unwrap()
             .insert(
                 CrdsValue::new_unsigned(CrdsData::from(&ci)),
                 0,

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -284,7 +284,7 @@ impl CrdsGossipPull {
     pub(crate) fn new_pull_request(
         &self,
         thread_pool: &ThreadPool,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         self_keypair: &Keypair,
         self_shred_version: u16,
         now: u64,
@@ -345,7 +345,7 @@ impl CrdsGossipPull {
 
     /// Create gossip responses to pull requests
     pub(crate) fn generate_pull_responses(
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         requests: &[PullRequest],
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
@@ -372,7 +372,7 @@ impl CrdsGossipPull {
     //  .2 => hash value of outdated values which will fail to insert.
     pub(crate) fn filter_pull_responses(
         &self,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         timeouts: &CrdsTimeouts,
         responses: Vec<CrdsValue>,
         now: u64,
@@ -380,7 +380,7 @@ impl CrdsGossipPull {
     ) -> (Vec<CrdsValue>, Vec<CrdsValue>, Vec<Hash>) {
         let mut active_values = vec![];
         let mut expired_values = vec![];
-        let crds = crds.read().unwrap();
+        let crds = crds.read();
         let upsert = |response: CrdsValue| {
             let owner = response.label().pubkey();
             // Check if the crds value is older than the msg_timeout
@@ -414,7 +414,7 @@ impl CrdsGossipPull {
     /// Process a vec of pull responses
     pub(crate) fn process_pull_responses(
         &self,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         responses: Vec<CrdsValue>,
         responses_expired_timeout: Vec<CrdsValue>,
         failed_inserts: Vec<Hash>,
@@ -422,7 +422,7 @@ impl CrdsGossipPull {
         stats: &mut ProcessPullStats,
     ) {
         let mut owners = HashSet::new();
-        let mut crds = crds.write().unwrap();
+        let mut crds = crds.write();
         for response in responses_expired_timeout {
             let _ = crds.insert(response, now, GossipRoute::PullResponse);
         }
@@ -467,7 +467,7 @@ impl CrdsGossipPull {
     pub fn build_crds_filters(
         &self,
         thread_pool: &ThreadPool,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         bloom_size: usize,
     ) -> Vec<CrdsFilter> {
         const PAR_MIN_LENGTH: usize = 512;
@@ -475,7 +475,7 @@ impl CrdsGossipPull {
         let hash_values: Vec<_> = {
             let failed_inserts = self.failed_inserts.read().unwrap();
             // crds should be locked last after self.failed_inserts.
-            let crds = crds.read().unwrap();
+            let crds = crds.read();
             thread_pool.install(|| {
                 crds.par_values()
                     .with_min_len(PAR_MIN_LENGTH)
@@ -503,7 +503,7 @@ impl CrdsGossipPull {
 
     /// Filter values that fail the bloom filter up to `max_bytes`.
     fn filter_crds_values(
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         requests: &[PullRequest],
         mut output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
@@ -521,7 +521,7 @@ impl CrdsGossipPull {
             now.saturating_sub(msg_timeout)..now.saturating_add(msg_timeout);
         let mut dropped_requests = 0usize;
         let mut total_skipped = 0usize;
-        let crds = crds.read().unwrap();
+        let crds = crds.read();
         let apply_filter = |request: &PullRequest| {
             if output_size_limit == 0 {
                 return Vec::default();
@@ -580,11 +580,11 @@ impl CrdsGossipPull {
     /// Purge values from the crds that are older then `active_timeout`
     pub(crate) fn purge_active(
         thread_pool: &ThreadPool,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         now: u64,
         timeouts: &CrdsTimeouts,
     ) -> usize {
-        let mut crds = crds.write().unwrap();
+        let mut crds = crds.write();
         let labels = crds.find_old_labels(thread_pool, now, timeouts);
         for label in &labels {
             crds.remove(label, now);
@@ -715,7 +715,7 @@ pub(crate) mod tests {
         fn old_pull_request(
             &self,
             thread_pool: &ThreadPool,
-            crds: &RwLock<Crds>,
+            crds: &parking_lot::RwLock<Crds>,
             self_keypair: &Keypair,
             self_shred_version: u16,
             now: u64,
@@ -741,7 +741,6 @@ pub(crate) mod tests {
             )?;
             let nodes: HashMap<SocketAddr, ContactInfo> = crds
                 .read()
-                .unwrap()
                 .get_nodes_contact_info()
                 .map(|node| (node.gossip().unwrap(), node.clone()))
                 .collect();
@@ -924,7 +923,7 @@ pub(crate) mod tests {
                 num_inserts += 1;
             }
         }
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
         assert!(num_inserts > 30_000, "num inserts: {num_inserts}");
         let filters = crds_gossip_pull.build_crds_filters(
             &thread_pool,
@@ -932,7 +931,7 @@ pub(crate) mod tests {
             992, // max_bloom_filter_bytes
         );
         assert_eq!(filters.len(), MIN_NUM_BLOOM_FILTERS.max(4));
-        let crds = crds.read().unwrap();
+        let crds = crds.read();
         let purged: Vec<_> = thread_pool.install(|| crds.purged().collect());
         let hash_values: Vec<_> = crds
             .values()
@@ -969,7 +968,7 @@ pub(crate) mod tests {
     #[test]
     fn test_new_pull_request() {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let node_keypair = Keypair::new();
         let entry = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &node_keypair.pubkey(),
@@ -996,7 +995,6 @@ pub(crate) mod tests {
         );
 
         crds.write()
-            .unwrap()
             .insert(entry, 0, GossipRoute::LocalMessage)
             .unwrap();
         assert_eq!(
@@ -1024,7 +1022,6 @@ pub(crate) mod tests {
             .mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.write()
-            .unwrap()
             .insert(new.clone(), now, GossipRoute::LocalMessage)
             .unwrap();
         let req = node.old_pull_request(
@@ -1047,7 +1044,6 @@ pub(crate) mod tests {
         offline.set_gossip(([127, 0, 0, 1], 8021)).unwrap();
         let offline = CrdsValue::new_unsigned(CrdsData::from(offline));
         crds.write()
-            .unwrap()
             .insert(offline, now, GossipRoute::LocalMessage)
             .unwrap();
         let req = node.old_pull_request(
@@ -1093,7 +1089,7 @@ pub(crate) mod tests {
         ping_cache.mock_pong(*new.pubkey(), new.gossip().unwrap(), Instant::now());
         let new = CrdsValue::new_unsigned(CrdsData::from(new));
         crds.insert(new, now, GossipRoute::LocalMessage).unwrap();
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
 
         // set request creation time to now.
         let now = now + 50_000;
@@ -1136,10 +1132,9 @@ pub(crate) mod tests {
             &solana_pubkey::new_rand(),
             new_wallclock,
         )));
-        let dest_crds = RwLock::<Crds>::default();
+        let dest_crds = parking_lot::RwLock::new(Crds::default());
         dest_crds
             .write()
-            .unwrap()
             .insert(new.clone(), new_wallclock, GossipRoute::LocalMessage)
             .unwrap();
 
@@ -1199,7 +1194,7 @@ pub(crate) mod tests {
             let entry: &VersionedCrdsValue = node_crds.get(&same_key.label()).unwrap();
             entry.local_timestamp
         });
-        let node_crds = RwLock::new(node_crds);
+        let node_crds = parking_lot::RwLock::new(node_crds);
         let stakes = HashMap::new();
         let timeouts = node.make_timeouts(node_pubkey, &stakes, Duration::default());
         let mut stats = ProcessPullStats::default();
@@ -1220,7 +1215,7 @@ pub(crate) mod tests {
         assert_eq!(stats.failed_insert, 0);
         assert_eq!(stats.failed_timeout, 0);
         assert_eq!(stats.success, 1);
-        let node_crds = node_crds.read().unwrap();
+        let node_crds = node_crds.read();
         let entry: &VersionedCrdsValue = node_crds.get(&new.label()).unwrap();
         assert_eq!(entry.value, new);
         assert_eq!(entry.local_timestamp, 1);
@@ -1254,21 +1249,18 @@ pub(crate) mod tests {
             node_label
         );
         // purge
-        let node_crds = RwLock::new(node_crds);
+        let node_crds = parking_lot::RwLock::new(node_crds);
         let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = node.make_timeouts(node_pubkey, &stakes, Duration::default());
         CrdsGossipPull::purge_active(&thread_pool, &node_crds, node.crds_timeout, &timeouts);
 
         //verify self is still valid after purge
         assert_eq!(node_label, {
-            let node_crds = node_crds.read().unwrap();
+            let node_crds = node_crds.read();
             node_crds.get::<&CrdsValue>(&node_label).unwrap().label()
         });
-        assert_eq!(
-            node_crds.read().unwrap().get::<&CrdsValue>(&old.label()),
-            None
-        );
-        assert_eq!(node_crds.read().unwrap().num_purged(), 1);
+        assert_eq!(node_crds.read().get::<&CrdsValue>(&old.label()), None);
+        assert_eq!(node_crds.read().num_purged(), 1);
         for _ in 0..30 {
             // there is a chance of a false positive with bloom filters
             // assert that purged value is still in the set
@@ -1278,7 +1270,7 @@ pub(crate) mod tests {
         }
 
         // purge the value
-        let mut node_crds = node_crds.write().unwrap();
+        let mut node_crds = node_crds.write();
         node_crds.trim_purged(node.crds_timeout + 1);
         assert_eq!(node_crds.num_purged(), 0);
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -471,27 +471,33 @@ impl CrdsGossipPull {
         bloom_size: usize,
     ) -> Vec<CrdsFilter> {
         const PAR_MIN_LENGTH: usize = 512;
-        let failed_inserts = self.failed_inserts.read().unwrap();
-        // crds should be locked last after self.failed_inserts.
-        let crds = crds.read().unwrap();
-        let num_items = crds.len() + crds.num_purged() + failed_inserts.len();
-        let num_items = MIN_NUM_BLOOM_ITEMS.max(num_items);
+        // Snapshot hashes so that the locks are not held while building the filters.
+        let hash_values: Vec<_> = {
+            let failed_inserts = self.failed_inserts.read().unwrap();
+            // crds should be locked last after self.failed_inserts.
+            let crds = crds.read().unwrap();
+            thread_pool.install(|| {
+                crds.par_values()
+                    .with_min_len(PAR_MIN_LENGTH)
+                    .map(|v| *v.value.hash())
+                    .chain(crds.purged().with_min_len(PAR_MIN_LENGTH))
+                    .chain(
+                        failed_inserts
+                            .par_iter()
+                            .with_min_len(PAR_MIN_LENGTH)
+                            .map(|(v, _)| *v),
+                    )
+                    .collect()
+            })
+        };
+        let num_items = MIN_NUM_BLOOM_ITEMS.max(hash_values.len());
         let filters = CrdsFilterSet::new(&mut rand::rng(), num_items, bloom_size);
         thread_pool.install(|| {
-            crds.par_values()
+            hash_values
+                .into_par_iter()
                 .with_min_len(PAR_MIN_LENGTH)
-                .map(|v| *v.value.hash())
-                .chain(crds.purged().with_min_len(PAR_MIN_LENGTH))
-                .chain(
-                    failed_inserts
-                        .par_iter()
-                        .with_min_len(PAR_MIN_LENGTH)
-                        .map(|(v, _)| *v),
-                )
                 .for_each(|v| filters.add(v));
         });
-        drop(crds);
-        drop(failed_inserts);
         filters.into()
     }
 

--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -83,9 +83,9 @@ impl Default for CrdsGossipPush {
     }
 }
 impl CrdsGossipPush {
-    pub fn num_pending(&self, crds: &RwLock<Crds>) -> usize {
+    pub fn num_pending(&self, crds: &parking_lot::RwLock<Crds>) -> usize {
         let mut cursor: Cursor = *self.crds_cursor.lock().unwrap();
-        crds.read().unwrap().get_entries(&mut cursor).count()
+        crds.read().get_entries(&mut cursor).count()
     }
 
     pub(crate) fn prune_received_cache<I>(
@@ -123,12 +123,12 @@ impl CrdsGossipPush {
     /// Returns origins' pubkeys of upserted values.
     pub(crate) fn process_push_message(
         &self,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         messages: Vec<(/*from:*/ Pubkey, Vec<CrdsValue>)>,
         now: u64,
     ) -> HashSet<Pubkey> {
         let mut received_cache = self.received_cache.lock().unwrap();
-        let mut crds = crds.write().unwrap();
+        let mut crds = crds.write();
         let wallclock_window = self.wallclock_window(now);
         let mut origins = HashSet::new();
         for (from, values) in messages {
@@ -166,7 +166,7 @@ impl CrdsGossipPush {
     pub(crate) fn new_push_messages(
         &self,
         pubkey: &Pubkey, // This node.
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         now: u64,
         stakes: &HashMap<Pubkey, u64>,
         // Predicate returning false if the CRDS value should be discarded.
@@ -185,7 +185,7 @@ impl CrdsGossipPush {
         let active_set = self.active_set.read().unwrap();
         let mut crds_cursor = self.crds_cursor.lock().unwrap();
         // crds should be locked last after self.{active_set,crds_cursor}.
-        let crds = crds.read().unwrap();
+        let crds = crds.read();
         let entries = crds
             .get_entries(crds_cursor.deref_mut())
             .map(|entry| &entry.value)
@@ -237,7 +237,7 @@ impl CrdsGossipPush {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn refresh_push_active_set(
         &self,
-        crds: &RwLock<Crds>,
+        crds: &parking_lot::RwLock<Crds>,
         stakes: &HashMap<Pubkey, u64>,
         gossip_validators: Option<&HashSet<Pubkey>>,
         self_keypair: &Keypair,
@@ -273,7 +273,7 @@ impl CrdsGossipPush {
         if nodes.len() == 0 {
             return;
         }
-        let cluster_size = crds.read().unwrap().num_pubkeys().max(stakes.len());
+        let cluster_size = crds.read().num_pubkeys().max(stakes.len());
         let mut active_set = self.active_set.write().unwrap();
         active_set.rotate(
             &mut rng,
@@ -310,7 +310,7 @@ mod tests {
         fn old_new_push_messages(
             &self,
             pubkey: &Pubkey,
-            crds: &RwLock<Crds>,
+            crds: &parking_lot::RwLock<Crds>,
             now: u64,
             stakes: &HashMap<Pubkey, u64>,
         ) -> HashMap<Pubkey, Vec<CrdsValue>> {
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_process_push_one() {
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let push = CrdsGossipPush::default();
         let value = CrdsValue::new_unsigned(CrdsData::from(ContactInfo::new_localhost(
             &solana_pubkey::new_rand(),
@@ -345,7 +345,7 @@ mod tests {
             push.process_push_message(&crds, vec![(Pubkey::default(), vec![value.clone()])], 0),
             [label.pubkey()].into_iter().collect(),
         );
-        assert_eq!(crds.read().unwrap().get::<&CrdsValue>(&label), Some(&value));
+        assert_eq!(crds.read().get::<&CrdsValue>(&label), Some(&value));
 
         // push it again
         assert!(
@@ -355,7 +355,7 @@ mod tests {
     }
     #[test]
     fn test_process_push_old_version() {
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ci.set_wallclock(1);
@@ -377,7 +377,7 @@ mod tests {
     }
     #[test]
     fn test_process_push_timeout() {
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let push = CrdsGossipPush::default();
         let timeout = push.msg_timeout;
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
@@ -400,7 +400,7 @@ mod tests {
     }
     #[test]
     fn test_process_push_update() {
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         let origin = *ci.pubkey();
@@ -435,7 +435,7 @@ mod tests {
             crds.insert(peer.clone(), now, GossipRoute::LocalMessage),
             Ok(())
         );
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
         let ping_cache = Mutex::new(ping_cache);
         push.refresh_push_active_set(
             &crds,
@@ -494,7 +494,7 @@ mod tests {
             crds.insert(peers[1].clone(), now, GossipRoute::LocalMessage),
             Ok(())
         );
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
         assert_eq!(
             push.process_push_message(
                 &crds,
@@ -545,7 +545,7 @@ mod tests {
             crds.insert(peer.clone(), 0, GossipRoute::LocalMessage),
             Ok(())
         );
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
         let ping_cache = Mutex::new(new_ping_cache());
         push.refresh_push_active_set(
             &crds,
@@ -593,7 +593,7 @@ mod tests {
             0,
         )));
         assert_eq!(crds.insert(peer, 0, GossipRoute::LocalMessage), Ok(()));
-        let crds = RwLock::new(crds);
+        let crds = parking_lot::RwLock::new(crds);
         let ping_cache = Mutex::new(new_ping_cache());
         push.refresh_push_active_set(
             &crds,
@@ -628,7 +628,7 @@ mod tests {
 
     #[test]
     fn test_purge_old_received_cache() {
-        let crds = RwLock::<Crds>::default();
+        let crds = parking_lot::RwLock::default();
         let push = CrdsGossipPush::default();
         let mut ci = ContactInfo::new_localhost(&solana_pubkey::new_rand(), 0);
         ci.set_wallclock(0);
@@ -639,10 +639,7 @@ mod tests {
             push.process_push_message(&crds, vec![(Pubkey::default(), vec![value.clone()])], 0),
             [label.pubkey()].into_iter().collect()
         );
-        assert_eq!(
-            crds.write().unwrap().get::<&CrdsValue>(&label),
-            Some(&value)
-        );
+        assert_eq!(crds.write().get::<&CrdsValue>(&label), Some(&value));
 
         // push it again
         assert!(

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -117,7 +117,7 @@ fn star_network_create(num: usize) -> Network {
             let new = CrdsValue::new(CrdsData::from(&contact_info), &node_keypair);
             let node = CrdsGossip::default();
             {
-                let mut node_crds = node.crds.write().unwrap();
+                let mut node_crds = node.crds.write();
                 node_crds
                     .insert(new.clone(), timestamp(), GossipRoute::LocalMessage)
                     .unwrap();
@@ -133,7 +133,6 @@ fn star_network_create(num: usize) -> Network {
     let id = entry.label().pubkey();
     node.crds
         .write()
-        .unwrap()
         .insert(entry, timestamp(), GossipRoute::LocalMessage)
         .unwrap();
     let node = Node::new(node_keypair, contact_info, Arc::new(node));
@@ -150,7 +149,6 @@ fn rstar_network_create(num: usize) -> Network {
     origin
         .crds
         .write()
-        .unwrap()
         .insert(entry, timestamp(), GossipRoute::LocalMessage)
         .unwrap();
     let mut network: HashMap<_, _> = (1..num)
@@ -161,13 +159,11 @@ fn rstar_network_create(num: usize) -> Network {
             let node = CrdsGossip::default();
             node.crds
                 .write()
-                .unwrap()
                 .insert(new.clone(), timestamp(), GossipRoute::LocalMessage)
                 .unwrap();
             origin
                 .crds
                 .write()
-                .unwrap()
                 .insert(new.clone(), timestamp(), GossipRoute::LocalMessage)
                 .unwrap();
             let node = Node::new(node_keypair, contact_info, Arc::new(node));
@@ -188,7 +184,6 @@ fn ring_network_create(num: usize) -> Network {
             let node = CrdsGossip::default();
             node.crds
                 .write()
-                .unwrap()
                 .insert(new.clone(), timestamp(), GossipRoute::LocalMessage)
                 .unwrap();
             let node = Node::new(node_keypair, contact_info, Arc::new(node));
@@ -201,11 +196,11 @@ fn ring_network_create(num: usize) -> Network {
             let start = &network[&keys[k]];
             let start_id = keys[k];
             let label = CrdsValueLabel::ContactInfo(start_id);
-            let gossip_crds = start.gossip.crds.read().unwrap();
+            let gossip_crds = start.gossip.crds.read();
             gossip_crds.get::<&CrdsValue>(&label).unwrap().clone()
         };
         let end = network.get_mut(&keys[(k + 1) % keys.len()]).unwrap();
-        let mut end_crds = end.gossip.crds.write().unwrap();
+        let mut end_crds = end.gossip.crds.write();
         end_crds
             .insert(start_info, timestamp(), GossipRoute::LocalMessage)
             .unwrap();
@@ -223,7 +218,6 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
             let node = CrdsGossip::default();
             node.crds
                 .write()
-                .unwrap()
                 .insert(new.clone(), timestamp(), GossipRoute::LocalMessage)
                 .unwrap();
             let node = Node::staked(node_keypair, contact_info, Arc::new(node), stakes[n]);
@@ -237,12 +231,12 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
         .map(|k| {
             let start = &network[k];
             let start_label = CrdsValueLabel::ContactInfo(*k);
-            let gossip_crds = start.gossip.crds.read().unwrap();
+            let gossip_crds = start.gossip.crds.read();
             gossip_crds.get::<&CrdsValue>(&start_label).unwrap().clone()
         })
         .collect();
     for (end_pubkey, end) in network.iter_mut() {
-        let mut end_crds = end.gossip.crds.write().unwrap();
+        let mut end_crds = end.gossip.crds.write();
         for k in 0..keys.len() {
             if keys[k] != *end_pubkey {
                 let start_info = start_entries[k].clone();
@@ -265,14 +259,14 @@ fn network_simulator_pull_only(thread_pool: &ThreadPool, network: &Network) {
         .iter()
         .map(|(&pubkey, node)| {
             let label = CrdsValueLabel::ContactInfo(pubkey);
-            let crds = node.gossip.crds.read().unwrap();
+            let crds = node.gossip.crds.read();
             let entry = crds.get::<&CrdsValue>(&label).unwrap().clone();
             (pubkey, entry)
         })
         .unzip();
     entries.rotate_right(1);
     for (pubkey, entry) in pubkeys.into_iter().zip(entries) {
-        let mut crds = network.nodes[&pubkey].gossip.crds.write().unwrap();
+        let mut crds = network.nodes[&pubkey].gossip.crds.write();
         let _ = crds.insert(entry, timestamp(), GossipRoute::LocalMessage);
     }
     // Star convergence needs O(SAMPLE_RATE * num) rounds.
@@ -311,7 +305,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
         network_values.par_iter().for_each(|node| {
             let node_pubkey = node.keypair.pubkey();
             let mut m = {
-                let node_crds = node.gossip.crds.read().unwrap();
+                let node_crds = node.gossip.crds.read();
                 node_crds.get::<&ContactInfo>(node_pubkey).cloned().unwrap()
             };
             m.set_wallclock(now);
@@ -552,7 +546,7 @@ fn network_run_pull(
                         .unwrap_or_default();
                     let from_pubkey = from.keypair.pubkey();
                     let label = CrdsValueLabel::ContactInfo(from_pubkey);
-                    let gossip_crds = from.gossip.crds.read().unwrap();
+                    let gossip_crds = from.gossip.crds.read();
                     let self_info = gossip_crds.get::<&CrdsValue>(&label).unwrap().clone();
                     requests
                         .into_iter()
@@ -633,7 +627,7 @@ fn network_run_pull(
         }
         let total: usize = network_values
             .par_iter()
-            .map(|v| v.gossip.crds.read().unwrap().len())
+            .map(|v| v.gossip.crds.read().len())
             .sum();
         convergance = total as f64 / ((num * num) as f64);
         if convergance > max_convergance {
@@ -774,7 +768,6 @@ fn test_prune_errors() {
     crds_gossip
         .crds
         .write()
-        .unwrap()
         .insert(
             CrdsValue::new(CrdsData::from(&ci), &Keypair::new()),
             0,

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6842,6 +6842,7 @@ dependencies = [
  "lazy-lru",
  "log",
  "num-traits",
+ "parking_lot 0.12.2",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -703,7 +703,7 @@ pub fn make_test_cluster<R: Rng>(
     {
         let now = timestamp();
         let keypair = Keypair::new();
-        let mut gossip_crds = cluster_info.gossip.crds.write().unwrap();
+        let mut gossip_crds = cluster_info.gossip.crds.write();
         // First node is pushed to crds table by ClusterInfo constructor.
         for node in nodes.iter().skip(1) {
             let node = CrdsData::from(node);

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -286,7 +286,7 @@ mod tests {
             assert_eq!(node_pubkey, entry.label().pubkey());
 
             {
-                let mut gossip_crds = cluster_info.gossip.crds.write().unwrap();
+                let mut gossip_crds = cluster_info.gossip.crds.write();
 
                 gossip_crds
                     .insert(entry, timestamp(), GossipRoute::LocalMessage)


### PR DESCRIPTION
## Summary

Use `parking_lot::RwLock<Crds>` for task-fair lock acquisition instead of `std::sync::RwLock`. The lock no longer poisons on panic, but the validator already exits on panic.

This stacked branch also:

- builds bloom filters from a hash snapshot outside the CRDS read lock;
- removes the redundant statistics mutex acquisition from `Crds::insert` (20% faster);
- replaces record iteration with a direct pubkey-index lookup (10% faster).

## Benchmark

Measured contended CRDS lock acquisitions for 60 seconds per variant on a live validator.

| Metric | origin/master | This branch's changes | Change |
|---|---:|---:|---:|
| Mean wait | 465.8 µs | 285.4 µs | −38.7% |
| Median wait | 178.6 µs | 74.2 µs | −58.5% |
| p95 wait | 1805.3 µs | 1472.7 µs | −18.4% |
| p99 wait | 2125.5 µs | 2055.4 µs | −3.3% |
| Maximum wait | 2634.1 µs | 2791.0 µs | +6.0% |
| Writer median | 253.4 µs | 77.6 µs | −69.4% |
| Total wait / 60 s | 402.9 ms | 270.5 ms | −32.8% |

Contended acquisitions: 865 → 948. Read p99 increased from 1302.3 to 1418.9 µs (+9.0%) as writers aren't starved anymore. p95+ latencies require splitting many long critical sections before they start improving. These changes come in follow-up PRs.