### PR TITLE
validator: panic if started with DCOU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
+ "agave-votor-messages",
  "agave-votor-transport",
  "agave-xdp",
  "arc-swap",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
+ "agave-votor-messages",
  "agave-votor-transport",
  "agave-xdp",
  "arc-swap",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -26,6 +26,7 @@ agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
+agave-votor-messages = { workspace = true }
 agave-votor-transport = { workspace = true }
 agave-xdp = { workspace = true }
 arc-swap = { workspace = true }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1272,6 +1272,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .conflicts_with("no_xdp")
             .help("Enable XDP zero copy mode. Requires hardware and driver support"),
     )
+    .arg(
+        Arg::with_name("experimental_allow_unsafe_dcou")
+            .long("experimental-allow-unsafe-dcou")
+            .takes_value(false)
+            .hidden(hidden_unless_forced())
+            .help("Do not use, skips the DCOU check on startup"),
+    )
     .args(&pub_sub_config::args(/*test_validator:*/ false))
     .args(&json_rpc_config::args())
     .args(&rpc_bigtable_config::args())

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -103,6 +103,14 @@ pub fn execute(
     operation: Operation,
     config: super::Config,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if !matches.is_present("experimental_allow_unsafe_dcou") {
+        assert_eq!(
+            agave_votor_messages::migration::MIGRATION_SLOT_OFFSET,
+            5000,
+            "agave-validator was built with `dev-context-only-utils` enabled; refusing to start, \
+             please use scripts/cargo-install-all.sh to properly build the binary"
+        );
+    }
     // Debugging panics is easier with a backtrace
     if env::var_os("RUST_BACKTRACE").is_none() {
         // Safety: env update is made before any spawned threads might access the environment

--- a/validator/tests/cli.rs
+++ b/validator/tests/cli.rs
@@ -30,6 +30,7 @@ fn test_use_the_same_path_for_accounts_and_snapshots() {
         temp_dir_str,
         "--snapshots",
         temp_dir_str,
+        "--experimental-allow-unsafe-dcou",
     ]);
     cmd.assert().failure().stderr(predicates::str::contains(
         "the --accounts and --snapshots paths must be unique",


### PR DESCRIPTION
#### Problem
People building without the install script could accidentally enable DCOU. This is even worse in the Jito fork where even running `cargo build --release -p agave-validator` enables DCOU.

The AG migration offset is gated on DCOU to enable testing with short epochs. I am worried that too many people with DCOU enabled can cause the migration to fail.

#### Summary of Changes
Panic if DCOU is enabled in `agave-votor-messages` on startup. Bit of a dirty hack, but we can delete this once AG goes live.