### PR TITLE
Verify index shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -144,7 +144,6 @@ pub(crate) struct AliveAccounts<'a> {
 
 pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
-    fn collect(&mut self, other: Self);
     fn add(&mut self, account: &'a AccountFromStorage);
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
@@ -152,10 +151,6 @@ pub(crate) trait ShrinkCollector<'a>: Sync + Send {
 }
 
 impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
-    fn collect(&mut self, mut other: Self) {
-        self.bytes = self.bytes.saturating_add(other.bytes);
-        self.accounts.append(&mut other.accounts);
-    }
     fn with_capacity(capacity: usize, slot: Slot) -> Self {
         Self {
             accounts: Vec::with_capacity(capacity),
@@ -190,11 +185,6 @@ pub(crate) struct ShrinkCollect<T> {
     /// total size in storage of all alive accounts
     pub(crate) alive_total_bytes: usize,
     pub(crate) total_starting_accounts: usize,
-}
-
-struct LoadAccountsIndexForShrink<T> {
-    /// all alive accounts
-    alive_accounts: T,
 }
 
 /// reference an account found during scanning a storage.
@@ -1862,25 +1852,18 @@ impl AccountsDb {
         );
     }
 
-    /// load the account index entry for the first `count` items in `accounts`
-    /// store a reference to all alive accounts in `alive_accounts`
-    /// return sum of account size for all alive accounts
-    fn load_accounts_index_for_shrink<'a, T: ShrinkCollector<'a>>(
+    /// verify via the accounts index that every account in `accounts` is alive in `slot_to_shrink`
+    fn verify_accounts_index_for_shrink(
         &self,
-        accounts: &'a [AccountFromStorage],
+        accounts: &[AccountFromStorage],
         stats: &ShrinkStats,
         slot_to_shrink: Slot,
-    ) -> LoadAccountsIndexForShrink<T> {
-        let count = accounts.len();
-        let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
-
-        let mut index = 0;
+    ) {
         let mut index_scan_returned_some_count = 0;
         let mut index_scan_returned_none_count = 0;
         self.accounts_index.scan(
             accounts.iter().map(|account| account.pubkey()),
             |_pubkey, slot_list| {
-                let stored_account = &accounts[index];
                 if let Some(slot_list) = slot_list {
                     index_scan_returned_some_count += 1;
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
@@ -1893,23 +1876,21 @@ impl AccountsDb {
                 } else {
                     // getting None here means the account is 'normal' and was written to disk.
                     index_scan_returned_none_count += 1;
-
-
                 }
-                alive_accounts.add(stored_account);
-                index += 1;
             },
             self.scan_filter_for_shrinking,
         );
-        assert_eq!(index, std::cmp::min(accounts.len(), count));
+        // the scan must have called back once per account
+        assert_eq!(
+            index_scan_returned_some_count + index_scan_returned_none_count,
+            accounts.len() as u64
+        );
         stats
             .index_scan_returned_some
             .fetch_add(index_scan_returned_some_count, Ordering::Relaxed);
         stats
             .index_scan_returned_none
             .fetch_add(index_scan_returned_none_count, Ordering::Relaxed);
-
-        LoadAccountsIndexForShrink { alive_accounts }
     }
 
     /// get all accounts in all the storages passed in
@@ -2018,16 +1999,6 @@ impl AccountsDb {
             .sum();
 
         let len = stored_accounts.len();
-        let shrink_collect = Mutex::new(ShrinkCollect {
-            slot,
-            written_bytes: *written_bytes,
-            alive_accounts: T::with_capacity(len, slot),
-            tombstones_to_carry_forward,
-            tombstones_total_bytes,
-            total_starting_accounts,
-            alive_total_bytes: 0, // will be updated after `alive_accounts` is populated
-        });
-
         stats
             .accounts_loaded
             .fetch_add(len as u64, Ordering::Relaxed);
@@ -2038,20 +2009,18 @@ impl AccountsDb {
             stored_accounts
                 .par_chunks(SHRINK_COLLECT_CHUNK_SIZE)
                 .for_each(|stored_accounts| {
-                    let LoadAccountsIndexForShrink { alive_accounts } =
-                        self.load_accounts_index_for_shrink(stored_accounts, stats, slot);
-
-                    // collect
-                    let mut shrink_collect = shrink_collect.lock().unwrap();
-                    shrink_collect.alive_accounts.collect(alive_accounts);
+                    self.verify_accounts_index_for_shrink(stored_accounts, stats, slot);
                 });
         });
 
         index_read_elapsed.stop();
 
-        let mut shrink_collect = shrink_collect.into_inner().unwrap();
-        let alive_total_bytes = shrink_collect.alive_accounts.alive_bytes();
-        shrink_collect.alive_total_bytes = alive_total_bytes;
+        // every account that survived the filtering above is alive
+        let mut alive_accounts = T::with_capacity(len, slot);
+        stored_accounts
+            .iter()
+            .for_each(|account| alive_accounts.add(account));
+        let alive_total_bytes = alive_accounts.alive_bytes();
 
         stats
             .index_read_elapsed
@@ -2060,19 +2029,25 @@ impl AccountsDb {
         // Tombstones carried forward are rewritten into the new storage, not reclaimed, so exclude
         // them from the "removed" totals (which measure what shrink actually freed).
         stats.accounts_removed.fetch_add(
-            total_starting_accounts
-                - shrink_collect.alive_accounts.len()
-                - shrink_collect.tombstones_to_carry_forward.len(),
+            total_starting_accounts - alive_accounts.len() - tombstones_to_carry_forward.len(),
             Ordering::Relaxed,
         );
         stats.bytes_removed.fetch_add(
             written_bytes
                 .saturating_sub(alive_total_bytes as u64)
-                .saturating_sub(shrink_collect.tombstones_total_bytes as u64),
+                .saturating_sub(tombstones_total_bytes as u64),
             Ordering::Relaxed,
         );
 
-        shrink_collect
+        ShrinkCollect {
+            slot,
+            written_bytes: *written_bytes,
+            alive_accounts,
+            tombstones_to_carry_forward,
+            tombstones_total_bytes,
+            total_starting_accounts,
+            alive_total_bytes,
+        }
     }
 
     /// common code from shrink and combine_ancient_slots

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -145,7 +145,7 @@ pub(crate) struct AliveAccounts<'a> {
 pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
-    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]);
+    fn add(&mut self, account: &'a AccountFromStorage);
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
@@ -163,7 +163,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
             slot,
         }
     }
