### PR TITLE
bls-sigverify: do not keep looking up my_pubkey

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -207,8 +207,11 @@ impl SigVerifier {
                 continue;
             }
 
-            let (verify_res, verify_time_us) =
-                measure_us!(self.verify_and_send_inputs(&datagrams_buffer, certificates));
+            let (verify_res, verify_time_us) = measure_us!(self.verify_and_send_inputs(
+                &self.cluster_info.id(),
+                &datagrams_buffer,
+                certificates
+            ));
             self.stats
                 .verify_and_send_batch_us
                 .add_sample(verify_time_us);
@@ -228,19 +231,24 @@ impl SigVerifier {
         &mut self,
         datagrams: Vec<Datagram>,
     ) -> Result<(), SigVerifyError> {
-        self.verify_and_send_inputs(&datagrams, vec![])
+        self.verify_and_send_inputs(&self.cluster_info.id(), &datagrams, vec![])
     }
 
     fn verify_and_send_inputs(
         &mut self,
+        my_pubkey: &Pubkey,
         datagrams: &[Datagram],
         certificates: Vec<(Slot, UnverifiedCertificate)>,
     ) -> Result<(), SigVerifyError> {
         let root_bank = self.sharable_banks.root();
         self.maybe_prune_caches(&root_bank);
 
-        let (extracted_msgs, extract_msgs_us) =
-            measure_us!(self.extract_and_filter_msgs(datagrams, certificates, &root_bank));
+        let (extracted_msgs, extract_msgs_us) = measure_us!(self.extract_and_filter_msgs(
+            my_pubkey,
+            datagrams,
+            certificates,
+            &root_bank
+        ));
         self.stats
             .extract_filter_msgs_us
             .add_sample(extract_msgs_us);
@@ -251,7 +259,7 @@ impl SigVerifier {
                     extracted_msgs.votes,
                     &self.rank_map_cache,
                     &root_bank,
-                    &self.cluster_info,
+                    my_pubkey,
                     &self.leader_schedule,
                     &self.ban_sender,
                     &self.thread_pool,
@@ -260,7 +268,7 @@ impl SigVerifier {
             },
             || {
                 verify_and_send_certificates(
-                    &self.cluster_info.id(),
+                    my_pubkey,
                     &mut self.verified_certs,
                     extracted_msgs.certs,
                     &root_bank,
@@ -320,6 +328,7 @@ impl SigVerifier {
 
     fn extract_and_filter_msgs(
         &mut self,
+        my_pubkey: &Pubkey,
         datagrams: &[Datagram],
         certificates: Vec<(Slot, UnverifiedCertificate)>,
         root_bank: &Bank,
@@ -352,6 +361,7 @@ impl SigVerifier {
             match decoded_msg {
                 DecodedWireConsensusMessage::Vote(unverified_vote) => {
                     if let Some(payload) = self.keep_vote(
+                        my_pubkey,
                         unverified_vote,
                         *sender_identity_pubkey,
                         root_bank,
@@ -424,6 +434,7 @@ impl SigVerifier {
     /// If this vote should be verified, then returns the [`UnverifiedVotePayload`].
     fn keep_vote(
         &mut self,
+        my_pubkey: &Pubkey,
         msg: UnverifiedVoteMessage,
         sender_identity_pubkey: Pubkey,
         root_bank: &Bank,
@@ -431,7 +442,7 @@ impl SigVerifier {
         migration_slot: Option<Slot>,
     ) -> Option<UnverifiedVotePayload> {
         // votes from self take a different pathway.
-        if sender_identity_pubkey == self.cluster_info.id() {
+        if &sender_identity_pubkey == my_pubkey {
             return None;
         }
         let root_slot = root_bank.slot();
@@ -454,12 +465,7 @@ impl SigVerifier {
             cmp::Ordering::Equal if msg.vote.is_genesis_vote() => (),
             // Votes are allowed at or below the root if they are useful for rewards
             cmp::Ordering::Less | cmp::Ordering::Equal => {
-                if !rewards_wants_vote(
-                    &self.cluster_info,
-                    &self.leader_schedule,
-                    root_slot,
-                    &msg.vote,
-                ) {
+                if !rewards_wants_vote(my_pubkey, &self.leader_schedule, root_slot, &msg.vote) {
                     self.stats.num_old_votes_received += 1;
                     return None;
                 }
@@ -786,13 +792,21 @@ mod tests {
         let slot = 2;
 
         ctx.verifier
-            .verify_and_send_inputs(&[], vec![(slot, certificate.clone())])
+            .verify_and_send_inputs(
+                &ctx.verifier.cluster_info.id(),
+                &[],
+                vec![(slot, certificate.clone())],
+            )
             .unwrap();
         expect_no_receive(&ctx.pool_receiver);
 
         ctx.verifier.migration_status.enable_alpenglow_for_tests();
         ctx.verifier
-            .verify_and_send_inputs(&[], vec![(slot, certificate)])
+            .verify_and_send_inputs(
+                &ctx.verifier.cluster_info.id(),
+                &[],
+                vec![(slot, certificate)],
+            )
             .unwrap();
         let SigVerifiedBatch::Certificates(certs) = ctx.pool_receiver.try_recv().unwrap() else {
             panic!("expected a certificate batch");
@@ -817,9 +831,12 @@ mod tests {
             Bank::new_from_parent(ctx.verifier.sharable_banks.root(), SlotLeader::default(), 5);
         ctx.verifier.migration_status.enable_alpenglow_for_tests();
 
-        let extracted_msgs =
-            ctx.verifier
-                .extract_and_filter_msgs(&[], vec![(slot, certificate)], &root_bank);
+        let extracted_msgs = ctx.verifier.extract_and_filter_msgs(
+            &ctx.verifier.cluster_info.id(),
+            &[],
+            vec![(slot, certificate)],
+            &root_bank,
+        );
         assert!(extracted_msgs.certs.is_empty());
         assert!(extracted_msgs.votes.is_empty());
         assert_eq!(ctx.verifier.stats.num_old_certs_received.0, 1);

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -33,7 +33,6 @@ use {
         signature::SignatureAffine,
     },
     solana_clock::{Epoch, Slot},
-    solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_measure::{measure::Measure, measure_us},
     solana_pubkey::Pubkey,
@@ -92,7 +91,7 @@ impl UnverifiedVotePayload {
 
 fn verify_vote_batch(
     root_bank: &Bank,
-    cluster_info: &ClusterInfo,
+    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
     ban_sender: &BanSender,
     thread_pool: &ThreadPool,
@@ -114,7 +113,7 @@ fn verify_vote_batch(
     );
 
     let processed_votes =
-        process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
+        process_verified_votes(verified_votes, root_bank, my_pubkey, leader_schedule);
     (
         unverified_votes_len,
         vote_verification_stats,
@@ -130,7 +129,7 @@ pub(super) fn verify_and_send_votes(
     unverified_votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
     rank_map_cache: &HashMap<Epoch, Arc<BLSPubkeyToRankMap>>,
     root_bank: &Bank,
-    cluster_info: &ClusterInfo,
+    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
     ban_sender: &BanSender,
     thread_pool: &ThreadPool,
@@ -155,7 +154,7 @@ pub(super) fn verify_and_send_votes(
                     let (unverified_votes_len, vote_verification_stats, processed_votes) =
                         verify_vote_batch(
                             root_bank,
-                            cluster_info,
+                            my_pubkey,
                             leader_schedule,
                             ban_sender,
                             thread_pool,
@@ -179,7 +178,6 @@ pub(super) fn verify_and_send_votes(
                 },
             )
     });
-    let my_pubkey = &cluster_info.id();
     let sender_stats = send_msgs(my_pubkey, channels, processed_votes)?;
     stats.votes_to_sig_verify += total_votes;
     stats.vote_verification_stats.merge(verification_stats);
@@ -217,7 +215,7 @@ fn inspect_for_repair(
 fn process_verified_votes(
     verified_votes: Vec<VerifiedVotePayload>,
     root_bank: &Bank,
-    cluster_info: &ClusterInfo,
+    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
 ) -> ProcessedVotes {
     let mut votes_for_reward = Vec::with_capacity(verified_votes.len());
@@ -234,7 +232,7 @@ fn process_verified_votes(
             });
         }
         if rewards_wants_vote(
-            cluster_info,
+            my_pubkey,
             leader_schedule,
             root_bank.slot(),
             payload.vote_aggregate.vote(),

--- a/bls-sigverify/src/rewards.rs
+++ b/bls-sigverify/src/rewards.rs
@@ -4,8 +4,8 @@ use {
         sig_verified_messages::VoteAggregate, vote::Vote,
     },
     solana_clock::Slot,
-    solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
+    solana_pubkey::Pubkey,
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -17,7 +17,7 @@ pub enum RewardInput {
 #[must_use]
 /// Returns true if the given `msg` is needed for rewards.
 pub fn rewards_wants_vote(
-    cluster_info: &ClusterInfo,
+    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
     root_slot: Slot,
     vote: &Vote,
@@ -30,27 +30,26 @@ pub fn rewards_wants_vote(
         Vote::Notarize(_) | Vote::Skip(_) => (),
     }
     let vote_slot = vote.slot();
-    vote_is_relevant_for_rewards(vote_slot, root_slot, cluster_info, leader_schedule)
+    vote_is_relevant_for_rewards(my_pubkey, leader_schedule, root_slot, vote_slot)
 }
 
 #[must_use]
 /// Returns true if a reward vote at the `vote_slot` is needed by this node for rewards.
 pub fn vote_is_relevant_for_rewards(
-    vote_slot: Slot,
-    root_slot: Slot,
-    cluster_info: &ClusterInfo,
+    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
+    root_slot: Slot,
+    vote_slot: Slot,
 ) -> bool {
     if vote_slot.saturating_add(NUM_SLOTS_FOR_REWARD) <= root_slot {
         return false;
     }
-    let my_pubkey = cluster_info.id();
     let Some(leader) =
         leader_schedule.slot_leader_at(vote_slot.saturating_add(NUM_SLOTS_FOR_REWARD), None)
     else {
         return false;
     };
-    if leader.id != my_pubkey {
+    if &leader.id != my_pubkey {
         return false;
     }
     true

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -335,7 +335,7 @@ pub(crate) fn create_and_send_own_vote_message(
 
     let root_slot = context.sharable_banks.root().slot();
     if rewards_wants_vote(
-        &context.cluster_info,
+        my_pubkey,
         &context.leader_schedule,
         root_slot,
         &vote_msg.vote,


### PR DESCRIPTION
#### Problem

In bls-sigverify, we keep looking up `my_pubkey` from `ClusterInfo`.  The pubkey is stored in an `ArcSwap` and even though it should be fairly cheap to load but still can incur a small cost.


#### Summary of Changes

Looks up `my_pubkey` once per iteration in the main loop of bls-sigverify to support identity changes and then passes the pubkey through the functions that need it.


#### Testing

No new tests added
