### PR TITLE
UDP streamer/recvmmsg: improve error handling

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -1017,10 +1017,9 @@ impl BlockIdRepairService {
                     .iter()
                     .map(|(bytes, addr)| (bytes, addr)),
             )
-            .inspect_err(|SendPktsError::IoError(err, failed)| {
+            .inspect_err(|SendPktsError::IoError(err)| {
                 error!(
-                    "{}: failed to send block_id repair packets, packets failed {failed}/{total}: \
-                     {err:?}",
+                    "{}: failed to send a batch of {total} block_id repair packets: {err:?}",
                     repair_info.cluster_info.id(),
                 )
             });
@@ -1031,10 +1030,9 @@ impl BlockIdRepairService {
                 repair_socket,
                 shred_socket_batch.iter().map(|(bytes, addr)| (bytes, addr)),
             )
-            .inspect_err(|SendPktsError::IoError(err, failed)| {
+            .inspect_err(|SendPktsError::IoError(err)| {
                 error!(
-                    "{}: failed to send shred repair requests, packets failed {failed}/{total}: \
-                     {err:?}",
+                    "{}: failed to send a batch of {total} shred repair requests: {err:?}",
                     repair_info.cluster_info.id(),
                 )
             });

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -843,15 +843,11 @@ impl RepairService {
                 }
             } else {
                 let batch = batch.iter().map(|(bytes, addr)| (bytes, addr));
-                match batch_send(repair_socket, batch) {
-                    Ok(()) => (),
-                    Err(SendPktsError::IoError(err, num_failed)) => {
-                        error!(
-                            "{} batch_send failed to send {num_failed}/{num_pkts} packets first \
-                             error {err:?}",
-                            repair_info.cluster_info.id()
-                        );
-                    }
+                if let Err(SendPktsError::IoError(err)) = batch_send(repair_socket, batch) {
+                    error!(
+                        "{} batch_send failed to send a batch of {num_pkts} packets: {err:?}",
+                        repair_info.cluster_info.id()
+                    );
                 }
             }
         }
@@ -1196,10 +1192,10 @@ impl RepairService {
 
         // Send packet batch
         match batch_send(repair_socket, reqs) {
-            Ok(()) => {
+            Ok(_) => {
                 debug!("successfully sent repair request to {pubkey} / {address}!");
             }
-            Err(SendPktsError::IoError(err, _num_failed)) => {
+            Err(SendPktsError::IoError(err)) => {
                 error!("batch_send failed to send packet - error = {err:?}");
             }
         }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1953,14 +1953,8 @@ impl ServeRepair {
         if !pending_pongs.is_empty() {
             let num_pkts = pending_pongs.len();
             let pending_pongs = pending_pongs.iter().map(|(bytes, addr)| (bytes, addr));
-            match batch_send(repair_socket, pending_pongs) {
-                Ok(()) => (),
-                Err(SendPktsError::IoError(err, num_failed)) => {
-                    warn!(
-                        "batch_send failed to send {num_failed}/{num_pkts} packets. First error: \
-                         {err:?}"
-                    );
-                }
+            if let Err(SendPktsError::IoError(err)) = batch_send(repair_socket, pending_pongs) {
+                warn!("batch_send failed to send a batch of {num_pkts} pongs: {err:?}");
             }
         }
     }

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -98,6 +98,6 @@ struct ServeRepairSocketProvider {
 impl ResponseSender for ServeRepairSocketProvider {
     fn send_batch(&self, batch: PacketBatch) -> std::result::Result<(), SendPktsError> {
         let packets = filter_packets_by_socket_addr_space(batch.iter(), &self.socket_addr_space);
-        batch_send(self.socket.as_ref(), packets.collect::<Vec<_>>())
+        batch_send(self.socket.as_ref(), packets.collect::<Vec<_>>()).map(|_num_sent| ())
     }
 }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -408,7 +408,7 @@ impl ResponseSender for GossipUdpSocketProvider {
     fn send_batch(&self, batch: PacketBatch) -> std::result::Result<(), SendPktsError> {
         let packets = filter_packets_by_socket_addr_space(batch.iter(), &self.socket_addr_space);
         let sock = self.socket_provider.current_socket_ref();
-        batch_send(sock, packets.collect::<Vec<_>>())
+        batch_send(sock, packets.collect::<Vec<_>>()).map(|_num_sent| ())
     }
 }
 
@@ -457,18 +457,14 @@ impl ResponseSender for GossipXdpSender {
             } else {
                 io::ErrorKind::WouldBlock
             };
-            return Err(SendPktsError::IoError(
-                io::Error::new(
-                    kind,
-                    format!(
-                        "XDP sender failed to enqueue {num_failed} out of {num_total} gossip \
-                         packets ({num_dropped_full} full queue, {num_dropped_disconnected} \
-                         disconnected)",
-                        num_total = num_sent + num_failed
-                    ),
+            return Err(SendPktsError::IoError(io::Error::new(
+                kind,
+                format!(
+                    "XDP sender failed to enqueue {num_failed} out of {num_total} gossip packets \
+                     ({num_dropped_full} full queue, {num_dropped_disconnected} disconnected)",
+                    num_total = num_sent + num_failed
                 ),
-                num_failed,
-            ));
+            )));
         }
         Ok(())
     }

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -139,16 +139,12 @@ fn retransmit_to(
             .filter(|addr| socket_addr_space.check(addr))
             .collect()
     };
-    match multi_target_send(socket, data, &dests) {
-        Ok(()) => (),
-        Err(SendPktsError::IoError(ioerr, num_failed)) => {
-            error!(
-                "retransmit_to multi_target_send error: {:?}, {}/{} packets failed",
-                ioerr,
-                num_failed,
-                dests.len(),
-            );
-        }
+    if let Err(SendPktsError::IoError(ioerr)) = multi_target_send(socket, data, &dests) {
+        error!(
+            "retransmit_to multi_target_send error: {:?}, {} destinations",
+            ioerr,
+            dests.len(),
+        );
     }
 }
 

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -23,9 +23,9 @@ use {
 
 #[derive(Debug, Error)]
 pub enum SendPktsError {
-    /// IO Error during send: first error, num failed packets
-    #[error("IO Error, some packets could not be sent")]
-    IoError(io::Error, usize),
+    /// Fatal IO error during send, the socket can not be used any more.
+    #[error("fatal IO error, the send path is broken")]
+    IoError(io::Error),
 }
 
 impl From<SendPktsError> for TransportError {
@@ -34,32 +34,57 @@ impl From<SendPktsError> for TransportError {
     }
 }
 
+/// Decide whether a failed send should abort the whole batch.
+///
+/// Only errors that make the socket itself unusable are fatal. Everything else is a
+/// problem with one destination or transient backpressure. Those are expected in
+/// normal operation and only cost us this one packet. On non-unix platforms we can not
+/// tell the two apart, so we swallow everything.
+fn check_fatal(err: io::Error) -> Result<(), SendPktsError> {
+    #[cfg(unix)]
+    match err.raw_os_error() {
+        Some(libc::EMSGSIZE) => {
+            debug_assert!(
+                false,
+                "packet exceeds the maximum UDP datagram size: {err:?}"
+            );
+        }
+        Some(
+            libc::EBADF
+            | libc::ENOTSOCK
+            | libc::EFAULT
+            | libc::EPIPE
+            | libc::EOPNOTSUPP
+            | libc::EDESTADDRREQ,
+        ) => {
+            return Err(SendPktsError::IoError(err));
+        }
+        _ => (),
+    }
+    #[cfg(not(unix))]
+    let _ = err;
+    Ok(())
+}
+
+/// See the linux implementation of [`batch_send`].
 // The type and lifetime constraints are overspecified to match 'linux' code.
 #[cfg(not(target_os = "linux"))]
 pub fn batch_send<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,
-) -> Result<(), SendPktsError>
+) -> Result</*num_sent:*/ usize, SendPktsError>
 where
     S: Borrow<SocketAddr>,
     &'a T: AsRef<[u8]>,
 {
-    let mut num_failed = 0;
-    let mut erropt = None;
+    let mut num_sent = 0;
     for (p, a) in packets {
-        if let Err(e) = sock.send_to(p.as_ref(), a.borrow()) {
-            num_failed += 1;
-            if erropt.is_none() {
-                erropt = Some(e);
-            }
+        match sock.send_to(p.as_ref(), a.borrow()) {
+            Ok(_) => num_sent += 1,
+            Err(err) => check_fatal(err)?,
         }
     }
-
-    if let Some(err) = erropt {
-        Err(SendPktsError::IoError(err, num_failed))
-    } else {
-        Ok(())
-    }
+    Ok(num_sent)
 }
 
 #[cfg(target_os = "linux")]
@@ -125,36 +150,32 @@ fn mmsghdr_for_packet(
 }
 
 #[cfg(target_os = "linux")]
-fn sendmmsg_retry(sock: &UdpSocket, hdrs: &mut [mmsghdr]) -> Result<(), SendPktsError> {
+fn sendmmsg_retry(
+    sock: &UdpSocket,
+    hdrs: &mut [mmsghdr],
+) -> Result</*num_sent:*/ usize, SendPktsError> {
     let sock_fd = sock.as_raw_fd();
-    let mut total_sent = 0;
-    let mut erropt = None;
+    let mut num_sent = 0;
 
     let mut pkts = &mut *hdrs;
     while !pkts.is_empty() {
         let npkts = match unsafe { libc::sendmmsg(sock_fd, &mut pkts[0], pkts.len() as u32, 0) } {
             -1 => {
-                if erropt.is_none() {
-                    erropt = Some(io::Error::last_os_error());
-                }
+                check_fatal(io::Error::last_os_error())?;
                 // skip over the failing packet
                 1_usize
             }
             n => {
                 // if we fail to send all packets we advance to the failing
                 // packet and retry in order to capture the error code
-                total_sent += n as usize;
+                num_sent += n as usize;
                 n as usize
             }
         };
         pkts = &mut pkts[npkts..];
     }
 
-    if let Some(err) = erropt {
-        Err(SendPktsError::IoError(err, hdrs.len() - total_sent))
-    } else {
-        Ok(())
-    }
+    Ok(num_sent)
 }
 
 #[cfg(target_os = "linux")]
@@ -164,7 +185,7 @@ const MAX_IOV: usize = libc::UIO_MAXIOV as usize;
 fn batch_send_max_iov<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,
-) -> Result<(), SendPktsError>
+) -> Result</*num_sent:*/ usize, SendPktsError>
 where
     S: Borrow<SocketAddr>,
     &'a T: AsRef<[u8]>,
@@ -202,33 +223,44 @@ where
     result
 }
 
+/// Send every `(packet, destination)` pair over `sock`.
+///
+/// Returns the number of packets that were sent successfully. Failures for individual
+/// destinations are expected and are not reported. An Err is returned only when the
+/// send failed for a reason that makes the socket permanently unusable.
 // Need &'a to ensure that raw packet pointers obtained in mmsghdr_for_packet
 // stay valid.
 #[cfg(target_os = "linux")]
 pub fn batch_send<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,
-) -> Result<(), SendPktsError>
+) -> Result</*num_sent:*/ usize, SendPktsError>
 where
     S: Borrow<SocketAddr>,
     &'a T: AsRef<[u8]>,
 {
     let mut packets = packets.into_iter();
+    let mut num_sent = 0;
     loop {
         let chunk = packets.by_ref().take(MAX_IOV);
         if chunk.len() == 0 {
             break;
         }
-        batch_send_max_iov(sock, chunk)?;
+        // On error the socket is dead, do not bother with the remaining chunks.
+        num_sent += batch_send_max_iov(sock, chunk)?;
     }
-    Ok(())
+    Ok(num_sent)
 }
 
+/// Send the same `packet` to every destination in `dests`.
+///
+/// Shares the semantics of [`batch_send`]: unreachable destinations only lower
+/// the returned count, an error means the socket is permanently unusable.
 pub fn multi_target_send<S, T>(
     sock: &UdpSocket,
     packet: T,
     dests: &[S],
-) -> Result<(), SendPktsError>
+) -> Result</*num_sent:*/ usize, SendPktsError>
 where
     S: Borrow<SocketAddr>,
     T: AsRef<[u8]>,
@@ -249,10 +281,7 @@ mod tests {
         assert_matches::assert_matches,
         solana_net_utils::sockets::bind_to_localhost_unique,
         solana_packet::PACKET_DATA_SIZE,
-        std::{
-            io::ErrorKind,
-            net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-        },
+        std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     };
 
     #[test]
@@ -264,8 +293,8 @@ mod tests {
         let packets: Vec<_> = (0..32).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
         let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &addr)).collect();
 
-        let sent = batch_send(&sender, packet_refs).ok();
-        assert_eq!(sent, Some(()));
+        let num_sent = batch_send(&sender, packet_refs).expect("socket should be usable");
+        assert_eq!(num_sent, 32);
 
         let mut packets = BytesPacketBatch::with_capacity(32);
         let recv = recv_mmsg(&reader, &mut packets, &mut PacketBufferPool::new()).unwrap();
@@ -295,8 +324,8 @@ mod tests {
             })
             .collect();
 