-    fn add(&mut self, account: &'a AccountFromStorage, _slot_list: &[(Slot, AccountInfo)]) {
+    fn add(&mut self, account: &'a AccountFromStorage) {
         self.accounts.push(account);
         self.bytes = self.bytes.saturating_add(account.stored_size());
     }
@@ -1890,17 +1890,13 @@ impl AccountsDb {
 
                     // All obsolete and tombstones have been filtered. Account MUST be alive in this slot
                     assert!(is_alive);
-                    alive_accounts.add(stored_account, slot_list);
                 } else {
+                    // getting None here means the account is 'normal' and was written to disk.
                     index_scan_returned_none_count += 1;
-                    // getting None here means the account is 'normal' and was written to disk. This means it must have
-                    // slot_list.len() = 1. This means it must be alive in this slot. This is by far the most common case.
-                    // Note that we could get Some(...) here if the account is in the in mem index because it is hot.
-                    // Note this could also mean the account isn't on disk either. That would indicate a bug in accounts db.
-                    // Account is alive.
-                    let slot_list = [(slot_to_shrink, AccountInfo::default())];
-                    alive_accounts.add(stored_account, &slot_list);
+
+
                 }
+                alive_accounts.add(stored_account);
                 index += 1;
             },
             self.scan_filter_for_shrinking,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -142,15 +142,7 @@ pub(crate) struct AliveAccounts<'a> {
     pub(crate) bytes: usize,
 }
 
