### PR TITLE
accounts-db: Moves account storage reader impl into append vec

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        account_info::Offset, account_storage_entry::AccountStorageEntry,
-        accounts_file::OpenFileForArchive,
+        account_storage_entry::AccountStorageEntry,
+        accounts_file::{AccountsFileReaderForArchiving, OpenFileForArchive},
     },
     agave_fs::{
         buffered_reader::{self, FileBufRead},
@@ -79,10 +79,7 @@ pub enum TombstonesFilter {
 /// via `set_file` (typically using a file opened with [`open_storage_files`])
 /// before constructing the reader.
 pub struct AccountStorageReader<'r, R> {
-    sorted_excluded_accounts: Vec<(Offset, usize)>,
-    reader: &'r mut R,
-    num_alive_bytes: usize,
-    num_total_bytes: usize,
+    reader: AccountsFileReaderForArchiving<'r, R>,
 }
 
 impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'r, R> {
@@ -97,47 +94,26 @@ impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'r, R> {
         tombstones_filter: TombstonesFilter,
         file_reader: &'r mut R,
     ) -> io::Result<Self> {
-        let num_total_bytes = storage.accounts.len();
-        let mut num_alive_bytes = num_total_bytes - storage.get_obsolete_bytes(snapshot_slot);
-
-        let mut sorted_excluded_accounts: Vec<_> = storage
+        let mut excluded_accounts: Vec<_> = storage
             .obsolete_accounts_read_lock()
             .filter_obsolete_accounts(snapshot_slot)
             .collect();
 
-        // Convert the length to the size
-        sorted_excluded_accounts
-            .iter_mut()
-            .for_each(|(_offset, len)| {
-                *len = storage.accounts.calculate_stored_size(*len);
-            });
-
         if tombstones_filter == TombstonesFilter::Exclude {
-            // Tombstones are zero-lamport accounts, which store no data, so every
-            // tombstone record has the fixed stored size of a data-less account.
-            let tombstone_stored_size = storage.accounts.calculate_stored_size(0);
             let tombstone_offsets = storage.tombstone_offsets_read_lock();
-            num_alive_bytes -= tombstone_offsets.len() * tombstone_stored_size;
-            sorted_excluded_accounts.extend(
-                tombstone_offsets
-                    .iter()
-                    .map(|offset| (*offset, tombstone_stored_size)),
-            );
+            // Tombstones are zero-lamport accounts, which store no data.
+            excluded_accounts.extend(tombstone_offsets.iter().map(|offset| (*offset, 0)));
         }
 
-        sorted_excluded_accounts
-            .sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
-
         Ok(Self {
-            sorted_excluded_accounts,
-            reader: file_reader,
-            num_alive_bytes,
-            num_total_bytes,
+            reader: storage
+                .accounts
+                .reader_for_archiving(excluded_accounts, file_reader),
         })
     }
 
     pub fn len(&self) -> usize {
-        self.num_alive_bytes
+        self.reader.len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -147,43 +123,7 @@ impl<'a, 'r, R: FileBufRead<'a>> AccountStorageReader<'r, R> {
 
 impl<'a, R: FileBufRead<'a>> Read for AccountStorageReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut total_read = 0;
-        let buf_len = buf.len();
-
-        while total_read < buf_len {
-            let next_excluded_account = self.sorted_excluded_accounts.last();
-            let file_offset = self.reader.get_file_offset();
-            if let Some(&(excluded_start, excluded_size)) = next_excluded_account
-                && file_offset == excluded_start
-            {
-                let skip_len = excluded_size.min(self.num_total_bytes - excluded_start as usize);
-                self.reader.consume_or_skip(skip_len);
-                self.sorted_excluded_accounts.pop();
-                continue;
-            }
-
-            // Cannot read beyond the end of the buffer
-            let bytes_left_in_buffer = buf_len.saturating_sub(total_read);
-
-            // Cannot read beyond the next excluded account or the end of the file
-            let bytes_to_read_from_file = if let Some((excluded_start, _)) = next_excluded_account {
-                excluded_start.saturating_sub(file_offset) as usize
-            } else {
-                self.num_total_bytes.saturating_sub(file_offset as usize)
-            };
-
-            let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
-
-            let read_size = self.reader.read(&mut buf[total_read..][..bytes_to_read])?;
-
-            if read_size == 0 {
-                break; // EOF
-            }
-
-            total_read += read_size;
-        }
-
-        Ok(total_read)
+        self.reader.read(buf)
     }
 }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -3,16 +3,20 @@ use {
         account_info::Offset,
         account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_db::AccountsFileId,
-        append_vec::{AppendVec, AppendVecError},
+        append_vec::{AppendVec, AppendVecError, AppendVecReaderForArchiving},
         storable_accounts::StorableAccounts,
     },
