### PR TITLE
bls-sigverify: reduces allocations for sending metrics

### DIFF
--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -227,12 +227,10 @@ fn process_verified_votes(
     for payload in verified_votes {
         inspect_for_repair(&payload, &mut msgs_for_repair);
 
-        for pubkey in &payload.sender_vote_account_pubkeys {
-            votes_for_metrics.push(ConsensusMetricsEvent::Vote {
-                id: *pubkey,
-                vote: *payload.vote_aggregate.vote(),
-            });
-        }
+        votes_for_metrics.push(ConsensusMetricsEvent::Vote {
+            ids: payload.sender_vote_account_pubkeys,
+            vote: *payload.vote_aggregate.vote(),
+        });
         if rewards_wants_vote(
             cluster_info,
             leader_schedule,

--- a/votor-messages/src/metric_types.rs
+++ b/votor-messages/src/metric_types.rs
@@ -14,7 +14,7 @@ pub enum ConsensusMetricsEvent {
     /// A vote was received from the node with `id`.
     Vote {
         /// The validator that voted.
-        id: Pubkey,
+        ids: Vec<Pubkey>,
         /// The type of vote.
         vote: Vote,
     },

--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -126,8 +126,8 @@ impl ConsensusMetrics {
                 Ok((received, events)) => {
                     for event in events {
                         match event {
-                            ConsensusMetricsEvent::Vote { id, vote } => {
-                                self.record_vote(id, &vote, received);
+                            ConsensusMetricsEvent::Vote { ids, vote } => {
+                                self.record_vote(ids, &vote, received);
                             }
                             ConsensusMetricsEvent::BlockHashSeen { leader, slot } => {
                                 self.record_block_hash_seen(leader, slot, received);
@@ -158,18 +158,21 @@ impl ConsensusMetrics {
     }
 
     /// Records a `vote` from the node with `id`.
-    fn record_vote(&mut self, id: Pubkey, vote: &Vote, received: Instant) {
+    fn record_vote(&mut self, ids: Vec<Pubkey>, vote: &Vote, received: Instant) {
         let slot = vote.slot();
         let epoch_metrics = self.epoch_metrics_for_slot(slot);
 
         let Some(start) = epoch_metrics.start_of_slot.get(&slot) else {
-            epoch_metrics.metrics_recording_failed =
-                epoch_metrics.metrics_recording_failed.saturating_add(1);
+            epoch_metrics.metrics_recording_failed = epoch_metrics
+                .metrics_recording_failed
+                .saturating_add(ids.len());
             return;
         };
-        let node = epoch_metrics.node_metrics.entry(id).or_default();
         let elapsed = received.duration_since(*start);
-        node.record_vote(vote, elapsed);
+        for id in ids {
+            let node = epoch_metrics.node_metrics.entry(id).or_default();
+            node.record_vote(vote, elapsed);
+        }
     }
 
     /// Records when a block for `slot` was seen and the `leader` is responsible for producing it.
@@ -322,7 +325,7 @@ mod tests {
         let mut metrics = new_metrics();
 
         metrics.record_vote(
-            Keypair::new().pubkey(),
+            vec![Keypair::new().pubkey()],
             &Vote::Skip(SkipVote { slot: 42 }),
             Instant::now(),
         );
@@ -337,7 +340,11 @@ mod tests {
 
         metrics.record_start_of_slot(42, Instant::now());
         sleep(Duration::from_millis(1));
-        metrics.record_vote(pubkey, &Vote::Skip(SkipVote { slot: 42 }), Instant::now());
+        metrics.record_vote(
+            vec![pubkey],
+            &Vote::Skip(SkipVote { slot: 42 }),
+            Instant::now(),
+        );
 
         let node = &metrics.epoch_metrics[&0].node_metrics[&pubkey];
         assert_eq!(node.skip.count(), 1);

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1625,7 +1625,8 @@ mod tests {
                 .consensus_metrics_receiver
                 .try_recv()
                 .expect("Should receive metrics event");
-            assert!(event.1.contains(&expected));
+            assert_eq!(event.1.len(), 1);
+            assert_eq!(event.1[0], expected);
         }
 
         fn crate_vote_history_storage_and_switch_identity(


### PR DESCRIPTION
#### Problem

Currently, `ConsensusMetricsEvent::Vote::id` is of type `Pubkey` so we need to send one event per vote received.  But we batch process votes in sigverify so we end up allocating a list of events to represent the vote events.  

#### Summary of Changes

This PR changes `ConsensusMetricsEvent::Vote::id` to `ConsensusMetricsEvent::Vote::ids` and makes it of type `Vec<Pubkey>`.  We are able to reuse the existing list of pubkeys the sigverify has and send it without doing additional allocations.

#### Testing

No new tests added