### PR TITLE
Remove shrinking from squash

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -311,10 +311,8 @@ pub struct ShrinkAncientStats {
     pub slots_considered: AtomicU64,
     pub shrinks_bounded_by_max_cleaned_root: AtomicU64,
     pub bytes_ancient_created: AtomicU64,
-    pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
     pub bytes_from_newest_storages: AtomicU64,
-    pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
     pub slot: AtomicU64,
@@ -678,11 +676,6 @@ impl ShrinkAncientStats {
             ),
             ("random", self.random_shrink.swap(0, Ordering::Relaxed), i64),
             (
-                "slots_eligible_to_shrink",
-                self.slots_eligible_to_shrink.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "total_dead_bytes",
                 self.total_dead_bytes.swap(0, Ordering::Relaxed),
                 i64
@@ -712,11 +705,6 @@ impl ShrinkAncientStats {
             (
                 "bytes_ancient_created",
                 self.bytes_ancient_created.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "bytes_from_must_shrink",
-                self.bytes_from_must_shrink.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -34,12 +34,6 @@ const HIGH_SLOT_OFFSET: u64 = 100;
 /// ancient packing algorithm tuning per pass
 #[derive(Debug)]
 struct PackedAncientStorageTuning {
-    /// Shrink enough of these ancient append vecs to realize this
-    /// percentage of the total dead data that needs to be shrunk
-    /// - shrinking too much, burns too much time and disk i/o,
-    /// - shrinking too little could cause us to never catch up,
-    ///   and have old data accumulate.
-    percent_of_alive_shrunk_data: u64,
     /// number of ancient slots we should aim to have. If we have more than this, combine further.
     max_ancient_slots: usize,
     /// # of bytes in an ideal ancient storage size
@@ -152,7 +146,7 @@ impl AncientSlotInfos {
     ) {
         // figure out which slots to combine
         // 1. should_shrink: largest bytes saved above some cutoff of ratio
-        self.choose_storages_to_shrink(tuning);
+        self.choose_storages_to_shrink();
         // 2. smallest files so we get the largest number of files to remove
         self.filter_by_smallest_capacity(tuning, stats);
     }
@@ -181,20 +175,7 @@ impl AncientSlotInfos {
     }
 
     /// clear 'should_shrink' for storages after a cutoff to limit how many storages we shrink
-    fn clear_should_shrink_after_cutoff(&mut self, tuning: &PackedAncientStorageTuning) {
-        let mut bytes_to_shrink_due_to_ratio = Saturating(0);
-        // shrink enough slots to write 'percent_of_alive_shrunk_data'% of the total alive data
-        // from slots that exceeded the shrink threshold.
-        // The goal is to limit overall i/o in this pass while making progress.
-        // Simultaneously, we cannot allow the overall budget to be dominated by ancient storages that need to be shrunk.
-        // So, we have to limit how much of the total resulting budget can be allocated to re-packing/shrinking ancient storages.
-        let threshold_bytes =
-            (self.total_alive_bytes_shrink.0 * tuning.percent_of_alive_shrunk_data / 100).min(
-                u64::from(tuning.max_resulting_storages)
-                    * u64::from(tuning.ideal_storage_size)
-                    * tuning.percent_of_alive_shrunk_data
-                    / 100,
-            );
+    fn clear_should_shrink_after_cutoff(&mut self) {
         // At this point self.shrink_indexes have been sorted by the
         // largest amount of dead bytes first in the corresponding
         // storages.
@@ -203,26 +184,19 @@ impl AncientSlotInfos {
             let info = &mut self.all_infos[*info_index];
             self.best_slots_to_shrink
                 .push_back((info.slot, info.written_bytes));
-            if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
-                // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
-                // It MAY be shrunk based on total capacity still.
-                // Mark it as false for 'should_shrink' so it gets evaluated solely based on # of files.
-                info.should_shrink = false;
-            } else {
-                bytes_to_shrink_due_to_ratio += info.alive_bytes;
-            }
+            info.should_shrink = false;
         }
     }
 
     /// after this function, only slots that were chosen to shrink are marked with
     /// 'should_shrink'
     /// There are likely more candidates to shrink than will be chosen.
-    fn choose_storages_to_shrink(&mut self, tuning: &PackedAncientStorageTuning) {
+    fn choose_storages_to_shrink(&mut self) {
         // sort the shrink_ratio_slots by most bytes saved to fewest
         // most bytes saved is more valuable to shrink
         self.sort_shrink_indexes_by_bytes_saved();
 
-        self.clear_should_shrink_after_cutoff(tuning);
+        self.clear_should_shrink_after_cutoff();
     }
 
     /// truncate 'all_infos' such that when the remaining entries in
@@ -345,9 +319,6 @@ impl AccountsDb {
         let tuning = PackedAncientStorageTuning {
             // Slots old enough to be ancient.
             max_ancient_slots: self.max_ancient_storages,
-            // Don't re-pack anything just to shrink.
-            // shrink_candidate_slots will handle these old storages.
-            percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
             can_randomly_shrink,
             max_resulting_storages: NonZeroU64::new(10).unwrap(),
@@ -1585,7 +1556,6 @@ mod tests {
                 let high_slot = false;
                 let is_candidate_for_shrink = db.is_candidate_for_shrink(&storage);
                 let mut tuning = PackedAncientStorageTuning {
-                    percent_of_alive_shrunk_data: 100,
                     max_ancient_slots: 0,
                     // irrelevant for what this test is trying to test, but necessary to avoid minimums
                     ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
@@ -1664,7 +1634,6 @@ mod tests {
                 );
             } else {
                 let tuning = PackedAncientStorageTuning {
-                    percent_of_alive_shrunk_data: 100,
                     max_ancient_slots: 0,
                     // irrelevant for what this test is trying to test, but necessary to avoid minimums
                     ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
@@ -1684,7 +1653,6 @@ mod tests {
     fn test_calc_ancient_slot_info_several(accounts_db_config: AccountsDbConfig) {
         let can_randomly_shrink = false;
         let tuning = PackedAncientStorageTuning {
-            percent_of_alive_shrunk_data: 100,
             max_ancient_slots: 0,
             // irrelevant for what this test is trying to test, but necessary to avoid minimums
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
@@ -1805,7 +1773,6 @@ mod tests {
                         }
                         TestCollectInfo::CollectSortFilterInfo => {
                             let mut tuning = PackedAncientStorageTuning {
-                                percent_of_alive_shrunk_data: 100,
                                 max_ancient_slots: 0,
                                 // irrelevant
                                 ideal_storage_size: NonZeroU64::new(
@@ -1886,8 +1853,6 @@ mod tests {
                 let tuning = PackedAncientStorageTuning {
                     max_ancient_slots: max_storages,
                     ideal_storage_size: NonZeroU64::new(ideal_storage_size_large).unwrap(),
-                    // irrelevant since we clear 'shrink_indexes'
-                    percent_of_alive_shrunk_data: 0,
                     can_randomly_shrink: false,
                     ..default_tuning()
                 };
@@ -1935,8 +1900,6 @@ mod tests {
                 let tuning = PackedAncientStorageTuning {
                     max_ancient_slots: max_storages,
                     ideal_storage_size: NonZeroU64::new(ideal_storage_size_large).unwrap(),
-                    // irrelevant since we clear 'shrink_indexes'
-                    percent_of_alive_shrunk_data: 0,
                     can_randomly_shrink: false,
                     ..default_tuning()
                 };
@@ -2195,7 +2158,6 @@ mod tests {
     fn test_calc_ancient_slot_info_one_shrink_one_not(accounts_db_config: AccountsDbConfig) {
         let can_randomly_shrink = false;
         let mut tuning = PackedAncientStorageTuning {
-            percent_of_alive_shrunk_data: 100,
             max_ancient_slots: 0,
             // irrelevant for what this test is trying to test, but necessary to avoid minimums
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
@@ -2292,36 +2254,11 @@ mod tests {
 
     fn default_tuning() -> PackedAncientStorageTuning {
         PackedAncientStorageTuning {
-            percent_of_alive_shrunk_data: 0,
             max_ancient_slots: 0,
             ideal_storage_size: NonZeroU64::new(1).unwrap(),
             can_randomly_shrink: false,
             max_resulting_storages: NonZeroU64::new(10).unwrap(),
         }
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_clear_should_shrink_after_cutoff_empty(accounts_db_config: AccountsDbConfig) {
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
-        let mut infos = create_test_infos(&db, 2);
-        for count in 0..2 {
-            for i in 0..count {
-                infos.all_infos[i].should_shrink = true;
-            }
-        }
-        let tuning = PackedAncientStorageTuning {
-            max_ancient_slots: 100,
-            ..default_tuning()
-        };
-        infos.clear_should_shrink_after_cutoff(&tuning);
-        assert_eq!(
-            0,
-            infos
-                .all_infos
-                .iter()
-                .filter_map(|info| info.should_shrink.then_some(()))
-                .count()
-        );
     }
 
     #[derive(EnumIter, Debug, PartialEq, Eq)]
@@ -2474,102 +2411,6 @@ mod tests {
         }
     }
 
-    #[derive(EnumIter, Debug, PartialEq, Eq)]
-    enum TestShouldShrink {
-        FilterAncientSlots,
-        ClearShouldShrink,
-        ChooseStoragesToShrink,
-    }
-
-    #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_clear_should_shrink_after_cutoff_simple(accounts_db_config: AccountsDbConfig) {
-        for swap in [false, true] {
-            for method in TestShouldShrink::iter() {
-                for (percent_of_alive_shrunk_data, mut expected_infos) in
-                    [(0, 0), (9, 1), (10, 1), (89, 2), (90, 2), (91, 2), (100, 2)]
-                {
-                    let db = AccountsDb::new_for_tests_with_config(
-                        Vec::new(),
-                        accounts_db_config.clone(),
-                    );
-                    let mut infos = create_test_infos(&db, 2);
-                    infos
-                        .all_infos
-                        .iter_mut()
-                        .enumerate()
-                        .for_each(|(i, info)| {
-                            info.should_shrink = true;
-                            info.written_bytes = ((i + 1) * 1000) as u64;
-                        });
-                    infos.all_infos[0].alive_bytes = 100;
-                    infos.all_infos[1].alive_bytes = 900;
-                    if swap {
-                        infos.all_infos = infos.all_infos.into_iter().rev().collect();
-                    }
-                    infos.total_alive_bytes_shrink = Saturating(
-                        infos
-                            .all_infos
-                            .iter()
-                            .map(|info| info.alive_bytes)
-                            .sum::<u64>(),
-                    );
-                    let tuning = PackedAncientStorageTuning {
-                        percent_of_alive_shrunk_data,
-                        // 0 so that we combine everything with regard to the overall # of slots limit
-                        max_ancient_slots: 0,
-                        // irrelevant for what this test is trying to test, but necessary to avoid minimums
-                        ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity())
-                            .unwrap(),
-                        can_randomly_shrink: false,
-                        ..default_tuning()
-                    };
-                    match method {
-                        TestShouldShrink::FilterAncientSlots => {
-                            infos.filter_ancient_slots(&tuning, &ShrinkAncientStats::default());
-                        }
-                        TestShouldShrink::ClearShouldShrink => {
-                            infos.clear_should_shrink_after_cutoff(&tuning);
-                        }
-                        TestShouldShrink::ChooseStoragesToShrink => {
-                            infos.choose_storages_to_shrink(&tuning);
-                        }
-                    }
-
-                    if expected_infos == 2 {
-                        let modify = if method == TestShouldShrink::FilterAncientSlots {
-                            // filter_ancient_slots modifies in several ways and doesn't retain the values to compare
-                            percent_of_alive_shrunk_data == 89 || percent_of_alive_shrunk_data == 90
-                        } else {
-                            infos.all_infos[infos.shrink_indexes[0]].alive_bytes
-                                >= infos.total_alive_bytes_shrink.0 * percent_of_alive_shrunk_data
-                                    / 100
-                        };
-                        if modify {
-                            // if the sorting ends up putting the bigger alive_bytes storage first, then only 1 will be shrunk due to 'should_shrink'
-                            expected_infos = 1;
-                        }
-                    }
-                    let count = infos
-                        .all_infos
-                        .iter()
-                        .filter_map(|info| info.should_shrink.then_some(()))
-                        .count();
-                    assert_eq!(
-                        expected_infos,
-                        count,
-                        "percent_of_alive_shrunk_data: {percent_of_alive_shrunk_data}, infos: \
-                         {expected_infos}, method: {method:?}, swap: {swap}, data: {:?}",
-                        infos
-                            .all_infos
-                            .iter()
-                            .map(|info| (info.slot, info.written_bytes, info.alive_bytes))
-                            .collect::<Vec<_>>()
-                    );
-                }
-            }
-        }
-    }
-
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
     fn test_sort_shrink_indexes_by_bytes_saved(accounts_db_config: AccountsDbConfig) {
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
@@ -2632,7 +2473,6 @@ mod tests {
                 let original_results_all_accounts = vec_unique_to_accounts(&original_results, &db);
 
                 let tuning = PackedAncientStorageTuning {
-                    percent_of_alive_shrunk_data: 0,
                     max_ancient_slots,
                     can_randomly_shrink,
                     ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
@@ -2732,7 +2572,6 @@ mod tests {
         // combine normal append vec(s) into packed ancient append vec
         let tuning = PackedAncientStorageTuning {
             max_ancient_slots: 0,
-            percent_of_alive_shrunk_data: 0,
             ideal_storage_size: NonZeroU64::new(get_ancient_append_vec_capacity()).unwrap(),
             can_randomly_shrink: false,
             ..default_tuning()
@@ -2839,7 +2678,6 @@ mod tests {
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
     fn test_ideal_storage_size_updated_before_used(accounts_db_config: AccountsDbConfig) {
         let mut tuning = PackedAncientStorageTuning {
-            percent_of_alive_shrunk_data: 100,
             max_ancient_slots: 100,
             ..default_tuning()
         };

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -55,8 +55,6 @@ struct SlotInfo {
     written_bytes: u64,
     /// # alive bytes in storage *after* shrinking
     alive_bytes: u64,
-    /// true if this should be shrunk due to ratio
-    should_shrink: bool,
     /// this slot is a high slot #
     /// It is important to include some high slot #s so that we have new slots to try each time pack runs.
     is_high_slot: bool,
@@ -129,7 +127,6 @@ impl AncientSlotInfos {
                 written_bytes,
                 storage,
                 alive_bytes: alive_bytes_after_shrink,
-                should_shrink,
                 is_high_slot,
             });
             self.total_alive_bytes += alive_bytes_after_shrink;
@@ -145,9 +142,8 @@ impl AncientSlotInfos {
         stats: &ShrinkAncientStats,
     ) {
         // figure out which slots to combine
-        // 1. should_shrink: largest bytes saved above some cutoff of ratio
         self.choose_storages_to_shrink();
-        // 2. smallest files so we get the largest number of files to remove
+        // smallest files so we get the largest number of files to remove
         self.filter_by_smallest_capacity(tuning, stats);
     }
 
@@ -184,7 +180,6 @@ impl AncientSlotInfos {
             let info = &mut self.all_infos[*info_index];
             self.best_slots_to_shrink
                 .push_back((info.slot, info.written_bytes));
-            info.should_shrink = false;
         }
     }
 
@@ -213,7 +208,6 @@ impl AncientSlotInfos {
         let total_storages = self.all_infos.len();
         let mut cumulative_bytes = Saturating(0u64);
         let low_threshold = tuning.max_ancient_slots * 50 / 100;
-        let mut bytes_from_must_shrink = 0;
         let mut bytes_from_smallest_storages = 0;
         let mut bytes_from_newest_storages = 0;
         for (i, info) in self.all_infos.iter().enumerate() {
@@ -238,17 +232,12 @@ impl AncientSlotInfos {
                 self.all_infos.truncate(i);
                 break;
             }
-            if info.should_shrink {
-                bytes_from_must_shrink += info.alive_bytes;
-            } else if info.is_high_slot {
+            if info.is_high_slot {
                 bytes_from_newest_storages += info.alive_bytes;
             } else {
                 bytes_from_smallest_storages += info.alive_bytes;
             }
         }
-        stats
-            .bytes_from_must_shrink
-            .fetch_add(bytes_from_must_shrink, Ordering::Relaxed);
         stats
             .bytes_from_smallest_storages
             .fetch_add(bytes_from_smallest_storages, Ordering::Relaxed);
@@ -280,12 +269,10 @@ impl AncientSlotInfos {
         // sort by:
         // 1. `high_slot`: we want to include new, high slots each time so that we try new slots
         //     each time alg runs and have several high target slots for packed storages.
-        // 2. 'should_shrink' so we make progress on shrinking ancient storages
-        // 3. smallest capacity to largest so that we remove the most slots possible
+        // 2. smallest capacity to largest so that we remove the most slots possible
         self.all_infos.sort_unstable_by(|l, r| {
             r.is_high_slot
                 .cmp(&l.is_high_slot)
-                .then_with(|| r.should_shrink.cmp(&l.should_shrink))
                 .then_with(|| l.written_bytes.cmp(&r.written_bytes))
         });
 
@@ -504,19 +491,10 @@ impl AccountsDb {
         }
         let mut total_dead_bytes = 0;
         let mut total_alive_bytes = 0;
-        let should_shrink_count = infos
-            .all_infos
-            .iter()
-            .filter(|info| info.should_shrink)
-            .map(|info| {
-                total_dead_bytes += info.written_bytes.saturating_sub(info.alive_bytes);
-                total_alive_bytes += info.alive_bytes;
-            })
-            .count()
-            .saturating_sub(randoms as usize);
-        self.shrink_ancient_stats
-            .slots_eligible_to_shrink
-            .fetch_add(should_shrink_count as u64, Ordering::Relaxed);
+        infos.all_infos.iter().for_each(|info| {
+            total_dead_bytes += info.written_bytes.saturating_sub(info.alive_bytes);
+            total_alive_bytes += info.alive_bytes;
+        });
         self.shrink_ancient_stats
             .total_dead_bytes
             .fetch_add(total_dead_bytes, Ordering::Relaxed);
@@ -886,7 +864,6 @@ mod tests {
                 slot: storage.slot(),
                 written_bytes: 0,
                 alive_bytes: 0,
-                should_shrink: false,
                 is_high_slot,
             })
             .collect();
@@ -1509,7 +1486,6 @@ mod tests {
                         info.slot,
                         info.written_bytes,
                         info.alive_bytes,
-                        info.should_shrink,
                     )
                 };
                 assert_eq!(
@@ -1523,12 +1499,11 @@ mod tests {
         }
     }
 
-    fn assert_storage_info(info: &SlotInfo, storage: &AccountStorageEntry, should_shrink: bool) {
+    fn assert_storage_info(info: &SlotInfo, storage: &AccountStorageEntry) {
         assert_eq!(storage.id(), info.storage.id());
         assert_eq!(storage.slot(), info.slot);
         assert_eq!(storage.written_bytes(), info.written_bytes);
         assert_eq!(storage.alive_bytes(), info.alive_bytes as usize);
-        assert_eq!(should_shrink, info.should_shrink);
     }
 
     #[derive(EnumIter, Debug, PartialEq, Eq)]
@@ -1583,28 +1558,11 @@ mod tests {
                     }
                 }
                 assert_eq!(infos.all_infos.len(), 1, "{method:?}");
-                let should_shrink = db.is_candidate_for_shrink(&storage);
-                assert_storage_info(infos.all_infos.first().unwrap(), &storage, should_shrink);
-                if should_shrink {
-                    // data size is so small compared to min aligned file size that the storage is marked as should_shrink
-                    assert_eq!(
-                        infos.shrink_indexes,
-                        if !matches!(method, TestCollectInfo::CollectSortFilterInfo) {
-                            vec![0]
-                        } else {
-                            Vec::default()
-                        }
-                    );
-                    assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected as u64);
-                    assert_eq!(
-                        infos.total_alive_bytes_shrink.0,
-                        alive_bytes_expected as u64
-                    );
-                } else {
-                    assert!(infos.shrink_indexes.is_empty());
-                    assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected as u64);
-                    assert_eq!(infos.total_alive_bytes_shrink.0, 0);
-                }
+                assert_storage_info(infos.all_infos.first().unwrap(), &storage);
+
+                assert!(infos.shrink_indexes.is_empty());
+                assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected as u64);
+                assert_eq!(infos.total_alive_bytes_shrink.0, 0);
             }
         }
     }
@@ -1690,28 +1648,10 @@ mod tests {
                             .iter()
                             .zip(infos.all_infos.iter())
                             .for_each(|(storage, info)| {
-                                let should_shrink = db.is_candidate_for_shrink(storage);
-                                assert_storage_info(info, storage, should_shrink);
-                                if should_shrink {
-                                    // data size is so small compared to min aligned file size that the storage is marked as should_shrink
-                                    assert_eq!(
-                                        infos.shrink_indexes,
-                                        slot_vec
-                                            .iter()
-                                            .enumerate()
-                                            .map(|(i, _)| i)
-                                            .collect::<Vec<_>>()
-                                    );
-                                    assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                                    assert_eq!(
-                                        infos.total_alive_bytes_shrink.0,
-                                        alive_bytes_expected
-                                    );
-                                } else {
-                                    assert!(infos.shrink_indexes.is_empty());
-                                    assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                                    assert_eq!(infos.total_alive_bytes_shrink.0, 0);
-                                }
+                                assert_storage_info(info, storage);
+                                assert!(infos.shrink_indexes.is_empty());
+                                assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
+                                assert_eq!(infos.total_alive_bytes_shrink.0, 0);
                             });
                     }
                 }
@@ -1788,25 +1728,10 @@ mod tests {
                     assert_eq!(infos.all_infos.len(), 1, "method: {method:?}");
                     alive_storages.iter().zip(infos.all_infos.iter()).for_each(
                         |(storage, info)| {
-                            let should_shrink = db.is_candidate_for_shrink(storage);
-                            assert_storage_info(info, storage, should_shrink);
-                            if should_shrink {
-                                // data size is so small compared to min aligned file size that the storage is marked as should_shrink
-                                assert_eq!(
-                                    infos.shrink_indexes,
-                                    if !matches!(method, TestCollectInfo::CollectSortFilterInfo) {
-                                        vec![0]
-                                    } else {
-                                        Vec::default()
-                                    }
-                                );
-                                assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                                assert_eq!(infos.total_alive_bytes_shrink.0, alive_bytes_expected);
-                            } else {
-                                assert!(infos.shrink_indexes.is_empty());
-                                assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                                assert_eq!(infos.total_alive_bytes_shrink.0, 0);
-                            }
+                            assert_storage_info(info, storage);
+                            assert!(infos.shrink_indexes.is_empty());
+                            assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
+                            assert_eq!(infos.total_alive_bytes_shrink.0, 0);
                         },
                     );
                 }
@@ -1826,7 +1751,6 @@ mod tests {
                     slot: index as Slot,
                     written_bytes: 1,
                     alive_bytes: 1,
-                    should_shrink: false,
                     is_high_slot: false,
                 })
                 .collect(),
@@ -2232,7 +2156,6 @@ mod tests {
                             .any(|info| info.slot == storage.slot())
                     );
                 });
-                // data size is so small compared to min aligned file size that the storage is marked as should_shrink
                 assert_eq!(
                     infos.shrink_indexes,
                     match method {
@@ -2428,7 +2351,6 @@ mod tests {
                 slot,
                 written_bytes: info1_written_bytes,
                 alive_bytes: 0,
-                should_shrink: false,
                 is_high_slot: false,
             };
             let info2 = SlotInfo {
@@ -2436,7 +2358,6 @@ mod tests {
                 slot,
                 written_bytes: 2,
                 alive_bytes: 1,
-                should_shrink: false,
                 is_high_slot: false,
             };
             let mut infos = AncientSlotInfos {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -170,28 +170,19 @@ impl AncientSlotInfos {
         });
     }
 
-    /// clear 'should_shrink' for storages after a cutoff to limit how many storages we shrink
-    fn clear_should_shrink_after_cutoff(&mut self) {
-        // At this point self.shrink_indexes have been sorted by the
-        // largest amount of dead bytes first in the corresponding
-        // storages.
-        self.best_slots_to_shrink = VecDeque::with_capacity(self.shrink_indexes.len());
-        for info_index in &self.shrink_indexes {
-            let info = &mut self.all_infos[*info_index];
-            self.best_slots_to_shrink
-                .push_back((info.slot, info.written_bytes));
-        }
-    }
-
-    /// after this function, only slots that were chosen to shrink are marked with
-    /// 'should_shrink'
-    /// There are likely more candidates to shrink than will be chosen.
+    /// record the storages to shrink in 'best_slots_to_shrink', most bytes saved to fewest
     fn choose_storages_to_shrink(&mut self) {
-        // sort the shrink_ratio_slots by most bytes saved to fewest
         // most bytes saved is more valuable to shrink
         self.sort_shrink_indexes_by_bytes_saved();
 
-        self.clear_should_shrink_after_cutoff();
+        self.best_slots_to_shrink = self
+            .shrink_indexes
+            .iter()
+            .map(|info_index| {
+                let info = &self.all_infos[*info_index];
+                (info.slot, info.written_bytes)
+            })
+            .collect();
     }
 
     /// truncate 'all_infos' such that when the remaining entries in

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -69,8 +69,6 @@ struct AncientSlotInfos {
     /// indexes to 'all_info' for storages that should be shrunk because alive ratio is too low.
     /// subset of all_infos
     shrink_indexes: Vec<usize>,
-    /// total alive bytes across contents of 'shrink_indexes'
-    total_alive_bytes_shrink: Saturating<u64>,
     /// total alive bytes across all slots
     total_alive_bytes: Saturating<u64>,
     /// slots that have dead accounts and thus the corresponding slot
@@ -111,9 +109,6 @@ impl AncientSlotInfos {
             // 2. # of active ancient roots, so that we don't consume too many open file handles
 
             if should_shrink {
-                // alive ratio is too low, so prioritize combining this slot with others
-                // to reduce disk space used
-                self.total_alive_bytes_shrink += alive_bytes_after_shrink;
                 self.shrink_indexes.push(self.all_infos.len());
             } else {
                 let already_ideal_size = u64::from(ideal_size) * 80 / 100;
@@ -1553,7 +1548,6 @@ mod tests {
 
                 assert!(infos.shrink_indexes.is_empty());
                 assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected as u64);
-                assert_eq!(infos.total_alive_bytes_shrink.0, 0);
             }
         }
     }
@@ -1594,7 +1588,6 @@ mod tests {
             assert!(infos.all_infos.is_empty());
             assert!(infos.shrink_indexes.is_empty());
             assert_eq!(infos.total_alive_bytes.0, 0);
-            assert_eq!(infos.total_alive_bytes_shrink.0, 0);
         }
     }
 
@@ -1632,7 +1625,6 @@ mod tests {
                         assert!(infos.all_infos.is_empty());
                         assert!(infos.shrink_indexes.is_empty());
                         assert_eq!(infos.total_alive_bytes.0, 0);
-                        assert_eq!(infos.total_alive_bytes_shrink.0, 0);
                     } else {
                         assert_eq!(infos.all_infos.len(), slots);
                         storages
@@ -1642,7 +1634,6 @@ mod tests {
                                 assert_storage_info(info, storage);
                                 assert!(infos.shrink_indexes.is_empty());
                                 assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                                assert_eq!(infos.total_alive_bytes_shrink.0, 0);
                             });
                     }
                 }
@@ -1722,7 +1713,6 @@ mod tests {
                             assert_storage_info(info, storage);
                             assert!(infos.shrink_indexes.is_empty());
                             assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                            assert_eq!(infos.total_alive_bytes_shrink.0, 0);
                         },
                     );
                 }
@@ -2161,7 +2151,6 @@ mod tests {
                     }
                 );
                 assert_eq!(infos.total_alive_bytes.0, alive_bytes_expected);
-                assert_eq!(infos.total_alive_bytes_shrink.0, alive_bytes_expected);
             }
         }
     }


### PR DESCRIPTION
#### Problem
Currently squash (or ancient shrink) has the capability of prioritizing by amount of data shrunk. Currently this is not used. Architecturally squash and shrink should be separate activities, as they have separate purposes: Shrink saves space, and squash saves file handles. 

#### Summary of Changes
4 Commits
1. Remove percent_of_alive_shrunk_data, assuming it is always 0 now (as has been the case in production)
2. Remove should_shrink flag from accounts, as it is no longer used now
3. Remove remaining references to should_shrink
4. Remove deprecated stats.

#### Testing
Receipts:
<img width="1647" height="577" alt="image" src="https://github.com/user-attachments/assets/e3b89f9f-6077-4316-99fd-82727a8d9c61" />



Fixes #
