### PR TITLE
svm: program_loader: document closed program reload loop

### DIFF
--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -529,7 +529,6 @@ pub(crate) mod tests {
         solana_message::Message,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::{
-            loaded_programs::ProgramToLoad,
             program_cache_entry::{
                 ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             },
@@ -538,7 +537,9 @@ pub(crate) mod tests {
         solana_pubkey::Pubkey,
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
         solana_signer::Signer,
-        solana_svm::account_loader::AccountLoader,
+        solana_svm::{
+            account_loader::AccountLoader, program_loader::filter_executable_program_accounts,
+        },
         solana_svm_timings::ExecuteTimings,
         solana_transaction::Transaction,
         solana_transaction_error::TransactionError,
@@ -769,14 +770,15 @@ pub(crate) mod tests {
                 1,
             );
             let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(bank.slot());
+            let missing_programs = filter_executable_program_accounts(
+                &account_loader,
+                &program_cache_for_tx_batch,
+                std::iter::once(&self.target_program_address),
+            );
             let mut execute_timings = ExecuteTimings::default();
             bank.transaction_processor.replenish_program_cache(
                 &account_loader,
-                vec![ProgramToLoad {
-                    program_id: &self.target_program_address,
-                    loader: ProgramCacheEntryOwner::LoaderV3,
-                    deployment_slot: migration_or_upgrade_slot,
-                }],
+                missing_programs,
                 &bank.transaction_processor.program_runtime_environment,
                 &mut program_cache_for_tx_batch,
                 &mut execute_timings,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -185,10 +185,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     Some(Arc::new(loaded_program))
 }
 
-/// Find the slot in which the program was most recently re-/deployed.
-/// Returns slot 0 for programs deployed with v1/v2 loaders, since programs deployed
-/// with those loaders do not retain deployment slot information.
-/// Returns an error if the program's account state can not be found or parsed.
 fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program: &AccountSharedData,
@@ -196,6 +192,8 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
 ) -> TransactionResult<Slot> {
     match loader {
         ProgramCacheEntryOwner::LoaderV1 | ProgramCacheEntryOwner::LoaderV2 => {
+            // V1 & V2 programs are immutable and hold no deployment metadata.
+            // As long as there is *some* kind of ELF present, return slot 0.
             if program.data().is_empty() {
                 Err(TransactionError::ProgramAccountNotFound)
             } else {
@@ -203,6 +201,8 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
             }
         }
         ProgramCacheEntryOwner::LoaderV3 => {
+            // V3 programs must have both a valid Program account as well as
+            // a valid ProgramData account.
             if let Ok(UpgradeableLoaderState::Program {
                 programdata_address,
             }) = bincode::deserialize(program.data())
@@ -224,6 +224,10 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
             Err(TransactionError::ProgramAccountNotFound)
         }
         ProgramCacheEntryOwner::LoaderV4 => {
+            // V4 programs must have valid state and must not be retracted!
+            // Loader V4 state does not have a leading discriminator, and
+            // `LoaderV4Status::Retracted` holds variant 0, so a gifting attack
+            // can happen if we don't disallow `Retracted`.
             let slot = loader_v4_get_state(program.data())
                 .ok()
                 .and_then(|state| {
@@ -232,12 +236,25 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
                 .ok_or(TransactionError::ProgramAccountNotFound)?;
             Ok(slot)
         }
-        ProgramCacheEntryOwner::NativeLoader => unreachable!(),
+        ProgramCacheEntryOwner::NativeLoader => {
+            // `filter_executable_program_accounts` won't pass native loader.
+            unreachable!("native loader programs are not sbpf")
+        }
     }
 }
 
-/// Returns the set of program accounts for a given batch of transactions.
-pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
+// Returns the set of programs to extract from the global program cache for a
+// given transaction's account keys.
+//
+// This list should only contain valid, active programs. Closed programs MUST
+// NOT be included in the search list.
+//
+// The global program cache searches for entries based on deployment slot, and
+// a closed program has no deployment slot. If a closed program ends up in the
+// search list, `replenish_program_cache` will miss during extraction, attempt
+// to reload, and insert a closed tombstone, BUT it will not remove the program
+// from the search list, resulting in reload loop.
+pub(crate) fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     keys: impl Iterator<Item = &'a Pubkey>,
@@ -247,6 +264,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
         } else if let Some(account) = callbacks.get_account_shared_data(account_key) {
+            // A valid program must be owned by one of the four BPF loaders.
             let loader = if loader_v4::check_id(account.owner()) {
                 ProgramCacheEntryOwner::LoaderV4
             } else if bpf_loader_upgradeable::check_id(account.owner()) {
@@ -258,6 +276,9 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             } else {
                 continue;
             };
+            // A valid program must also have a deployment slot stored.
+            // If the deployment slot cannot be determined, this program is
+            // likely *closed*; DON'T return it!
             let Ok(deployment_slot) = get_program_deployment_slot(callbacks, &account, loader)
             else {
                 continue;

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 #[cfg(feature = "metrics")]
 use solana_program_runtime::program_metrics::LoadProgramMetrics;
 use {
@@ -254,6 +256,7 @@ fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
 // search list, `replenish_program_cache` will miss during extraction, attempt
 // to reload, and insert a closed tombstone, BUT it will not remove the program
 // from the search list, resulting in reload loop.
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -13,13 +13,14 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments, ProgramToLoad},
-        program_cache_entry::{ProgramCacheEntryOwner, ProgramCacheEntryType},
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
+        program_cache_entry::ProgramCacheEntryType,
         program_metrics::ProgramStatistics,
     },
     solana_pubkey::Pubkey,
     solana_svm::{
         account_loader::{AccountLoader, CheckedTransactionDetails, TransactionCheckResult},
+        program_loader::filter_executable_program_accounts,
         transaction_processing_result::{
             ProcessedTransaction, TransactionProcessingResultExtensions,
         },
@@ -57,14 +58,6 @@ fn program_cache_execution(threads: usize) {
                 batch_processor.epoch,
             );
             thread::spawn(move || {
-                let missing_programs: Vec<ProgramToLoad> = programs
-                    .iter()
-                    .map(|program_id| ProgramToLoad {
-                        program_id,
-                        loader: ProgramCacheEntryOwner::LoaderV3,
-                        deployment_slot: 0,
-                    })
-                    .collect();
                 let feature_set = SVMFeatureSet::all_enabled();
                 let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
                     None,
@@ -73,6 +66,8 @@ fn program_cache_execution(threads: usize) {
                     0,
                 );
                 let mut result = ProgramCacheForTxBatch::new(processor.slot);
+                let missing_programs =
+                    filter_executable_program_accounts(&account_loader, &result, programs.iter());
                 let program_runtime_environment_for_execution =
                     processor.program_runtime_environment_for_epoch(processor.epoch);
                 processor.replenish_program_cache(

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -26,8 +26,7 @@ use {
         execution_budget::{
             MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, SVMTransactionExecutionAndFeeBudgetLimits,
         },
-        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments, ProgramToLoad},
-        program_cache_entry::ProgramCacheEntryOwner,
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments},
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
@@ -40,6 +39,7 @@ use {
             TransactionCheckResult,
         },
         nonce_info::NonceInfo,
+        program_loader::filter_executable_program_accounts,
         transaction_execution_result::TransactionExecutionDetails,
         transaction_processing_result::{
             ProcessedTransaction, TransactionProcessingResult,
@@ -354,7 +354,7 @@ impl SvmTestEnvironment<'_> {
         batch_output
     }
 
-    pub fn is_program_blocked(&self, program_id: &Pubkey, deployment_slot: Slot) -> bool {
+    pub fn is_program_blocked(&self, program_id: &Pubkey) -> bool {
         let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
             self.processing_config.account_overrides,
             &self.mock_bank,
@@ -362,14 +362,21 @@ impl SvmTestEnvironment<'_> {
             1,
         );
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(EXECUTION_SLOT);
+
+        let missing_programs = filter_executable_program_accounts(
+            &account_loader,
+            &program_cache_for_tx_batch,
+            std::iter::once(program_id),
+        );
+        if missing_programs.is_empty() {
+            // The program won't land in the search list if it's closed.
+            return true;
+        }
+
         let mut execute_timings = ExecuteTimings::default();
         self.batch_processor.replenish_program_cache(
             &account_loader,
-            vec![ProgramToLoad {
-                program_id,
-                loader: ProgramCacheEntryOwner::LoaderV3,
-                deployment_slot,
-            }],
+            missing_programs,
             self.processing_environment
                 .program_runtime_environments
                 .get_env_for_execution(),
@@ -383,7 +390,6 @@ impl SvmTestEnvironment<'_> {
         // in the same batch, a new valid loaderv3 program may have a Loaded entry with a later execution slot
         // in a later batch, the same loaderv3 program will have a DelayedVisibility tombstone
         // a new loaderv1/v2 account will have a FailedVerification tombstone
-        // and a closed loaderv3 program or any loaderv3 buffer will have a Closed tombstone
         program_cache_entry.effective_slot() > EXECUTION_SLOT || program_cache_entry.is_tombstone()
     }
 }
@@ -2955,7 +2961,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
 
     // test in same entry as program change
     env.execute();
-    assert!(env.is_program_blocked(&program_id, 5));
+    assert!(env.is_program_blocked(&program_id));
 
     let mut test_entry = SvmTestEntry {
         initial_accounts: env.test_entry.final_accounts.clone(),
@@ -2970,7 +2976,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
     // test in different entry same slot
     env.test_entry = test_entry;
     env.execute();
-    assert!(env.is_program_blocked(&program_id, 5));
+    assert!(env.is_program_blocked(&program_id));
 }
 
 #[test_case(false; "upgrade::scan_only")]
@@ -3087,7 +3093,7 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
 
     // test in same entry as program change
     env.execute();
-    assert!(env.is_program_blocked(&target, 5));
+    assert!(env.is_program_blocked(&target));
 
     let mut test_entry = SvmTestEntry {
         initial_accounts: env.test_entry.final_accounts.clone(),
@@ -3102,7 +3108,7 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
     // test in different entry same slot
     env.test_entry = test_entry;
     env.execute();
-    assert!(env.is_program_blocked(&target, 5));
+    assert!(env.is_program_blocked(&target));
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
If we regress inside of `filter_executable_program_accounts`, we could create a reload loop.

#### Summary of Changes
Document this scenario and make `filter_executable_program_accounts` crate-private.

#### Testing
I've already added tests for this in previous PRs.