-    agave_fs::{FileInfo, buffered_reader::RequiredLenBufFileRead, file_io::open_for_reading},
+    agave_fs::{
+        FileInfo,
+        buffered_reader::{FileBufRead, RequiredLenBufFileRead},
+        file_io::open_for_reading,
+    },
     solana_account::AccountSharedData,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
     std::{
         fs::File,
-        io,
+        io::{self, Read},
         iter::ExactSizeIterator,
         mem,
         path::{Path, PathBuf},
@@ -255,6 +259,41 @@ impl AccountsFile {
             Ok(match self {
                 Self::AppendVec(av) => av.open_file_for_archive(),
             })
+        }
+    }
+
+    pub(crate) fn reader_for_archiving<'a, 'r, R: FileBufRead<'a>>(
+        &self,
+        excluded_accounts: Vec<(Offset, /*data len*/ usize)>,
+        reader: &'r mut R,
+    ) -> AccountsFileReaderForArchiving<'r, R> {
+        match self {
+            Self::AppendVec(av) => AccountsFileReaderForArchiving::AppendVec(
+                av.reader_for_archiving(excluded_accounts, reader),
+            ),
+        }
+    }
+}
+
+/// A reader for archiving an AccountsFile.
+pub(crate) enum AccountsFileReaderForArchiving<'r, R> {
+    AppendVec(AppendVecReaderForArchiving<'r, R>),
+}
+
+impl<R> AccountsFileReaderForArchiving<'_, R> {
+    /// Returns the number of bytes to archive.
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::AppendVec(reader) => reader.len(),
+        }
+    }
+}
+
+impl<'a, R: FileBufRead<'a>> Read for AccountsFileReaderForArchiving<'_, R> {
+    /// Reads from this AccountsFile for archiving.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::AppendVec(reader) => reader.read(buf),
         }
     }
 }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -21,7 +21,7 @@ use {
     agave_fs::{
         FileInfo, FileSize,
         buffered_reader::{
-            BufReaderWithOverflow, BufferedReader, FileBufRead as _, RequiredLenBufFileRead,
+            BufReaderWithOverflow, BufferedReader, FileBufRead, RequiredLenBufFileRead,
             RequiredLenBufRead as _,
         },
         file_io::{read_into_buffer, write_buffer_to_file},
@@ -32,10 +32,10 @@ use {
     solana_pubkey::Pubkey,
     solana_system_interface::MAX_PERMITTED_DATA_LENGTH,
     std::{
-        self,
+        self, cmp,
         convert::TryFrom,
         fs::{File, OpenOptions, remove_file},
-        io,
+        io::{self, Read},
         iter::ExactSizeIterator,
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
@@ -1055,6 +1055,104 @@ impl AppendVec {
     pub(crate) fn open_file_for_archive(&self) -> OpenFileForArchive<'_> {
         OpenFileForArchive::Borrowed(&self.file)
     }
+
+    /// Creates a new reader for archiving this AppendVec.
+    pub(crate) fn reader_for_archiving<'a, 'r, R: FileBufRead<'a>>(
+        &self,
+        mut excluded_accounts: Vec<(FileOffset, /*data len*/ usize)>,
+        reader: &'r mut R,
+    ) -> AppendVecReaderForArchiving<'r, R> {
+        let num_total_bytes = self.len();
+        let mut num_alive_bytes = num_total_bytes;
+        excluded_accounts.sort_unstable_by(|(a_offset, _), (b_offset, _)| b_offset.cmp(a_offset));
+        let sorted_excluded_accounts = excluded_accounts
+            .into_iter()
+            .map(|(offset, data_len)| {
+                let stored_size = cmp::min(
+                    Self::calculate_stored_size(data_len),
+                    num_total_bytes - offset as usize,
+                );
+                num_alive_bytes -= stored_size;
+                ExcludedAccount {
+                    offset,
+                    stored_size,
+                }
+            })
+            .collect();
+
+        AppendVecReaderForArchiving {
+            sorted_excluded_accounts,
+            reader,
+            num_alive_bytes,
+            num_total_bytes,
+        }
+    }
+}
+
+/// A reader for archiving an AppendVec.
+pub(crate) struct AppendVecReaderForArchiving<'r, R> {
+    sorted_excluded_accounts: Vec<ExcludedAccount>,
+    reader: &'r mut R,
+    num_alive_bytes: usize,
+    num_total_bytes: usize,
+}
+
+impl<R> AppendVecReaderForArchiving<'_, R> {
+    /// Returns the number of bytes to archive.
+    pub(crate) fn len(&self) -> usize {
+        self.num_alive_bytes
+    }
+}
+
+impl<'a, R: FileBufRead<'a>> Read for AppendVecReaderForArchiving<'_, R> {
+    /// Reads from this AppendVec for archiving.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut total_read = 0;
+        let buf_len = buf.len();
+
+        while total_read < buf_len {
+            let next_excluded_account = self.sorted_excluded_accounts.last();
+            let file_offset = self.reader.get_file_offset();
+            if let Some(excluded_account) = next_excluded_account
+                && file_offset == excluded_account.offset
+            {
+                let skip_len = excluded_account
+                    .stored_size
+                    .min(self.num_total_bytes - excluded_account.offset as usize);
+                self.reader.consume_or_skip(skip_len);
+                self.sorted_excluded_accounts.pop();
+                continue;
+            }
+
+            // Cannot read beyond the end of the buffer
+            let bytes_left_in_buffer = buf_len.saturating_sub(total_read);
+
+            // Cannot read beyond the next excluded account or the end of the file
+            let bytes_to_read_from_file = if let Some(excluded_account) = next_excluded_account {
+                excluded_account.offset.saturating_sub(file_offset) as usize
+            } else {
+                self.num_total_bytes.saturating_sub(file_offset as usize)
+            };
+            let bytes_to_read = bytes_left_in_buffer.min(bytes_to_read_from_file);
+            let read_size = self.reader.read(&mut buf[total_read..][..bytes_to_read])?;
+
+            if read_size == 0 {
+                break; // EOF
+            }
+            total_read += read_size;
+        }
+
+        Ok(total_read)
+    }
+}
+
+/// An account to exclude from archiving.
+#[derive(Debug)]
+struct ExcludedAccount {
+    /// file offset of the account to exclude.
+    offset: FileOffset,
+    /// stored size of the account to exclude.
+    stored_size: usize,
 }
 
 /// Create a reusable buffered reader tuned for scanning storages with account data.


### PR DESCRIPTION
#### Problem

The AccountStorageReader has details of append vec hard coded into it. This will become an issue when adding support for the split accounts file format.


#### Summary of Changes

Moves the internals of AccountStorageReader into AppendVec, which then has a method in AccountsFile too.

The code itself shouldn't have changed beyond some formatting, comments, names, and a new ExcludedAccount struct.


#### Testing

Nothing additional.