### PR TITLE
introduces `BlockId` gently

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -552,7 +552,7 @@ mod tests {
         },
         agave_votor_messages::{
             certificate::{Certificate, CertificateType},
-            consensus_message::{Block, ConsensusMessage, VoteMessage},
+            consensus_message::{Block, BlockId, ConsensusMessage, VoteMessage},
             metric_types::ConsensusMetricsEventReceiver,
             sig_verified_messages::VoteAggregate,
             vote::Vote,
@@ -567,7 +567,6 @@ mod tests {
         },
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
-        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_net_utils::SocketAddrSpace,
         solana_pubkey::Pubkey,
@@ -2138,7 +2137,7 @@ mod tests {
             highest_parent_ready_slot,
             Block {
                 slot: highest_parent_ready_slot,
-                block_id: Hash::new_unique(),
+                block_id: BlockId::new_unique(),
             },
         );
         let max_vote_slot = highest_parent_ready_slot + MAX_VOTE_SLOT_DISTANCE_FROM_PARENT_READY;
@@ -2148,7 +2147,7 @@ mod tests {
 
         let genesis_block = Block {
             slot: genesis_slot,
-            block_id: Hash::new_unique(),
+            block_id: BlockId::new_unique(),
         };
         ctx.verifier
             .migration_status
@@ -2193,7 +2192,7 @@ mod tests {
             ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_genesis_vote(Block {
                 slot: genesis_slot,
-                block_id: Hash::new_unique(),
+                block_id: BlockId::new_unique(),
             }),
             different_hash_genesis_vote_rank,
         ));

--- a/bls-sigverify/src/vote_pool.rs
+++ b/bls-sigverify/src/vote_pool.rs
@@ -1,12 +1,11 @@
 use {
     agave_votor_messages::{
-        reward_certificate::NUM_SLOTS_FOR_REWARD, unverified_vote_message::UnverifiedVoteMessage,
-        vote::Vote,
+        consensus_message::BlockId, reward_certificate::NUM_SLOTS_FOR_REWARD,
+        unverified_vote_message::UnverifiedVoteMessage, vote::Vote,
     },
     bitvec::vec::BitVec,
     smallvec::SmallVec,
     solana_clock::Slot,
-    solana_hash::Hash,
     std::collections::HashMap,
 };
 
@@ -25,9 +24,9 @@ struct SlotEntry {
     skip: BitVec<u8>,
     skip_fallback: BitVec<u8>,
     finalize: BitVec<u8>,
-    genesis: Vec<Option<Hash>>,
-    notar: Vec<Option<Hash>>,
-    notar_fallback: Vec<SmallVec<[Hash; MAX_NOTAR_FALLBACK_ENTRIES]>>,
+    genesis: Vec<Option<BlockId>>,
+    notar: Vec<Option<BlockId>>,
+    notar_fallback: Vec<SmallVec<[BlockId; MAX_NOTAR_FALLBACK_ENTRIES]>>,
 }
 
 impl SlotEntry {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1108,7 +1108,7 @@ pub async fn process_get_ag_genesis_info(
             CliAgGenesisInfo::Ag(CliAgGenesisInfoPayload {
                 epoch,
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 bitvec,
                 signature: signature.signature,
             })

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -603,7 +603,7 @@ fn produce_window(
         slot_metrics,
         start_slot,
         parent_block.slot,
-        Some(parent_block.block_id),
+        Some(parent_block.block_id.into_hash()),
         block_timer,
     )?;
 
@@ -944,7 +944,7 @@ fn send_update_parent(
 ) -> Result<(), PohRecorderError> {
     let update_parent = UpdateParentV1 {
         new_parent_slot: new_parent_block.slot,
-        new_parent_block_id: new_parent_block.block_id,
+        new_parent_block_id: new_parent_block.block_id.into_hash(),
     };
     let marker = VersionedBlockMarker::from_update_parent(update_parent);
     poh_recorder.write().unwrap().send_marker(marker)?;
@@ -1025,7 +1025,7 @@ fn handle_parent_ready(
             slot,
             cleared_bank_id,
             parent_slot: new_parent_slot,
-            parent_block_id: new_parent_hash,
+            parent_block_id: new_parent_hash.into_hash(),
         }))
     {
         warn!("UpdateParent entry notification send failed: {err:?}");
@@ -1037,7 +1037,7 @@ fn handle_parent_ready(
         slot_metrics,
         slot,
         new_parent_slot,
-        Some(new_parent_hash),
+        Some(new_parent_hash.into_hash()),
         *block_timer,
         entry_bytes_consumed,
     )
@@ -1452,6 +1452,7 @@ mod tests {
         super::*,
         crate::banking_trace::BankingTracer,
         agave_banking_stage_ingress_types::BankingPacketReceiver,
+        agave_votor_messages::consensus_message::BlockId,
         crossbeam_channel::bounded,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
@@ -1975,7 +1976,7 @@ mod tests {
                 4,
                 Block {
                     slot: new_parent_slot,
-                    block_id: new_parent_hash,
+                    block_id: BlockId::from(new_parent_hash),
                 },
             ))),
             highest_finalized: Arc::new(RwLock::new(None)),
@@ -2028,7 +2029,7 @@ mod tests {
             end_slot: 7,
             parent_block: Block {
                 slot: new_parent_slot,
-                block_id: new_parent_hash,
+                block_id: BlockId::from(new_parent_hash),
             },
             block_timer: parent_ready_started_at,
         };
@@ -2038,7 +2039,7 @@ mod tests {
             parent_ready,
             Block {
                 slot: optimistic_parent_slot,
-                block_id: optimistic_parent_hash,
+                block_id: BlockId::from(optimistic_parent_hash),
             },
             vec![accumulated_tx.clone()],
             &mut Instant::now(),

--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -119,7 +119,7 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::{
-            consensus_message::Block,
+            consensus_message::{Block, BlockId},
             vote::Vote,
             wire::{VotePayloadToSign, get_vote_payload_to_sign},
         },
@@ -128,7 +128,6 @@ mod tests {
             Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed, SignatureProjective,
         },
         solana_epoch_schedule::EpochSchedule,
-        solana_hash::Hash,
         solana_pubkey::Pubkey,
         solana_runtime::{
             bank::{Bank, SlotLeader},
@@ -277,8 +276,8 @@ mod tests {
         assert_eq!(resp.skip, None);
         assert_eq!(resp.notar, None);
 
-        let blockid0 = Hash::new_unique();
-        let blockid1 = Hash::new_unique();
+        let blockid0 = BlockId::new_unique();
+        let blockid1 = BlockId::new_unique();
 
         for rank in 0..2 {
             let notar = Vote::new_notarization_vote(Block {
@@ -306,7 +305,7 @@ mod tests {
         assert_eq!(resp.skip, None);
         let notar = resp.notar.unwrap();
         assert_eq!(notar.slot, slot);
-        assert_eq!(notar.block_id, blockid1);
+        assert_eq!(notar.block_id, blockid1.into_hash());
         validate_bitmap(notar.bitmap(), 3, 5);
     }
 
@@ -329,7 +328,7 @@ mod tests {
         );
         entry.add_aggregate(aggregate, skip_validators).unwrap();
 
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let notar = Vote::new_notarization_vote(Block { slot, block_id });
         let (aggregate, notar_validators) =
             new_reward_vote_aggregate(notar, 2, &keypairs, None, shred_version);
@@ -339,7 +338,7 @@ mod tests {
 
         let resp = entry.build_certs(slot).unwrap();
         assert!(resp.skip.is_none());
-        assert_eq!(resp.notar.unwrap().block_id, block_id);
+        assert_eq!(resp.notar.unwrap().block_id, block_id.into_hash());
         assert_eq!(resp.validators, notar_validators);
     }
 
@@ -353,7 +352,7 @@ mod tests {
             .collect::<Vec<_>>();
         let mut entry = Entry::new(max_validators);
 
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let notar = Vote::new_notarization_vote(Block { slot, block_id });
         let (aggregate, notar_validators) = new_identity_reward_vote_aggregate(
             notar,

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -6,12 +6,11 @@ use {
     },
     agave_votor::aggregate_accumulator::AggregateAccumulatorError,
     agave_votor_messages::{
-        consensus_message::VoteMessage,
+        consensus_message::{BlockId, VoteMessage},
         reward_certificate::{BuildRewardCertsRespError, NotarRewardCertificate},
         sig_verified_messages::VoteAggregate,
     },
     solana_clock::Slot,
-    solana_hash::Hash,
     solana_pubkey::Pubkey,
     std::{cmp::Reverse, collections::HashMap},
 };
@@ -21,7 +20,7 @@ use {
 pub(super) struct NotarEntry {
     /// Different validators may vote for different block ids.
     /// This stores a [`PartialCert`] per block id observed.
-    partials: HashMap<Hash, PartialCert>,
+    partials: HashMap<BlockId, PartialCert>,
 }
 
 impl NotarEntry {
@@ -38,7 +37,7 @@ impl NotarEntry {
         &mut self,
         aggregate: VoteAggregate,
         vote_account_pubkeys: Vec<Pubkey>,
-        block_id: Hash,
+        block_id: BlockId,
         max_validators: usize,
     ) -> Result<(), AggregateAccumulatorError> {
         let partial = self
@@ -53,7 +52,7 @@ impl NotarEntry {
         &mut self,
         vote_msg: VoteMessage,
         vote_account_pubkey: Pubkey,
-        block_id: Hash,
+        block_id: BlockId,
         max_validators: usize,
     ) -> Result<(), AggregateAccumulatorError> {
         let partial = self
@@ -85,7 +84,12 @@ impl NotarEntry {
                     validators,
                 } => (signature, bitmap, validators),
             };
-            let cert = NotarRewardCertificate::try_new(reward_slot, block_id, signature, bitmap)?;
+            let cert = NotarRewardCertificate::try_new(
+                reward_slot,
+                block_id.into_hash(),
+                signature,
+                bitmap,
+            )?;
             return Ok(Some((cert, validators)));
         }
         Ok(None)
@@ -102,7 +106,6 @@ mod tests {
         },
         agave_votor_messages::{consensus_message::Block, vote::Vote},
         rand::Rng,
-        solana_hash::Hash,
     };
 
     #[test]
@@ -114,7 +117,7 @@ mod tests {
         let rank = 0;
         let mut entry = NotarEntry::new();
 
-        let blockid0 = Hash::new_unique();
+        let blockid0 = BlockId::new_unique();
         let block = Block {
             slot,
             block_id: blockid0,
@@ -139,8 +142,8 @@ mod tests {
         let mut entry = NotarEntry::new();
         assert_eq!(entry.clone().build_cert(slot).unwrap(), None);
 
-        let blockid0 = Hash::new_unique();
-        let blockid1 = Hash::new_unique();
+        let blockid0 = BlockId::new_unique();
+        let blockid1 = BlockId::new_unique();
 
         for rank in 0..2 {
             let notar = Vote::new_notarization_vote(Block {
@@ -167,7 +170,7 @@ mod tests {
         let (notar_cert, _) = entry.build_cert(slot).unwrap().unwrap();
         assert_eq!(notar_cert.slot, slot);
         // We should pick the block id with the most stake (not the most votes)
-        assert_eq!(notar_cert.block_id, blockid0);
+        assert_eq!(notar_cert.block_id, blockid0.into_hash());
         validate_bitmap(notar_cert.bitmap(), 2, 5);
     }
 
@@ -179,7 +182,7 @@ mod tests {
         let keypairs = get_keypairs(max_validators, slot);
         let mut entry = NotarEntry::new();
 
-        let blockid0 = Hash::new_unique();
+        let blockid0 = BlockId::new_unique();
         let notar = Vote::new_notarization_vote(Block {
             slot,
             block_id: blockid0,
@@ -194,7 +197,7 @@ mod tests {
             .add_aggregate(aggregate, vote_account_pubkeys, blockid0, max_validators)
             .unwrap();
 
-        let blockid1 = Hash::new_unique();
+        let blockid1 = BlockId::new_unique();
         let notar = Vote::new_notarization_vote(Block {
             slot,
             block_id: blockid1,
@@ -209,7 +212,7 @@ mod tests {
             .add_aggregate(aggregate, vote_account_pubkeys, blockid1, max_validators)
             .unwrap();
 
-        let blockid2 = Hash::new_unique();
+        let blockid2 = BlockId::new_unique();
         let notar = Vote::new_notarization_vote(Block {
             slot,
             block_id: blockid2,
@@ -222,7 +225,7 @@ mod tests {
             .unwrap();
 
         let (notar_cert, validators) = entry.build_cert(slot).unwrap().unwrap();
-        assert_eq!(notar_cert.block_id, blockid2);
+        assert_eq!(notar_cert.block_id, blockid2.into_hash());
         assert_eq!(validators, expected_validators);
         validate_bitmap(notar_cert.bitmap(), 1, max_validators);
     }

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -27,7 +27,7 @@ use {
         common::DELTA,
         event::{RepairEvent, RepairEventReceiver},
     },
-    agave_votor_messages::consensus_message::Block,
+    agave_votor_messages::consensus_message::{Block, BlockId},
     crossbeam_channel::select,
     lazy_lru::LruCache,
     log::{debug, info},
@@ -612,7 +612,7 @@ impl BlockIdRepairService {
                 state.push_pending_repair_event(RepairEvent::FetchBlock {
                     block: Block {
                         slot: p_slot,
-                        block_id: p_block_id,
+                        block_id: BlockId::from(p_block_id),
                     },
                 });
 
@@ -623,7 +623,7 @@ impl BlockIdRepairService {
                         let fec_set_index = i * DATA_SHREDS_PER_FEC_BLOCK as u32;
                         OutgoingMessage::Metadata(BlockIdRepairType::FecSetRoot {
                             slot,
-                            block_id,
+                            block_id: block_id.into_hash(),
                             fec_set_index,
                             fec_set_count,
                         })
@@ -656,7 +656,7 @@ impl BlockIdRepairService {
                             slot,
                             index,
                             fec_set_merkle_root,
-                            block_id,
+                            block_id: block_id.into_hash(),
                         })
                     }));
 
@@ -737,7 +737,7 @@ impl BlockIdRepairService {
 
                 // Check if we already have the full block, if so queue fetching the parent.
                 if let Some((slot_meta, _location)) =
-                    blockstore.get_slot_meta_for_block_id(block.slot, block.block_id)?
+                    blockstore.get_slot_meta_for_block_id(block.slot, block.block_id.into_hash())?
                 {
                     return Ok(PendingRepairDecision::Act(RepairAction::QueueParent {
                         slot_meta,
@@ -769,7 +769,7 @@ impl BlockIdRepairService {
                         );
                         Ok(PendingRepairDecision::KeepPending)
                     }
-                    Some(turbine_block_id) if turbine_block_id != block.block_id => {
+                    Some(turbine_block_id) if turbine_block_id != block.block_id.into_hash() => {
                         // Turbine has a different block
                         warn!(
                             "{my_pubkey}: FetchBlock: Turbine has different block \
@@ -787,8 +787,8 @@ impl BlockIdRepairService {
                              fetching parent",
                             block.slot
                         );
-                        if let Some((slot_meta, _location)) =
-                            blockstore.get_slot_meta_for_block_id(block.slot, block.block_id)?
+                        if let Some((slot_meta, _location)) = blockstore
+                            .get_slot_meta_for_block_id(block.slot, block.block_id.into_hash())?
                         {
                             Ok(PendingRepairDecision::Act(RepairAction::QueueParent {
                                 slot_meta,
@@ -841,7 +841,7 @@ impl BlockIdRepairService {
                     .push(OutgoingMessage::Metadata(
                         BlockIdRepairType::ParentAndFecSetCount {
                             slot: block.slot,
-                            block_id: block.block_id,
+                            block_id: block.block_id.into_hash(),
                         },
                     ));
                 state.requested_blocks.insert(block);
@@ -863,7 +863,7 @@ impl BlockIdRepairService {
         state.push_pending_repair_event(RepairEvent::FetchBlock {
             block: Block {
                 slot: meta.parent_slot.expect("Parent must exist for full slots"),
-                block_id: meta.parent_block_id,
+                block_id: BlockId::from(meta.parent_block_id),
             },
         });
 
@@ -999,7 +999,7 @@ impl BlockIdRepairService {
                     else {
                         state.requested_blocks.remove(&Block {
                             slot: shred_request.slot(),
-                            block_id: shred_request.block_id().unwrap(),
+                            block_id: BlockId::from(shred_request.block_id().unwrap()),
                         });
                         continue;
                     };
@@ -1443,7 +1443,7 @@ mod tests {
         assert_eq!(state.pending_repair_events.len(), 1);
         let RepairEvent::FetchBlock { block } = state.pending_repair_events.first().unwrap();
         assert_eq!(block.slot, parent_slot);
-        assert_eq!(block.block_id, parent_block_id);
+        assert_eq!(block.block_id.into_hash(), parent_block_id);
 
         // Verify: FecSetRoot requests were added to pending
         assert_eq!(state.pending_repair_requests.len(), fec_set_count_usize);
@@ -1709,7 +1709,7 @@ mod tests {
         let (mut state, _bank_forks) = create_test_repair_state();
 
         let slot = 100u64;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
 
         // Mark the slot as dead (Turbine failed)
         blockstore.set_dead_slot(slot).unwrap();
@@ -1729,7 +1729,7 @@ mod tests {
                 block_id: b,
             }) => {
                 assert_eq!(s, slot);
-                assert_eq!(b, block_id);
+                assert_eq!(b, block_id.into_hash());
             }
             _ => panic!("Expected ParentAndFecSetCount request"),
         }
@@ -1749,7 +1749,7 @@ mod tests {
         let (mut state, _bank_forks) = create_test_repair_state();
 
         let slot = 100u64;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let event = RepairEvent::FetchBlock {
             block: Block { slot, block_id },
         };
@@ -1778,7 +1778,7 @@ mod tests {
         let (mut state, _bank_forks) = create_test_repair_state();
 
         let slot = 100u64;
-        let requested_block_id = Hash::new_unique();
+        let requested_block_id = BlockId::new_unique();
         let turbine_block_id = Hash::new_unique(); // Different block_id from Turbine
 
         // Set up blockstore to have a different block_id at Original location
@@ -1804,7 +1804,7 @@ mod tests {
                 block_id: b,
             }) => {
                 assert_eq!(s, slot);
-                assert_eq!(b, requested_block_id);
+                assert_eq!(b, requested_block_id.into_hash());
             }
             _ => panic!("Expected ParentAndFecSetCount request"),
         }
@@ -1826,7 +1826,7 @@ mod tests {
         let (mut state, _bank_forks) = create_test_repair_state();
 
         let slot = 100u64;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
 
         // Pre-add block to requested_blocks
         state.requested_blocks.insert(Block { slot, block_id });
@@ -1850,7 +1850,7 @@ mod tests {
 
         // Use slot 0 which is at root
         let slot = 0u64;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let event = RepairEvent::FetchBlock {
             block: Block { slot, block_id },
         };
@@ -1876,7 +1876,7 @@ mod tests {
             state.requested_blocks.insert(Block::new_unique(slot));
         }
 
-        let new_block_id = Hash::new_unique();
+        let new_block_id = BlockId::new_unique();
         let event = RepairEvent::FetchBlock {
             block: Block {
                 slot,
@@ -1907,7 +1907,7 @@ mod tests {
         blockstore.set_dead_slot(slot).unwrap();
 
         let block_ids: Vec<_> = (0..=MAX_ALTERNATE_BLOCKS_PER_SLOT)
-            .map(|_| Hash::new_unique())
+            .map(|_| BlockId::new_unique())
             .collect();
         let actions: Vec<_> = block_ids
             .iter()

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -16,7 +16,10 @@ use {
             result::{Error, RepairVerifyError, Result},
         },
     },
-    agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
+    agave_votor_messages::{
+        consensus_message::{Block, BlockId},
+        migration::MigrationStatus,
+    },
     crossbeam_channel::{Receiver, RecvTimeoutError},
     lazy_lru::LruCache,
     rand::{
@@ -266,8 +269,14 @@ pub enum BlockIdRepairType {
 impl BlockIdRepairType {
     pub(crate) fn block(&self) -> Block {
         match *self {
-            BlockIdRepairType::ParentAndFecSetCount { slot, block_id } => Block { slot, block_id },
-            BlockIdRepairType::FecSetRoot { slot, block_id, .. } => Block { slot, block_id },
+            BlockIdRepairType::ParentAndFecSetCount { slot, block_id } => Block {
+                slot,
+                block_id: BlockId::from(block_id),
+            },
+            BlockIdRepairType::FecSetRoot { slot, block_id, .. } => Block {
+                slot,
+                block_id: BlockId::from(block_id),
+            },
         }
     }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -43,7 +43,7 @@ use {
     },
     agave_votor_messages::{
         certificate::Certificate,
-        consensus_message::{Block, VoteMessage},
+        consensus_message::{Block, BlockId, VoteMessage},
         migration::{GENESIS_VOTE_REFRESH, MigrationStatus},
         vote::Vote,
     },
@@ -1705,7 +1705,7 @@ impl ReplayStage {
         );
         assert!(genesis_bank.is_frozen());
 
-        if genesis_bank.block_id() != Some(genesis_block.block_id) {
+        if genesis_bank.block_id() != Some(genesis_block.block_id.into_hash()) {
             panic!(
                 "{my_pubkey}: Attempting to enable alpenglow but we have the wrong version of the \
                  genesis block our version: ({}, {:?}), certified version ({genesis_block:?})",
@@ -2468,7 +2468,7 @@ impl ReplayStage {
         };
         let block = event.block();
 
-        if bank_forks.read().unwrap().block_id(block.slot) == Some(block.block_id) {
+        if bank_forks.read().unwrap().block_id(block.slot) == Some(block.block_id.into_hash()) {
             // Nothing to switch
             *pending_switch = None;
             return Ok(());
@@ -2477,7 +2477,7 @@ impl ReplayStage {
         // Check if we have received the block and all of its ancestors and collect the ones we
         // need to switch out
         let mut ancestor_slot = block.slot;
-        let mut ancestor_block_id = block.block_id;
+        let mut ancestor_block_id = block.block_id.into_hash();
         let mut blocks_to_switch = vec![];
         let mut original_dead_slots_to_clear = BTreeSet::new();
         loop {
@@ -4410,7 +4410,7 @@ impl ReplayStage {
             end_slot,
             parent_block: Block {
                 slot: bank.slot(),
-                block_id,
+                block_id: BlockId::from(block_id),
             },
             block_timer: Instant::now(),
         };
@@ -4587,10 +4587,10 @@ impl ReplayStage {
 
                         let genesis_block = Block {
                             slot: genesis_slot,
-                            block_id: genesis_bank.block_id().expect(
+                            block_id: BlockId::from(genesis_bank.block_id().expect(
                                 "It is impossible for block id to not be known at this point, as \
                                  a descendant of this block has reached super oc status",
-                            ),
+                            )),
                         };
                         migration_status.set_genesis_block(genesis_block);
                     }

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -109,8 +109,8 @@ fn test_far_future_optimistic_parent_requires_parent_window_ready() {
         .unwrap();
     let parent_bank =
         Bank::new_from_parent_with_bank_forks(&bank_forks, root_bank, parent_leader, parent_slot);
-    let parent_block_id = Hash::new_unique();
-    parent_bank.set_block_id(Some(parent_block_id));
+    let parent_block_id = BlockId::new_unique();
+    parent_bank.set_block_id(Some(parent_block_id.into_hash()));
     parent_bank.freeze();
 
     let (sender, receiver) = bounded(1);
@@ -689,9 +689,9 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
     assert_eq!(bank_forks.read().unwrap().root(), 0);
     assert!(!blockstore.is_root(1));
 
-    let unfrozen_block_id = Hash::new_unique();
+    let unfrozen_block_id = BlockId::new_unique();
     let unfrozen_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 2);
-    unfrozen_bank.set_block_id(Some(unfrozen_block_id));
+    unfrozen_bank.set_block_id(Some(unfrozen_block_id.into_hash()));
     bank_forks.write().unwrap().insert(unfrozen_bank);
     let unfrozen_command = SetRootCommand {
         new_root: Block {
@@ -710,7 +710,10 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
 
     let block_id = bank_forks.read().unwrap().block_id(1).unwrap();
     let matching_command = SetRootCommand {
-        new_root: Block { slot: 1, block_id },
+        new_root: Block {
+            slot: 1,
+            block_id: BlockId::from(block_id),
+        },
     };
     ReplayStage::process_set_root_command(
         matching_command,

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -133,7 +133,7 @@ use {
     crate::entry::{Entry, EntryView, MaxDataShredsLen},
     agave_votor_messages::{
         certificate::{CertSignature, CertificateType, GenesisCert},
-        consensus_message::Block,
+        consensus_message::{Block, BlockId},
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
         unverified_vote_message::UnverifiedCertificate,
     },
@@ -289,7 +289,7 @@ impl TryFrom<GenesisCert> for GenesisCertBlockMarker {
         }
         Ok(Self {
             slot: cert.block.slot,
-            block_id: cert.block.block_id,
+            block_id: cert.block.block_id.into_hash(),
             bls_signature: cert.signature.signature,
             bitmap: cert.signature.bitmap,
         })
@@ -672,7 +672,10 @@ pub fn genesis_certificate_from_shred(
         return None;
     }
     Some(UnverifiedCertificate {
-        cert_type: CertificateType::Genesis(Block { slot, block_id }),
+        cert_type: CertificateType::Genesis(Block {
+            slot,
+            block_id: BlockId::from(block_id),
+        }),
         signature: bls_signature,
         bitmap,
         shred_version,
@@ -693,7 +696,10 @@ pub fn finalization_certificates_from_footer(
         final_aggregate,
         notar_aggregate,
     } = block_final_cert;
-    let block = Block { slot, block_id };
+    let block = Block {
+        slot,
+        block_id: BlockId::from(block_id),
+    };
 
     let final_signature = final_aggregate.uncompress_signature().ok()?;
     let final_bitmap = final_aggregate.into_bitmap();
@@ -779,7 +785,7 @@ mod tests {
             certificate.cert_type,
             CertificateType::Genesis(Block {
                 slot: parent_slot,
-                block_id,
+                block_id: BlockId::from(block_id),
             })
         );
         assert_eq!(certificate.signature, signature);
@@ -817,7 +823,10 @@ mod tests {
         };
         assert_eq!(
             certificate.cert_type,
-            CertificateType::FinalizeFast(Block { slot, block_id })
+            CertificateType::FinalizeFast(Block {
+                slot,
+                block_id: BlockId::from(block_id)
+            })
         );
         assert_eq!(certificate.signature, final_signature);
         assert_eq!(certificate.bitmap, final_bitmap);
@@ -851,7 +860,10 @@ mod tests {
         };
         assert_eq!(
             notarize.cert_type,
-            CertificateType::Notarize(Block { slot, block_id })
+            CertificateType::Notarize(Block {
+                slot,
+                block_id: BlockId::from(block_id)
+            })
         );
         assert_eq!(notarize.signature, notar_signature);
         assert_eq!(notarize.bitmap, notar_bitmap);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2495,7 +2495,7 @@ pub mod tests {
         agave_transaction_view::transaction_view::SanitizedTransactionView,
         agave_votor_messages::{
             certificate::{CertSignature, GenesisCert},
-            consensus_message::Block,
+            consensus_message::{Block, BlockId},
         },
         assert_matches::assert_matches,
         crossbeam_channel::bounded,
@@ -2578,7 +2578,7 @@ pub mod tests {
     fn test_startup_replay_enable_waits_for_poh_service_when_started() {
         let genesis_block = Block {
             slot: 1,
-            block_id: Hash::new_from_array([7; solana_hash::HASH_BYTES]),
+            block_id: BlockId::new([7; solana_hash::HASH_BYTES]),
         };
         let migration_status = Arc::new(ready_to_enable_migration_status(genesis_block));
         let poh_service = {

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -3,7 +3,7 @@
 use {
     crate::rpc_sender::*,
     agave_votor_messages::{
-        consensus_message::Block,
+        consensus_message::{Block, BlockId},
         wire::{WireBlockCertMessage, WireCertSignature},
     },
     async_trait::async_trait,
@@ -16,7 +16,6 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
-    solana_hash::Hash,
     solana_instruction::{TRANSACTION_LEVEL_STACK_HEIGHT, error::InstructionError},
     solana_message::MessageHeader,
     solana_pubkey::Pubkey,
@@ -179,7 +178,7 @@ impl RpcSender for MockSender {
             })?,
             "getAgGenesisCert" => {
                 let cert = WireBlockCertMessage {
-                    block: Block { slot: 0, block_id: Hash::default() },
+                    block: Block { slot: 0, block_id: BlockId::default() },
                     signature: WireCertSignature {
                         signature:  BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                         bitmap: vec![],

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -44,7 +44,7 @@ impl SetRootCommand {
     pub fn matches_frozen_bank(&self, bank_forks: &BankForks) -> bool {
         self.new_root.slot > bank_forks.root()
             && bank_forks.get(self.new_root.slot).is_some_and(|bank| {
-                bank.is_frozen() && bank.block_id() == Some(self.new_root.block_id)
+                bank.is_frozen() && bank.block_id() == Some(self.new_root.block_id.into_hash())
             })
     }
 }
@@ -225,7 +225,7 @@ mod tests {
     use {
         super::*,
         crate::{bank::SlotLeader, bank_forks::BankForks, genesis_utils::create_genesis_config},
-        solana_hash::Hash,
+        agave_votor_messages::consensus_message::BlockId,
         std::{thread, time::Duration},
     };
 
@@ -233,7 +233,7 @@ mod tests {
     fn test_bank_forks_controller_keeps_highest_pending_set_root() {
         let (controller, receiver) = BankForksControllerHandle::new();
 
-        let block_id_5 = Hash::new_unique();
+        let block_id_5 = BlockId::new_unique();
         controller.enqueue_set_root(Block {
             slot: 5,
             block_id: block_id_5,
@@ -279,8 +279,8 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
         let parent_bank = bank_forks.read().unwrap().root_bank();
         let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 1);
-        let block_id = Hash::new_unique();
-        bank.set_block_id(Some(block_id));
+        let block_id = BlockId::new_unique();
+        bank.set_block_id(Some(block_id.into_hash()));
         let bank = bank_forks
             .write()
             .unwrap()
@@ -363,8 +363,8 @@ mod tests {
 
         let parent_bank = bank_forks.read().unwrap().root_bank();
         let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 1);
-        let block_id = Hash::new_unique();
-        bank.set_block_id(Some(block_id));
+        let block_id = BlockId::new_unique();
+        bank.set_block_id(Some(block_id.into_hash()));
         bank.freeze();
         let inserted_bank = controller.insert_bank(bank).unwrap();
         assert_eq!(inserted_bank.slot(), 1);

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -13,7 +13,7 @@ use {
     agave_transaction_view::transaction_data::TransactionData,
     agave_votor_messages::{
         certificate::{CertSignature, Certificate, CertificateType, GenesisCert},
-        consensus_message::Block,
+        consensus_message::{Block, BlockId},
         migration::MigrationStatus,
         unverified_vote_message::UnverifiedCertificate,
     },
@@ -518,7 +518,7 @@ impl BlockComponentProcessor {
         let genesis_cert = GenesisCert {
             block: Block {
                 slot: genesis_block_marker.slot,
-                block_id: genesis_block_marker.block_id,
+                block_id: BlockId::from(genesis_block_marker.block_id),
             },
             signature: CertSignature {
                 signature: genesis_block_marker.bls_signature,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -9,7 +9,7 @@ use {
     agave_feature_set::{FEATURE_NAMES, FeatureSet},
     agave_votor_messages::{
         self,
-        consensus_message::{BLS_KEYPAIR_DERIVE_SEED, Block},
+        consensus_message::{BLS_KEYPAIR_DERIVE_SEED, Block, BlockId},
         migration::GENESIS_CERTIFICATE_ACCOUNT,
         wire::{WireBlockCertMessage, WireCertSignature},
     },
@@ -29,7 +29,6 @@ use {
     solana_feature_gate_interface::{self as feature, Feature},
     solana_fee_calculator::FeeRateGovernor,
     solana_genesis_config::GenesisConfig,
-    solana_hash::Hash,
     solana_keypair::Keypair,
     solana_native_token::LAMPORTS_PER_SOL,
     solana_pubkey::Pubkey,
@@ -346,7 +345,7 @@ fn configure_alpenglow_at_genesis(genesis_config: &mut GenesisConfig) {
     let cert = WireBlockCertMessage {
         block: Block {
             slot: 0,
-            block_id: Hash::default(),
+            block_id: BlockId::default(),
         },
         signature: WireCertSignature {
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -10,7 +10,7 @@ use {
         certificate::{
             CertSignature, Certificate, CertificateType, FastFinalizeCert, FinalizeCert, NotarCert,
         },
-        consensus_message::Block,
+        consensus_message::{Block, BlockId},
         finalized_slot::FinalizedSlot,
         unverified_vote_message::UnverifiedCertificate,
     },
@@ -92,7 +92,7 @@ impl ValidatedBlockFinalizationCert {
     ) -> Result<Self, BlockFinalizationCertError> {
         let block = Block {
             slot: block_final_cert.slot,
-            block_id: block_final_cert.block_id,
+            block_id: BlockId::from(block_final_cert.block_id),
         };
 
         if let Some(notar_aggregate) = block_final_cert.notar_aggregate {
@@ -343,7 +343,7 @@ impl ValidatedBlockFinalizationCert {
                 let block_id = notarize_cert.block.block_id;
                 BlockFinalizationCert {
                     slot,
-                    block_id,
+                    block_id: block_id.into_hash(),
                     final_aggregate: VotesAggregate::from_cert_signature(
                         finalize_cert.signature.clone(),
                     ),
@@ -356,7 +356,7 @@ impl ValidatedBlockFinalizationCert {
                 let block = cert.block;
                 BlockFinalizationCert {
                     slot: block.slot,
-                    block_id: block.block_id,
+                    block_id: block.block_id.into_hash(),
                     final_aggregate: VotesAggregate::from_cert_signature(cert.signature.clone()),
                     notar_aggregate: None,
                 }
@@ -522,7 +522,7 @@ mod tests {
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 final_aggregate: VotesAggregate::from_cert_signature(fast_finalize_cert_sig),
                 notar_aggregate: None,
             };
@@ -571,7 +571,7 @@ mod tests {
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
                 notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };
@@ -626,7 +626,7 @@ mod tests {
 
         let block_final_cert = BlockFinalizationCert {
             slot: block.slot,
-            block_id: block.block_id,
+            block_id: block.block_id.into_hash(),
             final_aggregate: VotesAggregate::from_cert_signature(finalize_cert.signature.clone()),
             notar_aggregate: Some(VotesAggregate::from_cert_signature(
                 notarize_cert.signature.clone(),
@@ -670,7 +670,7 @@ mod tests {
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 final_aggregate: VotesAggregate::from_cert_signature(fast_finalize_cert_sig),
                 notar_aggregate: None,
             };
@@ -714,7 +714,7 @@ mod tests {
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
                 notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };
@@ -760,7 +760,7 @@ mod tests {
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
-                block_id: block.block_id,
+                block_id: block.block_id.into_hash(),
                 final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
                 notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -2,7 +2,7 @@ use {
     crate::bank::Bank,
     agave_bls_cert_verify::cert_verify::{Error as BlsCertVerifyError, verify_base2},
     agave_votor_messages::{
-        consensus_message::Block,
+        consensus_message::{Block, BlockId},
         reward_certificate::{NUM_SLOTS_FOR_REWARD, NotarRewardCertificate, SkipRewardCertificate},
         vote::Vote,
         wire::get_vote_payload_to_sign,
@@ -119,7 +119,7 @@ impl ValidatedRewardCert {
         if let Some(notar) = notar {
             let vote = Vote::new_notarization_vote(Block {
                 slot: notar.slot,
-                block_id: notar.block_id,
+                block_id: BlockId::from(notar.block_id),
             });
             let payload = get_vote_payload_to_sign(vote, shred_version);
             verify_base2(
@@ -200,7 +200,6 @@ mod tests {
             Signature as BLSSignature, SignatureCompressed as BlsSignatureCompressed,
             SignatureProjective, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
         },
-        solana_hash::Hash,
         solana_leader_schedule::SlotLeader,
         solana_signer_store::encode_base2,
         std::{collections::HashMap, num::NonZero},
@@ -332,7 +331,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let notar_vote = Vote::new_notarization_vote(Block {
             slot: reward_slot,
             block_id,
@@ -342,7 +341,8 @@ mod tests {
             .collect::<Vec<_>>();
         let (signature, bitmap) = build_sig_bitmap(&notar_votes);
         let notar_reward_cert =
-            NotarRewardCertificate::try_new(reward_slot, block_id, signature, bitmap).unwrap();
+            NotarRewardCertificate::try_new(reward_slot, block_id.into_hash(), signature, bitmap)
+                .unwrap();
 
         let skip_vote = Vote::new_skip_vote(reward_slot);
         let skip_votes = (num_notar_validators..num_validators)

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -7,7 +7,10 @@ use {
     },
     crate::cluster_nodes::ClusterNodesCache,
     agave_votor::event::VotorEventSender,
-    agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
+    agave_votor_messages::{
+        consensus_message::{Block, BlockId},
+        migration::MigrationStatus,
+    },
     solana_cost_model::shred_limit::{
         DEFAULT_MAX_CODE_SHREDS_PER_SLOT, DEFAULT_MAX_DATA_SHREDS_PER_SLOT,
     },
@@ -89,7 +92,7 @@ impl StandardBroadcastRun {
             parent_block_id: Hash::default(),
             parent_for_double_merkle: Block {
                 slot: Slot::MAX,
-                block_id: Hash::default(),
+                block_id: BlockId::default(),
             },
             chained_merkle_root: Hash::default(),
             double_merkle_leaves: vec![],
@@ -173,7 +176,7 @@ impl StandardBroadcastRun {
         self.parent_block_id = parent_block_id;
         self.parent_for_double_merkle = Block {
             slot: bank.parent_slot(),
-            block_id: parent_block_id,
+            block_id: BlockId::from(parent_block_id),
         };
         self.chained_merkle_root = chained_merkle_root;
         self.double_merkle_leaves.clear();
@@ -294,7 +297,7 @@ impl StandardBroadcastRun {
         let parent_for_double_merkle = match update_parent {
             VersionedUpdateParent::V1(update_parent) => Block {
                 slot: update_parent.new_parent_slot,
-                block_id: update_parent.new_parent_block_id,
+                block_id: BlockId::from(update_parent.new_parent_block_id),
             },
         };
         self.parent_for_double_merkle = parent_for_double_merkle;
@@ -1352,15 +1355,15 @@ mod test {
         bs.parent_block_id = original_parent_block_id;
         bs.parent_for_double_merkle = Block {
             slot: bs.parent,
-            block_id: bs.parent_block_id,
+            block_id: BlockId::from(bs.parent_block_id),
         };
 
         let new_parent_slot = 7;
-        let new_parent_block_id = Hash::new_unique();
+        let new_parent_block_id = BlockId::new_unique();
         let component = BlockComponent::new_block_marker(VersionedBlockMarker::from_update_parent(
             solana_entry::block_component::UpdateParentV1 {
                 new_parent_slot,
-                new_parent_block_id,
+                new_parent_block_id: new_parent_block_id.into_hash(),
             },
         ));
         let mut stats = ProcessShredsStats::default();

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -7,8 +7,8 @@ use {
     serde::{Deserialize, Serialize},
     solana_bls_signatures::{Signature as BLSSignature, signature::SignatureAffine},
     solana_clock::Slot,
-    solana_hash::Hash,
-    std::num::NonZero,
+    solana_hash::{HASH_BYTES, Hash},
+    std::{fmt::Display, num::NonZero},
     wincode::{SchemaRead, SchemaWrite, pod_wrapper},
 };
 
@@ -25,6 +25,67 @@ pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 fn sample_hash(rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized)) -> Hash {
     use solana_frozen_abi::stable_abi::StableAbi;
     Hash::new_from_array(<[u8; solana_hash::HASH_BYTES] as StableAbi>::random(rng))
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    SchemaWrite,
+    SchemaRead,
+)]
+#[repr(transparent)]
+/// An alpenglow block id
+pub struct BlockId(
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "sample_hash(rng)"))] Hash,
+);
+
+impl BlockId {
+    /// Creates a new BlockId from the given hash
+    pub const fn new(bytes: [u8; HASH_BYTES]) -> Self {
+        Self(Hash::new_from_array(bytes))
+    }
+
+    /// Createa a new BlockId
+    pub fn new_unique() -> Self {
+        Self(Hash::new_unique())
+    }
+
+    /// Returns a reference to the byte representation of the the block id hash.
+    pub const fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    /// Returns the byte representation of the the block id hash consuming self.
+    pub const fn into_bytes(self) -> [u8; HASH_BYTES] {
+        self.0.to_bytes()
+    }
+
+    /// Returns the hash of the block id consuming self.
+    pub const fn into_hash(self) -> Hash {
+        self.0
+    }
+}
+
+impl Display for BlockId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<Hash> for BlockId {
+    fn from(block_id: Hash) -> Self {
+        Self(block_id)
+    }
 }
 
 /// An alpenglow block
@@ -49,8 +110,7 @@ pub struct Block {
     /// The slot in the block.
     pub slot: Slot,
     /// The block_id of the block.
-    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "sample_hash(rng)"))]
-    pub block_id: Hash,
+    pub block_id: BlockId,
 }
 
 impl Block {
@@ -59,7 +119,7 @@ impl Block {
     pub fn new_unique(slot: Slot) -> Self {
         Self {
             slot,
-            block_id: Hash::new_unique(),
+            block_id: BlockId::new_unique(),
         }
     }
 }

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -44,9 +44,8 @@
 //! - When in `FullAlpenglowEpoch` we completely shutdown these TowerBFT threads (AncestorHashesService and ClusterSlotsService)
 #[cfg(feature = "dev-context-only-utils")]
 use {
-    crate::certificate::CertSignature,
+    crate::{certificate::CertSignature, consensus_message::BlockId},
     solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
-    solana_hash::Hash,
 };
 use {
     crate::{certificate::GenesisCert, consensus_message::Block, fraction::Fraction},
@@ -358,7 +357,7 @@ impl MigrationStatus {
         let genesis_certificate = GenesisCert {
             block: Block {
                 slot: 0,
-                block_id: Hash::default(),
+                block_id: BlockId::default(),
             },
             signature: CertSignature {
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),

--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -1,5 +1,8 @@
 //! Vote data types for use by clients
-use {crate::consensus_message::Block, solana_clock::Slot, solana_hash::Hash};
+use {
+    crate::consensus_message::{Block, BlockId},
+    solana_clock::Slot,
+};
 
 /// Enum that clients can use to parse and create the vote
 /// structures expected by the program
@@ -80,7 +83,7 @@ impl Vote {
     }
 
     /// The block id associated with the block which was voted for
-    pub fn block_id(&self) -> Option<&Hash> {
+    pub fn block_id(&self) -> Option<&BlockId> {
         match self {
             Self::Notarize(vote) => Some(&vote.block.block_id),
             Self::NotarizeFallback(vote) => Some(&vote.block.block_id),

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -347,7 +347,7 @@ impl WireConsensusMessageV1 {
         SchemaRead
     ),
     frozen_abi(
-        digest = "BuNdLfQfseGa7sL29neSwUYqrWo1AVRyTYxMGxLATzia",
+        digest = "6w46grD3baydWXq2k3MZgJBnTXeZ2eSVWjFJtEMAGwBe",
         abi_digest = "ErGjoTr18hn3dvPVA7jFgK5WLwb4jgx7a39Yn8dSzB2K",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",
@@ -436,7 +436,7 @@ impl VersionedWireConsensusMessage {
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize),
     frozen_abi(
-        digest = "FaLMAAzQUX8FfCZhUqETKB1xdBwQuC3pwz2mEaC6t3Gb",
+        digest = "cTaLzChFuNY5yp3mN3YSpxFPX8skAaxXYGNjMy9oSSv",
         abi_digest = "2aBMTuPyDgGSYeYX1aBbXURgA4qqr92Eh9yiTeHX6qZq",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -576,7 +576,7 @@ mod tests {
         super::{parent_ready_tracker::BlockProductionParent, *},
         crate::tests::get_cluster_info,
         agave_votor_messages::{
-            consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
+            consensus_message::{BLS_KEYPAIR_DERIVE_SEED, BlockId, VoteMessage},
             sig_verified_messages::{SigVerifiedBatch, VoteAggregate},
             vote::Vote,
             wire::get_vote_payload_to_sign,
@@ -587,7 +587,6 @@ mod tests {
             keypair::Keypair as BLSKeypair, signature::SignatureAffine,
         },
         solana_clock::Slot,
-        solana_hash::Hash,
         solana_runtime::{
             bank::{Bank, NewBankOptions, SlotLeader},
             bank_forks::BankForks,
@@ -636,7 +635,7 @@ mod tests {
                 get_cluster_info(validator_keypairs[0].vote_keypair.insecure_clone());
             let root_block = Block {
                 slot: root_bank.slot(),
-                block_id: root_bank.block_id().unwrap_or_default(),
+                block_id: BlockId::from(root_bank.block_id().unwrap_or_default()),
             };
             let initial_parent_ready = (root_bank.slot().checked_add(1).unwrap(), root_block);
             Self {
@@ -1581,7 +1580,7 @@ mod tests {
 
         // Use slot 0 (first in leader window: 0 % 4 == 0) so SafeToNotar goes directly to events
         let slot = 0;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
 
         // Add a skip from myself.
         let vote = Vote::new_skip_vote(slot);
@@ -1611,7 +1610,7 @@ mod tests {
 
         // Use slot 4 (first in leader window: 4 % 4 == 0) for the second part
         let slot = 4;
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
 
         // Add 20% notarize, but no vote from myself, should fail
         for rank in 1..3 {
@@ -1661,7 +1660,7 @@ mod tests {
         // Add 20% notarization for another block, we should notify on new block_id
         // but not on the same block_id because we already sent the event
         let mut events = vec![];
-        let duplicate_block_id = Hash::new_unique();
+        let duplicate_block_id = BlockId::new_unique();
         for rank in 7..9 {
             let vote = Vote::new_notarization_vote(Block {
                 slot,
@@ -1699,7 +1698,7 @@ mod tests {
         let mut new_events = vec![];
 
         // Add a notarize from myself.
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let vote = Vote::new_notarization_vote(Block { slot: 2, block_id });
         let ret_events = ctx.add_own_vote_msg(0, vote);
         // Should still fail because there are no other votes.
@@ -1922,13 +1921,10 @@ mod tests {
         let mut events = vec![];
 
         // Add a notarization cert on slot 1 to 3
-        let hash = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         for slot in 1..=3 {
             let cert = Certificate {
-                cert_type: CertificateType::Notarize(Block {
-                    slot,
-                    block_id: hash,
-                }),
+                cert_type: CertificateType::Notarize(Block { slot, block_id }),
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
@@ -1942,17 +1938,14 @@ mod tests {
                 .any(|event| matches!(event, VotorEvent::ParentReady {
                 slot: 4,
                 parent_block
-            } if parent_block == &Block { slot: 3, block_id: hash }))
+            } if parent_block == &Block { slot: 3, block_id }))
         );
         events.clear();
 
         // Also works if we add FinalizeFast for slot 4 to 7
         for slot in 4..=7 {
             let cert = Certificate {
-                cert_type: CertificateType::FinalizeFast(Block {
-                    slot,
-                    block_id: hash,
-                }),
+                cert_type: CertificateType::FinalizeFast(Block { slot, block_id }),
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
@@ -1966,17 +1959,14 @@ mod tests {
                 .any(|event| matches!(event, VotorEvent::ParentReady {
                 slot: 8,
                 parent_block
-            } if parent_block == &Block { slot: 7, block_id: hash }))
+            } if parent_block == &Block { slot: 7, block_id }))
         );
         events.clear();
 
         // NotarizeFallback on slot 8 to 10 and FinalizeFast on slot 11
         for slot in 8..=10 {
             let cert = Certificate {
-                cert_type: CertificateType::NotarizeFallback(Block {
-                    slot,
-                    block_id: hash,
-                }),
+                cert_type: CertificateType::NotarizeFallback(Block { slot, block_id }),
                 signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                 bitmap: dummy_bitmap(),
             };
@@ -1984,10 +1974,7 @@ mod tests {
             events.append(&mut ret_events);
         }
         let cert = Certificate {
-            cert_type: CertificateType::FinalizeFast(Block {
-                slot: 11,
-                block_id: hash,
-            }),
+            cert_type: CertificateType::FinalizeFast(Block { slot: 11, block_id }),
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: dummy_bitmap(),
         };
@@ -2001,7 +1988,7 @@ mod tests {
                 .any(|event| matches!(event, VotorEvent::ParentReady {
             slot: 12,
             parent_block
-        } if parent_block == &Block { slot: 11, block_id: hash }))
+        } if parent_block == &Block { slot: 11, block_id }))
         );
     }
 
@@ -2010,8 +1997,8 @@ mod tests {
         let mut ctx = TestContext::new();
         let parent_bank = ctx.bank_forks.read().unwrap().root_bank();
         let root_bank = create_bank(63, parent_bank, SlotLeader::new_unique());
-        let root_block_id = Hash::new_unique();
-        root_bank.set_block_id(Some(root_block_id));
+        let root_block_id = BlockId::new_unique();
+        root_bank.set_block_id(Some(root_block_id.into_hash()));
         root_bank.freeze();
         let root_block = Block {
             slot: root_bank.slot(),
@@ -2079,11 +2066,8 @@ mod tests {
     fn received_certs_do_not_set_generated_certs() {
         let mut ctx = TestContext::new();
         let slot = ctx.bank_forks.read().unwrap().root_bank().slot() + 1;
-        let hash = Hash::default();
-        let cert_type = CertificateType::NotarizeFallback(Block {
-            slot,
-            block_id: hash,
-        });
+        let block_id = BlockId::default();
+        let cert_type = CertificateType::NotarizeFallback(Block { slot, block_id });
         let cert = Certificate {
             cert_type,
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -7,9 +7,12 @@ use {
         consensus_pool::stats::ConsensusPoolStats,
         event::VotorEvent,
     },
-    agave_votor_messages::{consensus_message::Block, fraction::Fraction, vote::Vote},
+    agave_votor_messages::{
+        consensus_message::{Block, BlockId},
+        fraction::Fraction,
+        vote::Vote,
+    },
     solana_clock::Slot,
-    solana_hash::Hash,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     std::{collections::BTreeMap, num::NonZero},
 };
@@ -20,9 +23,9 @@ pub(crate) struct SlotStakeCounters {
     total_stake: NonZero<Stake>,
     skip_total: Stake,
     notarize_total: Stake,
-    notarize_entry_total: BTreeMap<Hash, Stake>,
+    notarize_entry_total: BTreeMap<BlockId, Stake>,
     top_notarized_stake: Stake,
-    safe_to_notar_sent: Vec<Hash>,
+    safe_to_notar_sent: Vec<BlockId>,
     safe_to_skip_sent: bool,
 }
 
@@ -111,7 +114,7 @@ impl SlotStakeCounters {
         }
     }
 
-    fn is_safe_to_notar(&self, block_id: &Hash, stake: &Stake) -> bool {
+    fn is_safe_to_notar(&self, block_id: &BlockId, stake: &Stake) -> bool {
         // White paper v1.1 page 22: The event is only issued if the node voted in slot s already,
         // but not to notarize b. Moreover:
         // notar(b) >= 40% or (skip(s) + notar(b) >= 60% and notar(b) >= 20%)
@@ -232,11 +235,11 @@ mod tests {
         let slot = 4;
 
         // I voted for notarize b
-        let hash_1 = Hash::new_unique();
+        let block_id_1 = BlockId::new_unique();
         counters.add_vote(
             &Vote::new_notarization_vote(Block {
                 slot,
-                block_id: hash_1,
+                block_id: block_id_1,
             }),
             1,
             true,
@@ -249,11 +252,11 @@ mod tests {
         assert_eq!(stats.event_safe_to_notarize, 0);
 
         // 25% of stake holders voted notarize b'
-        let hash_2 = Hash::new_unique();
+        let block_id_2 = BlockId::new_unique();
         counters.add_vote(
             &Vote::new_notarization_vote(Block {
                 slot,
-                block_id: hash_2,
+                block_id: block_id_2,
             }),
             25,
             false,
@@ -278,7 +281,7 @@ mod tests {
         match &events[0] {
             VotorEvent::SafeToNotar(block) => {
                 assert_eq!(block.slot, slot);
-                assert_eq!(block.block_id, hash_2);
+                assert_eq!(block.block_id, block_id_2);
             }
             rest => panic!("unexpected: {rest:?}"),
         }
@@ -308,7 +311,7 @@ mod tests {
         assert!(pending_safe_to_notar.is_empty());
 
         // 40% of stake holders voted notarize
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         counters.add_vote(
             &Vote::new_notarization_vote(Block { slot, block_id }),
             40,
@@ -378,11 +381,11 @@ mod tests {
         stats = ConsensusPoolStats::default();
 
         // I voted for notarize b, 10% of stake holders voted with me
-        let hash_1 = Hash::new_unique();
+        let block_id_1 = BlockId::new_unique();
         counters.add_vote(
             &Vote::new_notarization_vote(Block {
                 slot,
-                block_id: hash_1,
+                block_id: block_id_1,
             }),
             10,
             true,
@@ -391,11 +394,11 @@ mod tests {
             &mut stats,
         );
         // 20% of stake holders voted a different notarization b'
-        let hash_2 = Hash::new_unique();
+        let block_id_2 = BlockId::new_unique();
         counters.add_vote(
             &Vote::new_notarization_vote(Block {
                 slot,
-                block_id: hash_2,
+                block_id: block_id_2,
             }),
             20,
             false,
@@ -421,7 +424,7 @@ mod tests {
         counters.add_vote(
             &Vote::new_notarization_vote(Block {
                 slot,
-                block_id: hash_1,
+                block_id: block_id_1,
             }),
             10,
             false,

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -23,7 +23,7 @@ use {
     agave_bls_sigverify::generated_cert_types::GeneratedCertTypes,
     agave_votor_messages::{
         certificate::Certificate,
-        consensus_message::{Block, VoteMessage},
+        consensus_message::{Block, BlockId, VoteMessage},
         migration::MigrationStatus,
         sig_verified_messages::{SigVerifiedBatch, VoteAggregate},
         vote::Vote,
@@ -512,7 +512,7 @@ impl ConsensusPoolService {
             // Check if we've received the full block in blockstore
             let Some((slot_meta, _location)) = ctx
                 .blockstore
-                .get_slot_meta_for_block_id(block.slot, block.block_id)
+                .get_slot_meta_for_block_id(block.slot, block.block_id.into_hash())
                 .expect("Blockstore operations must succeed")
             else {
                 // Block not yet received, keep waiting
@@ -523,7 +523,7 @@ impl ConsensusPoolService {
                 slot: slot_meta
                     .parent_slot
                     .expect("parent slot must exist for full blocks"),
-                block_id: slot_meta.parent_block_id,
+                block_id: BlockId::from(slot_meta.parent_block_id),
             };
 
             // Check if the parent has a NotarizeFallback certificate (or stronger)
@@ -712,10 +712,12 @@ impl ConsensusPoolService {
 fn root_block(root_bank: &Bank) -> Block {
     Block {
         slot: root_bank.slot(),
-        block_id: root_bank
-            .block_id()
-            // Once SIMD-0333 is active we can hard unwrap here
-            .unwrap_or_default(),
+        block_id: BlockId::from(
+            root_bank
+                .block_id()
+                // Once SIMD-0333 is active we can hard unwrap here
+                .unwrap_or_default(),
+        ),
     }
 }
 
@@ -736,7 +738,6 @@ mod tests {
             BLS_SIGNATURE_AFFINE_SIZE, keypair::Keypair as BLSKeypair,
             signature::Signature as BLSSignature,
         },
-        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::get_tmp_ledger_path_auto_delete,
         solana_runtime::{
@@ -844,7 +845,7 @@ mod tests {
         let mut ctx = TestContext::default();
 
         // validator 0 to 7 send Notarize on slot 2
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let target_slot = 2;
         let notarize_vote = Vote::new_notarization_vote(Block {
             slot: target_slot,

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -198,14 +198,14 @@ impl LatestSwitchRequest {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_hash::Hash};
+    use {super::*, agave_votor_messages::consensus_message::BlockId};
 
     fn block(slot: u64, id_byte: u8) -> Block {
         let mut bytes = [0; 32];
         bytes[31] = id_byte;
         Block {
             slot,
-            block_id: Hash::new_from_array(bytes),
+            block_id: BlockId::new(bytes),
         }
     }
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -21,7 +21,9 @@ use {
         votor::{ExitOnDrop, SharedContext},
     },
     agave_votor_messages::{
-        consensus_message::Block, metric_types::ConsensusMetricsEvent, migration::MigrationStatus,
+        consensus_message::{Block, BlockId},
+        metric_types::ConsensusMetricsEvent,
+        migration::MigrationStatus,
         vote::Vote,
     },
     crossbeam_channel::select,
@@ -639,7 +641,7 @@ impl EventHandler {
             // We haven't finished replay for the block, so we can't trigger parent ready
             return None;
         }
-        if bank.block_id() != Some(block_id) {
+        if bank.block_id() != Some(block_id.into_hash()) {
             // We have a different block id for the slot, repair should kick in later
             return None;
         }
@@ -660,7 +662,7 @@ impl EventHandler {
         );
         Some(Block {
             slot: parent_slot,
-            block_id: parent_block_id,
+            block_id: BlockId::from(parent_block_id),
         })
     }
 
@@ -735,7 +737,7 @@ impl EventHandler {
         let slot = bank.slot();
         let block = Block {
             slot,
-            block_id: bank.block_id().expect("Block id must be set upstream"),
+            block_id: BlockId::from(bank.block_id().expect("Block id must be set upstream")),
         };
         let parent_slot = bank.parent_slot();
         let parent_block_id = bank.parent_block_id().unwrap_or_else(|| {
@@ -748,7 +750,7 @@ impl EventHandler {
         });
         let parent_block = Block {
             slot: parent_slot,
-            block_id: parent_block_id,
+            block_id: BlockId::from(parent_block_id),
         };
         (block, parent_block)
     }
@@ -963,7 +965,7 @@ impl EventHandler {
 
                 // Check for bank hash mismatch
                 if bank.is_frozen()
-                    && bank.block_id() == Some(block.block_id)
+                    && bank.block_id() == Some(block.block_id.into_hash())
                     && let Some(expected_hash) = bank.expected_bank_hash()
                     && expected_hash != bank.hash()
                 {
@@ -986,7 +988,9 @@ impl EventHandler {
                 (block.slot > old_root
                     && vctx.vote_history.voted(block.slot)
                     && bank.is_frozen()
-                    && bank.block_id().is_some_and(|bid| bid == block.block_id))
+                    && bank
+                        .block_id()
+                        .is_some_and(|bid| bid == block.block_id.into_hash()))
                 .then_some((block, bank.hash()))
             })
             .max_by_key(|(block, _)| block.slot)
@@ -1667,7 +1671,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(slot, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
 
         test_context.check_for_metrics_event(ConsensusMetricsEvent::StartOfSlot { slot });
 
@@ -1684,7 +1688,7 @@ mod tests {
         let slot = 2;
         let bank2 = test_context.create_block_and_send_block_event(slot, bank1.clone());
         test_context.check_alpenglow_slot(1);
-        let block_id_2 = bank2.block_id().unwrap();
+        let block_id_2 = BlockId::from(bank2.block_id().unwrap());
 
         // Because 2 is middle of window, we should see Notarize vote for block 2 even without parentready
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
@@ -1699,7 +1703,7 @@ mod tests {
         // Slot 4 completed replay without parent ready or parent notarized should not trigger Notarize vote
         let slot = 4;
         let bank4 = test_context.create_block_and_send_block_event(slot, bank2);
-        let block_id_4 = bank4.block_id().unwrap();
+        let block_id_4 = BlockId::from(bank4.block_id().unwrap());
 
         // Send parent ready for slot 4 should trigger Notarize vote for slot 4
         test_context.send_parent_ready_event(
@@ -1755,7 +1759,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
 
         // Add parent ready for 0 to trigger notar vote for 1
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
@@ -1773,7 +1777,7 @@ mod tests {
         test_context.check_for_vote(&Vote::new_finalization_vote(1));
 
         let bank2 = test_context.create_block_and_send_block_event(2, bank1);
-        let block_id_2 = bank2.block_id().unwrap();
+        let block_id_2 = BlockId::from(bank2.block_id().unwrap());
         // Both Notarize and Finalize votes should trigger for 2
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot: 2,
@@ -1789,7 +1793,7 @@ mod tests {
         // Create bank3 but do not Notarize, so Finalize vote should not trigger
         let slot = 3;
         let bank3 = test_context.create_block_only(slot, bank2);
-        let block_id_3 = bank3.block_id().unwrap();
+        let block_id_3 = BlockId::from(bank3.block_id().unwrap());
         // Check no notarization vote for 3
         test_context.check_no_vote_or_commitment();
 
@@ -1898,7 +1902,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank_1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1_old = bank_1.block_id().unwrap();
+        let block_id_1_old = BlockId::from(bank_1.block_id().unwrap());
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
         test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
@@ -1909,7 +1913,7 @@ mod tests {
         test_context.check_for_commitment(CommitmentType::Notarize, 1);
 
         // Now we got safe_to_notar event for slot 1 and a different block id
-        let block_id_1_1 = Hash::new_unique();
+        let block_id_1_1 = BlockId::new_unique();
         test_context.send_safe_to_notar_event(Block {
             slot: 1,
             block_id: block_id_1_1,
@@ -1927,7 +1931,7 @@ mod tests {
         // In this test you can trigger this any number of times, but the white paper
         // proved we can only get up to 3 different block ids on a slot, and our
         // certificate pool implementation checks that.
-        let block_id_1_2 = Hash::new_unique();
+        let block_id_1_2 = BlockId::new_unique();
         test_context.send_safe_to_notar_event(Block {
             slot: 1,
             block_id: block_id_1_2,
@@ -1959,7 +1963,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank_1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank_1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank_1.block_id().unwrap());
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
         test_context.check_parent_ready_slot((1, test_context.local_context.genesis_block));
@@ -2000,7 +2004,7 @@ mod tests {
         );
 
         // Suddenly I found out I produced block 1 already, send new produce window event
-        let block_id_1 = Hash::new_unique();
+        let block_id_1 = BlockId::new_unique();
         test_context.send_produce_window_event(
             2,
             3,
@@ -2033,7 +2037,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
 
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
@@ -2070,7 +2074,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank = test_context.create_block_only(1, root_bank);
-        let block_id = bank.block_id().unwrap();
+        let block_id = BlockId::from(bank.block_id().unwrap());
         let expected_hash = Hash::new_unique();
         bank.set_expected_bank_hash(expected_hash);
 
@@ -2089,7 +2093,7 @@ mod tests {
         let bank = test_context.create_block_only(1, root_bank);
         let expected_hash = Hash::new_unique();
         bank.set_expected_bank_hash(expected_hash);
-        let finalized_block_id = Hash::new_unique();
+        let finalized_block_id = BlockId::new_unique();
 
         test_context.send_finalized_event(
             Block {
@@ -2112,10 +2116,10 @@ mod tests {
             .sharable_banks()
             .root();
         let bank4 = test_context.create_block_and_send_block_event(4, root_bank);
-        let block_id_4 = bank4.block_id().unwrap();
+        let block_id_4 = BlockId::from(bank4.block_id().unwrap());
 
         let bank5 = test_context.create_block_and_send_block_event(5, bank4);
-        let block_id_5 = bank5.block_id().unwrap();
+        let block_id_5 = BlockId::from(bank5.block_id().unwrap());
 
         test_context.send_finalized_event(
             Block {
@@ -2137,7 +2141,7 @@ mod tests {
         // We are partitioned off from rest of the network, and suddenly received finalize for
         // slot 9 a little before we finished replay slot 9
         let bank9 = test_context.create_block_only(9, bank5);
-        let block_id_9 = bank9.block_id().unwrap();
+        let block_id_9 = BlockId::from(bank9.block_id().unwrap());
         test_context.send_finalized_event(
             Block {
                 slot: 9,
@@ -2169,10 +2173,10 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
 
         let bank4 = test_context.create_block_and_send_block_event(4, bank1);
-        let block_id_4 = bank4.block_id().unwrap();
+        let block_id_4 = BlockId::from(bank4.block_id().unwrap());
 
         test_context.send_finalized_event(
             Block {
@@ -2203,7 +2207,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
 
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
@@ -2309,7 +2313,7 @@ mod tests {
         // We should now be able to vote again
         let slot = 4;
         let bank4 = test_context.create_block_and_send_block_event(slot, root_bank);
-        let block_id_4 = bank4.block_id().unwrap();
+        let block_id_4 = BlockId::from(bank4.block_id().unwrap());
         test_context.send_parent_ready_event(slot, test_context.local_context.genesis_block);
         test_context.check_for_vote(&Vote::new_notarization_vote(Block {
             slot,
@@ -2406,7 +2410,7 @@ mod tests {
         let rooted_bank = test_context.create_block_and_send_block_event(effective_root, root_bank);
         let rooted_block = Block {
             slot: effective_root,
-            block_id: rooted_bank.block_id().unwrap(),
+            block_id: BlockId::from(rooted_bank.block_id().unwrap()),
         };
         test_context.send_parent_ready_event(effective_root, Block::default());
         test_context.send_finalized_event(rooted_block, true);
@@ -2516,7 +2520,7 @@ mod tests {
             .sharable_banks()
             .root();
         let bank1 = test_context.create_block_and_send_block_event(1, root_bank);
-        let block_id_1 = bank1.block_id().unwrap();
+        let block_id_1 = BlockId::from(bank1.block_id().unwrap());
         test_context.send_parent_ready_event(1, test_context.local_context.genesis_block);
         let block = Block {
             slot: 1,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -6,7 +6,7 @@ use {
         voting_utils::VotingContext,
         votor::SharedContext,
     },
-    agave_votor_messages::consensus_message::Block,
+    agave_votor_messages::consensus_message::{Block, BlockId},
     crossbeam_channel::Sender,
     solana_clock::Slot,
     solana_hash::Hash,
@@ -53,7 +53,7 @@ pub(crate) fn set_root(
     *pending_blocks = pending_blocks.split_off(&new_root_slot);
     *finalized_blocks = finalized_blocks.split_off(&Block {
         slot: new_root_slot,
-        block_id: Hash::default(),
+        block_id: BlockId::default(),
     });
     *received_shred = received_shred.split_off(&new_root_slot);
 

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -2,9 +2,12 @@ use {
     super::vote_history_storage::{
         Result, SavedVoteHistory, SavedVoteHistoryVersions, VoteHistoryStorage,
     },
-    agave_votor_messages::{consensus_message::Block, vote::Vote, wire::VotePayloadToSign},
+    agave_votor_messages::{
+        consensus_message::{Block, BlockId},
+        vote::Vote,
+        wire::VotePayloadToSign,
+    },
     solana_clock::Slot,
-    solana_hash::Hash,
     solana_keypair::Keypair,
     solana_pubkey::Pubkey,
     std::collections::{HashMap, HashSet, hash_map::Entry},
@@ -50,11 +53,11 @@ pub struct VoteHistory {
 
     /// The blocks for which this node has cast a notarization vote
     /// In the format of slot, block_id, bank_hash
-    voted_notar: HashMap<Slot, Hash>,
+    voted_notar: HashMap<Slot, BlockId>,
 
     /// The blocks for which this node has cast a notarization fallback
     /// vote in this slot
-    voted_notar_fallback: HashMap<Slot, HashSet<Hash>>,
+    voted_notar_fallback: HashMap<Slot, HashSet<BlockId>>,
 
     /// The slots for which this node has cast a skip fallback vote
     voted_skip_fallback: HashSet<Slot>,
@@ -127,13 +130,13 @@ impl VoteHistory {
     }
 
     /// The block for which we voted notarize in slot `slot`
-    pub fn voted_notar(&self, slot: Slot) -> Option<Hash> {
+    pub fn voted_notar(&self, slot: Slot) -> Option<BlockId> {
         assert!(slot >= self.root);
         self.voted_notar.get(&slot).copied()
     }
 
     /// Whether we voted notarize fallback in `slot` for block `(block_id, bank_hash)`
-    pub fn voted_notar_fallback(&self, slot: Slot, block_id: Hash) -> bool {
+    pub fn voted_notar_fallback(&self, slot: Slot, block_id: BlockId) -> bool {
         assert!(slot >= self.root);
         self.voted_notar_fallback
             .get(&slot)
@@ -379,7 +382,7 @@ mod test {
         assert!(vote_history.votes_cast_since(0).is_empty());
 
         // Vote Notarize on slot 1
-        let block_id_1 = Hash::new_unique();
+        let block_id_1 = BlockId::new_unique();
         let vote_notarize_1 = Vote::new_notarization_vote(Block {
             slot: 1,
             block_id: block_id_1,
@@ -416,7 +419,7 @@ mod test {
         assert!(vote_history.bad_window(2));
 
         // Now vote NotarizeFallback on slot 2
-        let block_id_2 = Hash::new_unique();
+        let block_id_2 = BlockId::new_unique();
         let vote_notarize_fallback_2 = Vote::new_notarization_fallback_vote(Block {
             slot: 2,
             block_id: block_id_2,
@@ -440,7 +443,7 @@ mod test {
         assert!(vote_history.bad_window(2));
 
         // Vote Notarize on slot 3
-        let block_id_3 = Hash::new_unique();
+        let block_id_3 = BlockId::new_unique();
         let vote_notarize_3 = Vote::new_notarization_vote(Block {
             slot: 3,
             block_id: block_id_3,
@@ -535,7 +538,7 @@ mod test {
         let genesis_block = Block::new_unique(2);
         vote_history
             .voted_notar
-            .insert(genesis_block.slot, Hash::new_unique());
+            .insert(genesis_block.slot, BlockId::new_unique());
 
         vote_history.initialize_genesis(genesis_block);
     }

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -370,10 +370,9 @@ mod tests {
     use {
         super::*,
         crate::vote_history_storage::NullVoteHistoryStorage,
-        agave_votor_messages::consensus_message::Block,
+        agave_votor_messages::consensus_message::{Block, BlockId},
         crossbeam_channel::{Receiver, bounded},
         solana_gossip::contact_info::ContactInfo,
-        solana_hash::Hash,
         solana_net_utils::SocketAddrSpace,
         solana_runtime::{
             bank::{Bank, SlotLeader},
@@ -485,7 +484,7 @@ mod tests {
         .unwrap();
 
         // Generate a normal notarization vote and check it's sent out correctly.
-        let block_id = Hash::new_unique();
+        let block_id = BlockId::new_unique();
         let vote_slot = 2;
         let block = Block {
             slot: vote_slot,


### PR DESCRIPTION
#### Problem

Currently, block id is stored as a `Hash`.  There are other objects that are also `Hash` in particular bank hash.  It is easy to mistake one for the other and pass in the wrong one.


#### Summary of Changes

- Introduces a `BlockId` new type that holds `Hash`.  
- This improves readability of the code adding documentation and helps differentiate from bank hash and other uses of `Hash`.
- The previous attempt (https://github.com/anza-xyz/agave/pull/14166) was deemed too disruptive so this attempt reduces the blast radius of the PR.  Subsequent PRs will update additional structs to use `BlockId`.


#### Testing

No new tests added