### PR TITLE
accounts-db: Updates account storage reader tests

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -241,24 +241,29 @@ impl AccountStorageEntry {
     }
 
     /// Collect the offsets that should be excluded from scans
-    fn excluded_offsets(&self) -> IntSet<Offset> {
+    fn excluded_offsets(&self, obsolete_slot: Option<Slot>) -> IntSet<Offset> {
         let mut offsets: IntSet<_> = self
             .obsolete_accounts_read_lock()
-            .filter_obsolete_accounts(None)
+            .filter_obsolete_accounts(obsolete_slot)
             .map(|(offset, _)| offset)
             .collect();
         offsets.extend(self.tombstone_offsets_read_lock().iter().copied());
         offsets
     }
 
-    /// Iterate over the alive accounts in this storage, excluding obsolete accounts and tombstones.
-    /// The return value is the number of values excluded from the scan.
+    /// Iterate over the alive accounts in this storage, excluding tombstones
+    /// and obsolete accounts marked as of `obsolete_slot`.
+    ///
+    /// Pass in None for `obsolete_slot` to exclude all accounts marked obsolete.
+    ///
+    /// Returns the number of accounts excluded from the scan.
     pub(crate) fn scan_accounts<'a>(
         &'a self,
         reader: &mut impl RequiredLenBufFileRead<'a>,
+        obsolete_slot: Option<Slot>,
         mut callback: impl for<'local> FnMut(Offset, StoredAccountInfo<'local>),
     ) -> Result<u64, AccountsFileError> {
-        let excluded_offsets = self.excluded_offsets();
+        let excluded_offsets = self.excluded_offsets(obsolete_slot);
         let mut num_excluded = 0;
         self.accounts.scan_accounts(reader, |offset, account| {
             if excluded_offsets.contains(&offset) {
@@ -276,7 +281,7 @@ impl AccountStorageEntry {
         &self,
         mut callback: impl for<'local> FnMut(Offset, StoredAccountInfoWithoutData<'local>),
     ) -> Result<u64, AccountsFileError> {
-        let excluded_offsets = self.excluded_offsets();
+        let excluded_offsets = self.excluded_offsets(None);
         let mut num_excluded = 0;
         self.accounts
             .scan_accounts_without_data(|offset, account| {
@@ -354,7 +359,7 @@ mod tests {
         let mut reader = new_scan_accounts_reader();
         let mut visited = Vec::new();
         let num_excluded = storage
-            .scan_accounts(&mut reader, |offset, account| {
+            .scan_accounts(&mut reader, None, |offset, account| {
                 visited.push((offset, *account.pubkey()));
             })
             .unwrap();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -196,6 +196,8 @@ mod tests {
             account_storage_entry::AccountStorageEntry,
             accounts_db::get_temp_accounts_paths,
             accounts_file::{AccountsFile, AccountsFileProvider},
+            append_vec,
+            utils::create_account_shared_data,
         },
         agave_fs::io_setup::IoSetupState,
         log::*,
@@ -206,7 +208,7 @@ mod tests {
         },
         solana_account::AccountSharedData,
         solana_pubkey::Pubkey,
-        std::{fs::File, iter},
+        std::{collections::HashMap, fs::File, iter},
         test_case::test_case,
     };
 
@@ -283,7 +285,7 @@ mod tests {
 
         // Generate a seed from entropy and log the original seed
         let seed: u64 = rand::random();
-        dbg!("Generated seed: {seed}");
+        dbg!(seed);
 
         // Use a seedable RNG with the generated seed for reproducibility
         let mut rng = StdRng::seed_from_u64(seed);
@@ -357,12 +359,9 @@ mod tests {
         let mut reader =
             AccountStorageReader::new(&storage, None, tombstones_filter, &mut file_reader).unwrap();
         let mut number_of_accounts_to_remove = num_obsolete;
-        let mut current_len = storage.accounts.len() - storage.get_obsolete_bytes(None);
         if tombstones_filter == TombstonesFilter::Exclude {
             number_of_accounts_to_remove += num_tombstones;
-            current_len -= num_tombstones * storage.accounts.calculate_stored_size(0);
         }
-        assert_eq!(reader.len(), current_len);
 
         // Create a temporary directory and a file within it
         let temp_dir = tempfile::tempdir().unwrap();
@@ -379,7 +378,7 @@ mod tests {
         // and verify that the number of accounts in the new file is correct
         if (total_accounts - number_of_accounts_to_remove) != 0 {
             let (accounts_file, num_accounts) =
-                AccountsFile::new_from_file(temp_file_path, current_len).unwrap();
+                AccountsFile::new_from_file(temp_file_path, bytes_written as usize).unwrap();
 
             // Verify that the correct number of accounts were found in the file
             assert_eq!(
@@ -397,6 +396,35 @@ mod tests {
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
+
+            // Verify that the new storage has all the expected accounts
+            let include_tombstones = tombstones_filter == TombstonesFilter::Include;
+            let expected_accounts: HashMap<_, _> = accounts_to_append
+                .iter()
+                .enumerate()
+                .filter_map(|(i, (pubkey, account))| {
+                    let is_obsolete = obsolete_indexes.contains(&i);
+                    let is_tombstone = tombstone_indexes.contains(&i);
+                    (!is_obsolete && (!is_tombstone || include_tombstones))
+                        .then(|| (*pubkey, account.clone()))
+                })
+                .collect();
+            let mut reader_for_scan_accounts = append_vec::new_scan_accounts_reader();
+            let accounts_in_new_storage = {
+                let mut accounts = HashMap::new();
+                new_storage
+                    .accounts
+                    .scan_accounts(&mut reader_for_scan_accounts, |_offset, stored_account| {
+                        let old_value = accounts.insert(
+                            *stored_account.pubkey(),
+                            create_account_shared_data(&stored_account),
+                        );
+                        assert!(old_value.is_none());
+                    })
+                    .unwrap();
+                accounts
+            };
+            assert_eq!(accounts_in_new_storage, expected_accounts);
         }
     }
 
@@ -482,19 +510,17 @@ mod tests {
         )
         .unwrap();
         for snapshot_slot in 0..slot_marked_dead {
+            let obsolete_slot = Some(snapshot_slot);
             file_reader
                 .set_file(files[0].as_ref(), storage.accounts.len() as u64)
                 .unwrap();
             let mut reader = AccountStorageReader::new(
                 &storage,
-                Some(snapshot_slot),
+                obsolete_slot,
                 TombstonesFilter::Include,
                 &mut file_reader,
             )
             .unwrap();
-            let current_len =
-                storage.accounts.len() - storage.get_obsolete_bytes(Some(snapshot_slot));
-            assert_eq!(reader.len(), current_len);
 
             // Create a file to write the reader's output. It will get deleted by AccountsFile::drop() every
             // iteration so it does not need a unique name
@@ -508,7 +534,7 @@ mod tests {
             drop(output_file);
 
             let (accounts_file, _num_accounts) =
-                AccountsFile::new_from_file(temp_file_path, current_len).unwrap();
+                AccountsFile::new_from_file(temp_file_path, bytes_written as usize).unwrap();
 
             // Create a new AccountStorageEntry from the output file
             let new_storage = AccountStorageEntry::new_existing(
@@ -520,6 +546,41 @@ mod tests {
 
             // Verify that the new storage has the same length as the reader
             assert_eq!(new_storage.accounts.len(), reader.len());
+
+            // Verify that the new storage has all the expected accounts
+            let mut reader_for_scan_accounts = append_vec::new_scan_accounts_reader();
+            let accounts_in_old_storage = {
+                let mut accounts = HashMap::new();
+                storage
+                    .scan_accounts(
+                        &mut reader_for_scan_accounts,
+                        obsolete_slot,
+                        |_offset, stored_account| {
+                            let old_value = accounts.insert(
+                                *stored_account.pubkey(),
+                                create_account_shared_data(&stored_account),
+                            );
+                            assert!(old_value.is_none());
+                        },
+                    )
+                    .unwrap();
+                accounts
+            };
+            let accounts_in_new_storage = {
+                let mut accounts = HashMap::new();
+                new_storage
+                    .accounts
+                    .scan_accounts(&mut reader_for_scan_accounts, |_offset, stored_account| {
+                        let old_value = accounts.insert(
+                            *stored_account.pubkey(),
+                            create_account_shared_data(&stored_account),
+                        );
+                        assert!(old_value.is_none());
+                    })
+                    .unwrap();
+                accounts
+            };
+            assert_eq!(accounts_in_new_storage, accounts_in_old_storage);
         }
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1441,7 +1441,7 @@ impl AccountsDb {
             |reader, storage| {
                 let slot = storage.slot();
                 storage
-                    .scan_accounts(reader.as_mut(), |_offset, account| {
+                    .scan_accounts(reader.as_mut(), None, |_offset, account| {
                         let pk = account.pubkey();
                         match pubkey_slot_lists.entry(*pk) {
                             dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
@@ -2758,7 +2758,7 @@ impl AccountsDb {
                 }
                 ScanAccountStorageData::DataRefForStorage => {
                     let mut reader = append_vec::new_scan_accounts_reader();
-                    storage.scan_accounts(&mut reader, |_offset, account| {
+                    storage.scan_accounts(&mut reader, None, |_offset, account| {
                         let account_without_data = StoredAccountInfoWithoutData::new_from(&account);
                         storage_scan_func(retval, &account_without_data, Some(account.data));
                     })
@@ -5017,7 +5017,7 @@ impl AccountsDb {
         // counter per account and use that for the write version.
         let mut write_version_for_geyser = 0;
         let num_obsolete_accounts_skipped = storage
-            .scan_accounts(reader, |offset, account| {
+            .scan_accounts(reader, None, |offset, account| {
                 let data_len = account.data.len();
                 stored_size_alive += storage.accounts.calculate_stored_size(data_len);
                 let is_account_zero_lamport = account.is_zero_lamport();

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -958,7 +958,7 @@ mod tests {
             if let Some(storage) = db.storage.get_slot_storage_entry(slot) {
                 let mut reader = crate::append_vec::new_scan_accounts_reader();
                 storage
-                    .scan_accounts(&mut reader, |offset, account| {
+                    .scan_accounts(&mut reader, None, |offset, account| {
                         let info = AccountInfo::new(
                             StorageLocation::AccountsFile(storage.id(), offset),
                             account.is_zero_lamport(),


### PR DESCRIPTION
#### Problem

We're adding a new account storage file format, and that impacts how the accounts index tracks accounts. Specifically, the offset field will need to change to not assume the underlying storage is an AppendVec.

This also manifests in the obsolete accounts, and the AccountStorageReader.

For this PR, the problem is related to `AccountStorageEntry::get_obsolete_bytes()`. That fn will change a bit, since currently it also assumes the underlying file is an AppendVec. Luckily it only impacts tests, and only two tests within AccountStorageReader.

For these tests, they are verifying when a new storage is written out that the sizes are correct/expected. Calculating the expected size relies on `get_obsolete_bytes()`, so those tests break.


#### Summary of Changes

The AccountStorageReader tests will not call `get_obsolete_bytes()`. Instead, the tests will read all the accounts from the new storages and confirm they match what is expected.

The two commits are:
1. pre-reqs, need to update AccountStorageEntry::{excluded_offsets, scan_accounts} to take a param for the obsolete slot.
2. update the tests.


#### Testing

Nothing additional.