-        let sent = batch_send(&sender, packet_refs).ok();
-        assert_eq!(sent, Some(()));
+        let num_sent = batch_send(&sender, packet_refs).expect("socket should be usable");
+        assert_eq!(num_sent, 32);
 
         let mut packets = BytesPacketBatch::with_capacity(32);
         let recv = recv_mmsg(&reader, &mut packets, &mut PacketBufferPool::new()).unwrap();
@@ -325,13 +354,13 @@ mod tests {
 
         let packet = Packet::default();
 
-        let sent = multi_target_send(
+        let num_sent = multi_target_send(
             &sender,
             packet.data(..).unwrap(),
             &[&addr, &addr2, &addr3, &addr4],
         )
-        .ok();
-        assert_eq!(sent, Some(()));
+        .expect("socket should be usable");
+        assert_eq!(num_sent, 4);
 
         let mut packets = BytesPacketBatch::with_capacity(32);
         let recv = recv_mmsg(&reader, &mut packets, &mut PacketBufferPool::new()).unwrap();
@@ -363,10 +392,16 @@ mod tests {
         let dest_refs: Vec<_> = vec![&ip4, &ip6, &ip4];
 
         let sender = bind_to_localhost_unique().expect("should bind - sender");
-        let res = batch_send(&sender, packet_refs);
-        assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
-        let res = multi_target_send(&sender, &packets[0], &dest_refs);
-        assert_matches!(res, Err(SendPktsError::IoError(_, /*num_failed*/ 1)));
+        assert_matches!(
+            batch_send(&sender, packet_refs),
+            Ok(/*num_sent:*/ 2),
+            "a destination with a mismatched IP version must be skipped, not fatal"
+        );
+        assert_matches!(
+            multi_target_send(&sender, &packets[0], &dest_refs),
+            Ok(/*num_sent:*/ 2),
+            "a destination with a mismatched IP version must be skipped, not fatal"
+        );
     }
 
     #[test]
@@ -384,13 +419,11 @@ mod tests {
             (&packets[3][..], &ipv4broadcast),
             (&packets[4][..], &ipv4local),
         ];
-        match batch_send(&sender, packet_refs) {
-            Ok(()) => panic!(),
-            Err(SendPktsError::IoError(ioerror, num_failed)) => {
-                assert_matches!(ioerror.kind(), ErrorKind::PermissionDenied);
-                assert_eq!(num_failed, 2);
-            }
-        }
+        assert_matches!(
+            batch_send(&sender, packet_refs),
+            Ok(/*num_sent:*/ 3),
+            "unreachable destinations in the middle of a batch must be skipped, not fatal"
+        );
 
         // test leading and trailing failures for batch_send
         let packet_refs: Vec<_> = vec![
@@ -400,13 +433,11 @@ mod tests {
             (&packets[3][..], &ipv4local),
             (&packets[4][..], &ipv4broadcast),
         ];
-        match batch_send(&sender, packet_refs) {
-            Ok(()) => panic!(),
-            Err(SendPktsError::IoError(ioerror, num_failed)) => {
-                assert_matches!(ioerror.kind(), ErrorKind::PermissionDenied);
-                assert_eq!(num_failed, 3);
-            }
-        }
+        assert_matches!(
+            batch_send(&sender, packet_refs),
+            Ok(/*num_sent:*/ 2),
+            "unreachable destinations at the edges of a batch must be skipped, not fatal"
+        );
 
         // test consecutive intermediate failures for batch_send
         let packet_refs: Vec<_> = vec![
@@ -416,13 +447,11 @@ mod tests {
             (&packets[3][..], &ipv4broadcast),
             (&packets[4][..], &ipv4local),
         ];
-        match batch_send(&sender, packet_refs) {
-            Ok(()) => panic!(),
-            Err(SendPktsError::IoError(ioerror, num_failed)) => {
-                assert_matches!(ioerror.kind(), ErrorKind::PermissionDenied);
-                assert_eq!(num_failed, 2);
-            }
-        }
+        assert_matches!(
+            batch_send(&sender, packet_refs),
+            Ok(/*num_sent:*/ 3),
+            "consecutive unreachable destinations must be skipped, not fatal"
+        );
 
         // test intermediate failures for multi_target_send
         let dest_refs: Vec<_> = vec![
@@ -432,13 +461,11 @@ mod tests {
             &ipv4broadcast,
             &ipv4local,
         ];
-        match multi_target_send(&sender, &packets[0], &dest_refs) {
-            Ok(()) => panic!(),
-            Err(SendPktsError::IoError(ioerror, num_failed)) => {
-                assert_matches!(ioerror.kind(), ErrorKind::PermissionDenied);
-                assert_eq!(num_failed, 2);
-            }
-        }
+        assert_matches!(
+            multi_target_send(&sender, &packets[0], &dest_refs),
+            Ok(/*num_sent:*/ 3),
+            "unreachable destinations in the middle of a batch must be skipped, not fatal"
+        );
 
         // test leading and trailing failures for multi_target_send
         let dest_refs: Vec<_> = vec![
@@ -448,11 +475,57 @@ mod tests {
             &ipv4local,
             &ipv4broadcast,
         ];
-        match multi_target_send(&sender, &packets[0], &dest_refs) {
-            Ok(()) => panic!(),
-            Err(SendPktsError::IoError(ioerror, num_failed)) => {
-                assert_matches!(ioerror.kind(), ErrorKind::PermissionDenied);
-                assert_eq!(num_failed, 3);
+        assert_matches!(
+            multi_target_send(&sender, &packets[0], &dest_refs),
+            Ok(/*num_sent:*/ 2),
+            "unreachable destinations at the edges of a batch must be skipped, not fatal"
+        );
+    }
+
+    #[test]
+    fn test_all_destinations_unreachable() {
+        let packets: Vec<_> = (0..3).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let ipv4broadcast = SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), 8080);
+        let sender = bind_to_localhost_unique().expect("should bind - sender");
+
+        let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &ipv4broadcast)).collect();
+        assert_matches!(
+            batch_send(&sender, packet_refs),
+            Ok(/*num_sent:*/ 0),
+            "a usable socket must not report an error even if no destination is reachable"
+        );
+
+        let dest_refs: Vec<_> = vec![&ipv4broadcast, &ipv4broadcast, &ipv4broadcast];
+        assert_matches!(
+            multi_target_send(&sender, &packets[0], &dest_refs),
+            Ok(/*num_sent:*/ 0),
+            "a usable socket must not report an error even if no destination is reachable"
+        );
+    }
+
+    /// A socket that is not actually a socket makes every send fail with
+    /// `ENOTSOCK`, which is permanent and must surface as an error.
+    #[test]
+    #[cfg(unix)]
+    fn test_fatal_error_not_a_socket() {
+        use std::{
+            fs::File,
+            os::fd::{FromRawFd, IntoRawFd},
+        };
+
+        let devnull = File::open("/dev/null").expect("should open /dev/null");
+        // SAFETY: `into_raw_fd` transfers ownership of a valid, open fd, so the
+        // resulting `UdpSocket` is the sole owner and closes it exactly once.
+        let not_a_socket = unsafe { UdpSocket::from_raw_fd(devnull.into_raw_fd()) };
+
+        let packets: Vec<_> = (0..3).map(|_| vec![0u8; PACKET_DATA_SIZE]).collect();
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let packet_refs: Vec<_> = packets.iter().map(|p| (&p[..], &addr)).collect();
+
+        match batch_send(&not_a_socket, packet_refs) {
+            Ok(num_sent) => panic!("a send on a non-socket fd must fail, sent {num_sent}"),
+            Err(SendPktsError::IoError(ioerror)) => {
+                assert_eq!(ioerror.raw_os_error(), Some(libc::ENOTSOCK));
             }
         }
     }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -443,9 +443,8 @@ pub fn filter_packets_by_socket_addr_space<'a>(
 pub trait ResponseSender {
     /// Send a batch of packets.
     ///
-    /// Returns Ok if all the packets with valid destination within batch were sent successfully,
-    /// and returns an error if any packet within the batch failed to send with number of failed
-    /// packets.
+    /// Returns Ok if the batch was handed to a usable socket, and an error if the send path is
+    /// broken. Packets with an invalid or unreachable destination are dropped silently.
     fn send_batch(&self, batch: PacketBatch) -> std::result::Result<(), SendPktsError>;
 }
 
@@ -557,7 +556,7 @@ mod test {
         fn send_batch(&self, batch: PacketBatch) -> std::result::Result<(), SendPktsError> {
             let packets =
                 filter_packets_by_socket_addr_space(batch.iter(), &self.socket_addr_space);
-            batch_send(self.socket.as_ref(), packets.collect::<Vec<_>>())
+            batch_send(self.socket.as_ref(), packets.collect::<Vec<_>>()).map(|_num_sent| ())
         }
     }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -608,14 +608,12 @@ pub fn broadcast_shreds(
     match socket {
         BroadcastSocket::Udp(s) => {
             let packets: Vec<_> = packets.collect();
-            num_packets += packets.len();
+            let batch_len = packets.len();
+            num_packets += batch_len;
             let mut send_mmsg_time = Measure::start("send_mmsg");
             match batch_send(s, packets) {
-                Ok(()) => (),
-                Err(SendPktsError::IoError(ioerr, num_failed)) => {
-                    transmit_stats.dropped_packets_udp += num_failed;
-                    result = Err(Error::Io(ioerr));
-                }
+                Ok(num_sent) => transmit_stats.dropped_packets_udp += batch_len - num_sent,
+                Err(SendPktsError::IoError(ioerr)) => result = Err(Error::Io(ioerr)),
             }
             send_mmsg_time.stop();
             transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -450,7 +450,9 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 panic!("Xdp not supported for duplicate shreds run");
             }
         };
-        batch_send(sock, packets).map_err(|SendPktsError::IoError(err, _)| Error::Io(err))
+        batch_send(sock, packets)
+            .map(|_num_sent| ())
+            .map_err(|SendPktsError::IoError(err)| Error::Io(err))
     }
 
     fn record<'db>(

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -537,13 +537,13 @@ fn retransmit_shred(
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
             match multi_target_send(socket, shred, addrs.as_ref()) {
-                Ok(()) => num_addrs,
-                Err(SendPktsError::IoError(ioerr, num_failed)) => {
+                Ok(num_sent) => num_sent,
+                Err(SendPktsError::IoError(ioerr)) => {
                     error!(
-                        "retransmit_to multi_target_send error: {ioerr:?}, \
-                         {num_failed}/{num_addrs} packets failed"
+                        "retransmit_to multi_target_send error: {ioerr:?}, {num_addrs} \
+                         destinations"
                     );
-                    num_addrs - num_failed
+                    0
                 }
             }
         }

--- a/udp-client/src/udp_client.rs
+++ b/udp-client/src/udp_client.rs
@@ -38,13 +38,15 @@ impl ClientConnection for UdpClientConnection {
     fn send_data_batch(&self, buffers: &[Vec<u8>]) -> TransportResult<()> {
         let addr = self.server_addr();
         let pkts = buffers.iter().map(|bytes| (bytes, addr));
-        Ok(batch_send(&self.socket, pkts)?)
+        batch_send(&self.socket, pkts)?;
+        Ok(())
     }
 
     fn send_data_batch_async(&self, buffers: Vec<Vec<u8>>) -> TransportResult<()> {
         let addr = self.server_addr();
         let pkts = buffers.iter().map(|bytes| (bytes, addr));
-        Ok(batch_send(&self.socket, pkts)?)
+        batch_send(&self.socket, pkts)?;
+        Ok(())
     }
 
     fn send_data(&self, buffer: &[u8]) -> TransportResult<()> {


### PR DESCRIPTION
#### Problem

UDP streamer read loop has accumulated a bunch of debt around error handling. 

This is a followup for https://github.com/anza-xyz/agave/pull/14710

#### Summary of Changes

- Report fatal socket errors upstream
- Report non-fatal errors as "packets failed to send" rather than screaming about entire batch.

#### Testing

CI, mds1