-pub(crate) trait ShrinkCollector<'a>: Sync + Send {
-    fn with_capacity(capacity: usize, slot: Slot) -> Self;
-    fn add(&mut self, account: &'a AccountFromStorage);
-    fn len(&self) -> usize;
-    fn alive_bytes(&self) -> usize;
-    fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
-}
-
-impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
+impl<'a> AliveAccounts<'a> {
     fn with_capacity(capacity: usize, slot: Slot) -> Self {
         Self {
             accounts: Vec::with_capacity(capacity),
@@ -1945,12 +1937,12 @@ impl AccountsDb {
 
     /// shared code for shrinking normal slots and combining into ancient append vecs
     /// note 'unique_accounts' is passed by ref so we can return references to data within it, avoiding self-references
-    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollector<'b>>(
+    pub(crate) fn shrink_collect<'a>(
         &self,
-        store: &'a AccountStorageEntry,
-        unique_accounts: &'b mut GetUniqueAccountsResult,
+        store: &AccountStorageEntry,
+        unique_accounts: &'a mut GetUniqueAccountsResult,
         stats: &ShrinkStats,
-    ) -> ShrinkCollect<T> {
+    ) -> ShrinkCollect<AliveAccounts<'a>> {
         let slot = store.slot();
 
         let GetUniqueAccountsResult {
@@ -2016,7 +2008,7 @@ impl AccountsDb {
         index_read_elapsed.stop();
 
         // every account that survived the filtering above is alive
-        let mut alive_accounts = T::with_capacity(len, slot);
+        let mut alive_accounts = AliveAccounts::with_capacity(len, slot);
         stored_accounts
             .iter()
             .for_each(|account| alive_accounts.add(account));
@@ -2102,11 +2094,7 @@ impl AccountsDb {
         let mut unique_accounts =
             self.get_unique_accounts_from_storage_for_shrink(&store, &self.shrink_stats);
         debug!("do_shrink_slot_store: slot: {slot}");
-        let shrink_collect = self.shrink_collect::<AliveAccounts<'_>>(
-            &store,
-            &mut unique_accounts,
-            &self.shrink_stats,
-        );
+        let shrink_collect = self.shrink_collect(&store, &mut unique_accounts, &self.shrink_stats);
 
         let total_rewrite_bytes =
             shrink_collect.alive_total_bytes + shrink_collect.tombstones_total_bytes;

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1476,11 +1476,8 @@ fn test_shrink_collect_carries_forward_existing_tombstones() {
     // not mis-routed into the alive set.
     let mut unique_accounts =
         accounts_db.get_unique_accounts_from_storage_for_shrink(&storage, &ShrinkStats::default());
-    let shrink_collect = accounts_db.shrink_collect::<AliveAccounts<'_>>(
-        &storage,
-        &mut unique_accounts,
-        &ShrinkStats::default(),
-    );
+    let shrink_collect =
+        accounts_db.shrink_collect(&storage, &mut unique_accounts, &ShrinkStats::default());
     assert_eq!(shrink_collect.tombstones_to_carry_forward.len(), 1);
     assert!(shrink_collect.tombstones_total_bytes > 0);
     assert_eq!(
@@ -1498,11 +1495,8 @@ fn test_shrink_collect_carries_forward_existing_tombstones() {
     accounts_db.set_latest_full_snapshot_slot(slot);
     let mut unique_accounts =
         accounts_db.get_unique_accounts_from_storage_for_shrink(&storage, &ShrinkStats::default());
-    let shrink_collect = accounts_db.shrink_collect::<AliveAccounts<'_>>(
-        &storage,
-        &mut unique_accounts,
-        &ShrinkStats::default(),
-    );
+    let shrink_collect =
+        accounts_db.shrink_collect(&storage, &mut unique_accounts, &ShrinkStats::default());
     assert!(shrink_collect.tombstones_to_carry_forward.is_empty());
     assert_eq!(shrink_collect.tombstones_total_bytes, 0);
 }
@@ -6053,7 +6047,7 @@ fn test_shrink_collect_simple() {
                                     &ShrinkStats::default(),
                                 );
 
-                            let shrink_collect = db.shrink_collect::<AliveAccounts<'_>>(
+                            let shrink_collect = db.shrink_collect(
                                 &storage,
                                 &mut unique_accounts,
                                 &ShrinkStats::default(),
@@ -6214,11 +6208,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
     let mut unique_accounts =
         db.get_unique_accounts_from_storage_for_shrink(&storage, &ShrinkStats::default());
 
-    let shrink_collect = db.shrink_collect::<AliveAccounts<'_>>(
-        &storage,
-        &mut unique_accounts,
-        &ShrinkStats::default(),
-    );
+    let shrink_collect = db.shrink_collect(&storage, &mut unique_accounts, &ShrinkStats::default());
 
     assert_eq!(shrink_collect.slot, slot);
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -696,7 +696,7 @@ impl AccountsDb {
         let accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
-                self.shrink_collect::<AliveAccounts<'_>>(
+                self.shrink_collect(
                     &info.storage,
                     unique_accounts,
                     &self.shrink_ancient_stats.shrink_stats,


### PR DESCRIPTION
#### Problem
As of https://github.com/anza-xyz/agave/pull/15128, alive_accounts.add no longer uses the slot list parameter. This has a follow on effect that it now becomes pretty clear that load_accounts_index_for_shrink doesn't actually do anything other than verify the entries. 

#### Summary of Changes
- Remove unused parameter slot_list from shrink_collect add
- Change name of load_accounts_index_for_shrink to verify_accounts_index_for_shrink and some related changes.
- Remove the shrink collector trait as its no longer needed (only one implementation) and it doesn't collect. 


#### Testing


Fixes #
