### PR TITLE
runtime: Update `RewardEpochDelegatedStakes` for VAT

### DIFF
--- a/runtime/src/alpenglow_epoch_type.rs
+++ b/runtime/src/alpenglow_epoch_type.rs
@@ -14,6 +14,7 @@ use {
 /// Note that this is not the same as `epoch_stakes`, which is calculated an epoch
 /// in advance.
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub(crate) struct RewardEpochDelegatedStakes {
     pub(crate) epoch: Epoch,
     pub(crate) delegated_stakes: HashMap<Pubkey, u64>,
@@ -68,32 +69,39 @@ impl RewardEpochDelegatedStakesAccount {
 }
 
 impl RewardEpochDelegatedStakes {
-    pub(crate) fn set(&self, bank: &Bank, distribution_vote_accounts: &VoteAccounts) {
+    pub(crate) fn set(&mut self, bank: &Bank, distribution_vote_accounts: &VoteAccounts) {
         assert!(
             distribution_vote_accounts.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS,
             "reward epoch delegated stakes account must be bounded by MAX_ALPENGLOW_VOTE_ACCOUNTS"
         );
 
-        let mut delegated_stakes = distribution_vote_accounts
+        // Drop entries that didn't pay VAT
+        self.delegated_stakes
+            .retain(|vote_address, _| distribution_vote_accounts.get(vote_address).is_some());
+        // Add new vote accounts that paid VAT (note: this shouldn't ever do
+        // anything, but provides some extra safety)
+        distribution_vote_accounts
             .delegated_stakes()
+            .for_each(|(&vote_address, _)| {
+                self.delegated_stakes.entry(vote_address).or_insert(0);
+            });
+        let mut delegated_stakes = self
+            .delegated_stakes
+            .iter()
             .map(
-                |(vote_pubkey, _delegated_stake)| RewardEpochDelegatedStake {
-                    vote_pubkey: *vote_pubkey,
-                    delegated_stake: self
-                        .delegated_stakes
-                        .get(vote_pubkey)
-                        .copied()
-                        .unwrap_or_default(),
+                |(&vote_pubkey, &delegated_stake)| RewardEpochDelegatedStake {
+                    vote_pubkey,
+                    delegated_stake,
                 },
             )
             .collect::<Vec<_>>();
         delegated_stakes.sort_unstable_by_key(|stake| stake.vote_pubkey);
 
-        let account = RewardEpochDelegatedStakesAccount {
+        let delegated_stakes_account = RewardEpochDelegatedStakesAccount {
             epoch: self.epoch,
             delegated_stakes,
         };
-        let data = wincode::serialize(&account).unwrap();
+        let data = wincode::serialize(&delegated_stakes_account).unwrap();
         let lamports = bank
             .get_minimum_balance_for_rent_exemption(RewardEpochDelegatedStakesAccount::max_size());
         let mut account = AccountSharedData::new(lamports, data.len(), &system_program::ID);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1825,7 +1825,7 @@ impl Bank {
                 stake_history,
                 unfiltered_distribution_vote_accounts,
                 delegated_stakes,
-                reward_epoch_delegated_stakes,
+                mut reward_epoch_delegated_stakes,
             ),
             calculate_activated_stake_time_us,
         ) = measure_us!(stakes.calculate_activated_stake(

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -438,11 +438,15 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::{SlotLeader, tests::create_genesis_config},
+            alpenglow_epoch_type::RewardEpochDelegatedStakes,
+            bank::{
+                NewEpochBundle, RewardsMetrics, SlotLeader, null_tracer,
+                tests::create_genesis_config,
+            },
             bank_forks::BankForks,
             genesis_utils::{
-                GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
-                deactivate_features,
+                GenesisConfigInfo, ValidatorVoteKeypairs, activate_all_features_alpenglow,
+                create_genesis_config_with_vote_accounts, deactivate_features,
             },
             runtime_config::RuntimeConfig,
             stake_utils,
@@ -450,7 +454,10 @@ mod tests {
         },
         assert_matches::assert_matches,
         rand::Rng,
-        solana_account::{Account, state_traits::StateMutWincode as _},
+        rayon::ThreadPoolBuilder,
+        solana_account::{
+            Account, ReadableAccount, WritableAccount, state_traits::StateMutWincode as _,
+        },
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
             partitioned_rewards::PartitionedEpochRewardsConfig,
@@ -461,6 +468,7 @@ mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_reward_info::RewardType,
         solana_signer::Signer,
+        solana_stake_interface::{stake_flags::StakeFlags, state::StakeStateV2},
         solana_system_transaction as system_transaction,
         solana_vote::vote_transaction,
         solana_vote_interface::state::{MAX_LOCKOUT_HISTORY, VoteStateV4, VoteStateVersions},
@@ -1275,5 +1283,163 @@ mod tests {
             num_partitions: Some(42),
         };
         assert!(rewards_and_partitions.should_record());
+    }
+
+    #[test]
+    fn test_reward_epoch_delegated_stakes_excludes_vat() {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(500);
+        activate_all_features_alpenglow(&mut genesis_config);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let first_normal_slot = bank.epoch_schedule().first_normal_slot;
+        let slots_per_epoch = bank.epoch_schedule().slots_per_epoch;
+
+        let stake_amount = 10_000;
+        {
+            let stakes = bank.stakes_cache.stakes();
+            assert!(stakes.vote_accounts().as_ref().is_empty());
+            assert!(stakes.stake_delegations().is_empty());
+        }
+
+        let ((non_vat_vote_address, non_vat_vote_account), (stake_address, stake_account)) =
+            crate::stakes::tests::create_staked_node_accounts(
+                stake_amount,
+                &bank.rent_collector.rent,
+            );
+
+        bank.store_account(&non_vat_vote_address, &non_vat_vote_account);
+        bank.store_account(&stake_address, &stake_account);
+
+        let ((vat_vote_address, mut vat_vote_account), (stake_address, stake_account)) =
+            crate::stakes::tests::create_staked_node_accounts(
+                stake_amount,
+                &bank.rent_collector.rent,
+            );
+        vat_vote_account.set_lamports(bank.vat_to_burn_per_epoch() * 5);
+
+        bank.store_account(&vat_vote_address, &vat_vote_account);
+        bank.store_account(&stake_address, &stake_account);
+
+        // Advance to first normal slot
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            SlotLeader::default(),
+            first_normal_slot,
+        );
+        drop(bank_forks); // so that `Arc::into_inner` succeeds
+        let mut bank = Arc::into_inner(bank).unwrap();
+
+        let (
+            (unstaked_vat_vote_address, mut unstaked_vat_vote_account),
+            (stake_address, mut stake_account),
+        ) = crate::stakes::tests::create_staked_node_accounts(
+            stake_amount,
+            &bank.rent_collector.rent,
+        );
+        unstaked_vat_vote_account.set_lamports(bank.vat_to_burn_per_epoch() * 5);
+        {
+            // Will activate in next epoch, so validator still has 0 stake in
+            // rewarded epoch
+            let state: StakeStateV2 = stake_account.state().unwrap();
+            let meta = state.meta().unwrap();
+            let mut stake = state.stake().unwrap();
+            stake.delegation.activation_epoch = bank.epoch();
+
+            stake_account
+                .set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
+                .expect("set_state");
+        }
+        bank.store_account(&unstaked_vat_vote_address, &unstaked_vat_vote_account);
+        bank.store_account(&stake_address, &stake_account);
+
+        {
+            let stakes = bank.stakes_cache.stakes();
+            assert_eq!(stakes.vote_accounts().len(), 3);
+            assert_eq!(stakes.stake_delegations().len(), 3);
+        }
+
+        // Mimic some of the early work in `Bank::new_from_parent`
+        bank.slot = bank.slot() + slots_per_epoch;
+        bank.epoch += 1;
+
+        // Simulate the steps in `compute_new_epoch_caches_and_rewards`
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let mut rewards_metrics = RewardsMetrics::default();
+        let NewEpochBundle {
+            stake_history: _,
+            unfiltered_distribution_vote_accounts,
+            delegated_stakes: _,
+            reward_epoch_delegated_stakes,
+            filtered_distribution_vote_accounts,
+            rewards_calculation: _,
+            calculate_activated_stake_time_us: _,
+            update_rewards_with_thread_pool_time_us: _,
+        } = bank.compute_new_epoch_caches_and_rewards(
+            &thread_pool,
+            bank.epoch() - 1,
+            null_tracer(),
+            &mut rewards_metrics,
+        );
+        unfiltered_distribution_vote_accounts
+            .get(&non_vat_vote_address)
+            .unwrap();
+        unfiltered_distribution_vote_accounts
+            .get(&vat_vote_address)
+            .unwrap();
+        unfiltered_distribution_vote_accounts
+            .get(&unstaked_vat_vote_address)
+            .unwrap();
+
+        assert!(
+            filtered_distribution_vote_accounts
+                .get(&non_vat_vote_address)
+                .is_none()
+        );
+        filtered_distribution_vote_accounts
+            .get(&unstaked_vat_vote_address)
+            .unwrap();
+        filtered_distribution_vote_accounts
+            .get(&vat_vote_address)
+            .unwrap();
+
+        // Filtered out during `RewardEpochDelegatedStakes::set`
+        assert!(
+            !reward_epoch_delegated_stakes
+                .delegated_stakes
+                .contains_key(&non_vat_vote_address)
+        );
+        assert!(
+            reward_epoch_delegated_stakes
+                .delegated_stakes
+                .contains_key(&vat_vote_address)
+        );
+
+        // Even though the validator isn't staked in the rewarded epoch, it still
+        // has an entry in the map because there is an activating stake account
+        // delegated to it
+        assert_eq!(
+            *reward_epoch_delegated_stakes
+                .delegated_stakes
+                .get(&unstaked_vat_vote_address)
+                .unwrap(),
+            0
+        );
+
+        // actually advance to the next epoch, see that everything lines up
+        bank.slot = bank.slot() - slots_per_epoch;
+        bank.epoch -= 1;
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            SlotLeader::default(),
+            first_normal_slot + slots_per_epoch,
+        );
+        let fetched_reward_epoch_delegated_stakes = RewardEpochDelegatedStakes::get(&bank).unwrap();
+        assert_eq!(
+            fetched_reward_epoch_delegated_stakes,
+            reward_epoch_delegated_stakes
+        );
     }
 }


### PR DESCRIPTION
#### Problem

The `RewardEpochDelegatedStakes` used during epoch rollover doesn't line up with what's stored in accounts-db. There's additional filtering performed to only include VAT payers, whereas the calculated structure contains *all* vote accounts that had stake in the rewarded epoch.

#### Summary of changes

During `RewardEpochDelegatedStakes::set`, also update the instance to reflect what's being stored in accounts-db.

NOTE: This does NOT impact any of the reward calculations.

For normal inflation rewards, we only use the value stored in `reward_epoch_delegated_stakes` for vote accounts that have paid VAT. `redeem_delegation_rewards` returns zero if the vote address is not in `distribution_epoch_vote_accounts`, which is the VAT filtered list.

For the block reward in SIMD-0123, `calculate_block_reward` returns zero if the vote address isn't in `distribution_epoch_vote_accounts`.

#### Testing

New unit test.