### PR TITLE
fix: report streamer::receiver metrics using a thread every 2s

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -40,6 +40,8 @@ use {
     },
 };
 
+const SUBMIT_ANCESTOR_HASHES_STATS_INTERVAL: Duration = Duration::from_secs(2);
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum AncestorHashesReplayUpdate {
     Dead(Slot),
@@ -164,6 +166,8 @@ impl AncestorHashesService {
             info!("Alpenglow enabled, not starting AncestorHashesService");
             return None;
         }
+        let receiver_stats =
+            Arc::new(StreamerReceiveStats::new("ancestor_hashes_response_receiver"));
         let outstanding_requests = Arc::<RwLock<OutstandingAncestorHashesRepairs>>::default();
         let (response_sender, response_receiver) = bounded(RESPONSE_CHANNEL_SIZE);
         let t_receiver = streamer::receiver(
@@ -171,9 +175,7 @@ impl AncestorHashesService {
             ancestor_hashes_request_socket.clone(),
             exit.clone(),
             response_sender.clone(),
-            Arc::new(StreamerReceiveStats::new(
-                "ancestor_hashes_response_receiver",
-            )),
+            receiver_stats.clone(),
             Some(Duration::from_millis(1)), // coalesce
             false,                          // is_staked_service
         );
@@ -206,12 +208,23 @@ impl AncestorHashesService {
             ancestor_hashes_request_socket,
             repair_info,
             outstanding_requests,
-            exit,
+            exit.clone(),
             ancestor_hashes_replay_update_receiver,
             retryable_slots_receiver,
         );
+
+        let t_metrics = Builder::new()
+            .name("solAncHashMetr".to_string())
+            .spawn(move || {
+                while !exit.load(Ordering::Relaxed) {
+                    sleep(SUBMIT_ANCESTOR_HASHES_STATS_INTERVAL);
+                    receiver_stats.report();
+                }
+            })
+            .unwrap();
+
         Some(Self {
-            thread_hdls: vec![t_receiver, t_ancestor_hashes_responses, t_ancestor_requests],
+            thread_hdls: vec![t_receiver, t_ancestor_hashes_responses, t_ancestor_requests, t_metrics],
         })
     }
 
@@ -1219,6 +1232,7 @@ mod test {
     struct ResponderThreads {
         t_request_receiver: JoinHandle<()>,
         t_listen: JoinHandle<()>,
+        t_metrics: JoinHandle<()>,
         exit: Arc<AtomicBool>,
         responder_info: ContactInfo,
         response_receiver: PacketBatchReceiver,
@@ -1230,6 +1244,7 @@ mod test {
             self.exit.store(true, Ordering::Relaxed);
             self.t_request_receiver.join().unwrap();
             self.t_listen.join().unwrap();
+            self.t_metrics.join().unwrap();
         }
 
         fn new(slot_to_query: Slot) -> Self {
@@ -1280,21 +1295,34 @@ mod test {
             }
 
             // Set up repair request receiver threads
+            let receiver_stats = Arc::new(StreamerReceiveStats::new("repair_request_receiver"));
             let t_request_receiver = streamer::receiver(
                 "solRcvrTest".to_string(),
                 Arc::new(responder_node.sockets.serve_repair),
                 exit.clone(),
                 requests_sender,
-                Arc::new(StreamerReceiveStats::new("repair_request_receiver")),
+                receiver_stats.clone(),
                 Some(Duration::from_millis(1)), // coalesce
                 false,
             );
             let t_listen =
                 responder_serve_repair.listen(requests_receiver, response_sender, exit.clone());
 
+            let exit_flag = exit.clone();
+            let t_metrics = Builder::new()
+                .name("solRcvrTestMetr".to_string())
+                .spawn(move || {
+                    while !exit_flag.load(Ordering::Relaxed) {
+                        sleep(SUBMIT_ANCESTOR_HASHES_STATS_INTERVAL);
+                        receiver_stats.report();
+                    }
+                })
+                .unwrap();
+
             Self {
                 t_request_receiver,
                 t_listen,
+                t_metrics,
                 exit,
                 responder_info: responder_node.info,
                 response_receiver,

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -57,7 +57,7 @@ use {
             Arc, RwLock,
             atomic::{AtomicBool, Ordering},
         },
-        thread::{self, Builder, JoinHandle},
+        thread::{self, sleep, Builder, JoinHandle},
         time::{Duration, Instant},
     },
 };
@@ -77,6 +77,8 @@ const IDLE_TICK: Duration = Duration::from_millis(10);
 const RESPONSE_CHANNEL_SIZE: usize = SHRED_FETCH_CHANNEL_SIZE / DATA_SHREDS_PER_FEC_BLOCK;
 /// Roughly 1/32th of shred sigverify, amortizes overhead without starving processing
 const SOFT_RECEIVE_CAP: usize = 192;
+
+const SUBMIT_BLOCK_ID_REPAIR_STATS_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The type of messages that this service will send
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -260,6 +262,10 @@ impl BlockIdRepairService {
         repair_info: RepairInfo,
         outstanding_shred_requests: Arc<RwLock<OutstandingShredRepairs>>,
     ) -> Self {
+        let receiver_stats = Arc::new(StreamerReceiveStats::new(
+            "block_id_repair_response_receiver",
+        ));
+
         let (response_sender, response_receiver) =
             EvictingSender::new_bounded(RESPONSE_CHANNEL_SIZE);
 
@@ -269,15 +275,13 @@ impl BlockIdRepairService {
             block_id_repair_socket.clone(),
             exit.clone(),
             response_sender,
-            Arc::new(StreamerReceiveStats::new(
-                "block_id_repair_response_receiver",
-            )),
+            receiver_stats.clone(),
             None,  // coalesce
             false, // is_staked_service
         );
 
         let t_block_id_repair = Self::run(BlockIdRepairContext {
-            exit,
+            exit: exit.clone(),
             response_receiver,
             channels: block_id_repair_channels,
             blockstore,
@@ -289,8 +293,18 @@ impl BlockIdRepairService {
             outstanding_shred_requests,
         });
 
+        let t_metrics = Builder::new()
+            .name("solBlockIdMetr".to_string())
+            .spawn(move || {
+                while !exit.load(Ordering::Relaxed) {
+                    sleep(SUBMIT_BLOCK_ID_REPAIR_STATS_INTERVAL);
+                    receiver_stats.report();
+                }
+            })
+            .unwrap();
+
         Self {
-            thread_hdls: vec![t_receiver, t_block_id_repair],
+            thread_hdls: vec![t_receiver, t_block_id_repair, t_metrics],
         }
     }
 

--- a/core/src/repair/serve_repair_service.rs
+++ b/core/src/repair/serve_repair_service.rs
@@ -13,11 +13,16 @@ use {
     },
     std::{
         net::UdpSocket,
-        sync::{Arc, atomic::AtomicBool},
-        thread::{self, Builder, JoinHandle},
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread::{self, sleep, Builder, JoinHandle},
         time::Duration,
     },
 };
+
+const SUBMIT_SERVE_REPAIR_STATS_INTERVAL: Duration = Duration::from_secs(2);
 
 pub struct ServeRepairService {
     thread_hdls: Vec<JoinHandle<()>>,
@@ -37,6 +42,7 @@ impl ServeRepairService {
         stats_reporter_sender: Sender<Box<dyn FnOnce() + Send>>,
         exit: Arc<AtomicBool>,
     ) -> Self {
+        let receiver_stats = Arc::new(StreamerReceiveStats::new("serve_repair_receiver"));
         let (request_sender, request_receiver) = EvictingSender::new_bounded(REQUEST_CHANNEL_SIZE);
         let serve_repair_socket = Arc::new(serve_repair_socket);
         let t_receiver = streamer::receiver(
@@ -44,7 +50,7 @@ impl ServeRepairService {
             serve_repair_socket.clone(),
             exit.clone(),
             request_sender,
-            Arc::new(StreamerReceiveStats::new("serve_repair_receiver")),
+            receiver_stats.clone(),
             Some(Duration::from_millis(1)), // coalesce
             false,                          // is_staked_service
         );
@@ -56,9 +62,19 @@ impl ServeRepairService {
             socket_addr_space,
             Some(stats_reporter_sender),
         );
-        let t_listen = serve_repair.listen(request_receiver, response_sender, exit);
+        let t_listen = serve_repair.listen(request_receiver, response_sender, exit.clone());
 
-        let thread_hdls = vec![t_receiver, t_responder, t_listen];
+        let t_metrics = Builder::new()
+            .name("solServeRepMetr".to_string())
+            .spawn(move || {
+                while !exit.load(Ordering::Relaxed) {
+                    sleep(SUBMIT_SERVE_REPAIR_STATS_INTERVAL);
+                    receiver_stats.report();
+                }
+            })
+            .unwrap();
+
+        let thread_hdls = vec![t_receiver, t_responder, t_listen, t_metrics];
         Self { thread_hdls }
     }
 


### PR DESCRIPTION
#### Problem
There is no reporting action within streamer::receiver function, which may lead to metrics loss. So, a separate thread has been added for metrics reporting.

#### Summary of Changes
core/src/repair/ancestor_hashes_service.rs
core/src/repair/block_id_repair_service.rs
core/src/repair/serve_repair_service.rs

issue:  
Fixes: #14950

