### PR TITLE
 bls-sigverify: reuses the HashMap memory for unverified votes 

### DIFF
--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -134,7 +134,7 @@ fn bench_verify_individual_votes(c: &mut Criterion) {
                 |(votes, prepared_hash_map, max_validators)| {
                     let res = verify_individual_votes(
                         max_validators,
-                        black_box(votes),
+                        black_box(&votes),
                         black_box(prepared_hash_map),
                         &thread_pool,
                     );

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -122,11 +122,6 @@ pub fn spawn_service(
         .unwrap()
 }
 
-struct ExtractedMsgs {
-    certs: HashMap<CertificateType, Vec<CertPayload>>,
-    votes: HashMap<VotePayloadToSign, (Vec<UnverifiedVotePayload>, Arc<BLSPubkeyToRankMap>)>,
-}
-
 struct SigVerifier {
     migration_status: Arc<MigrationStatus>,
     ban_sender: BanSender,
@@ -188,9 +183,11 @@ impl SigVerifier {
 
     fn run(mut self, exit: Arc<AtomicBool>) {
         let mut datagrams_buffer = Vec::new();
+        let mut votes_buffer = HashMap::new();
         while !exit.load(Ordering::Relaxed) {
             const SOFT_RECEIVE_CAP: usize = 5000;
             datagrams_buffer.clear();
+            votes_buffer.clear();
             let Ok(certificates) = recv_inputs(
                 &self.channels.packet_receiver,
                 &self.channels.certificate_receiver,
@@ -210,6 +207,7 @@ impl SigVerifier {
             let (verify_res, verify_time_us) = measure_us!(self.verify_and_send_inputs(
                 &self.cluster_info.id(),
                 &datagrams_buffer,
+                &mut votes_buffer,
                 certificates
             ));
             self.stats
@@ -231,21 +229,31 @@ impl SigVerifier {
         &mut self,
         datagrams: Vec<Datagram>,
     ) -> Result<(), SigVerifyError> {
-        self.verify_and_send_inputs(&self.cluster_info.id(), &datagrams, vec![])
+        self.verify_and_send_inputs(
+            &self.cluster_info.id(),
+            &datagrams,
+            &mut HashMap::new(),
+            vec![],
+        )
     }
 
     fn verify_and_send_inputs(
         &mut self,
         my_pubkey: &Pubkey,
         datagrams: &[Datagram],
+        votes_buffer: &mut HashMap<
+            VotePayloadToSign,
+            (Vec<UnverifiedVotePayload>, Arc<BLSPubkeyToRankMap>),
+        >,
         certificates: Vec<(Slot, UnverifiedCertificate)>,
     ) -> Result<(), SigVerifyError> {
         let root_bank = self.sharable_banks.root();
         self.maybe_prune_caches(&root_bank);
 
-        let (extracted_msgs, extract_msgs_us) = measure_us!(self.extract_and_filter_msgs(
+        let (certs, extract_msgs_us) = measure_us!(self.extract_and_filter_msgs(
             my_pubkey,
             datagrams,
+            votes_buffer,
             certificates,
             &root_bank
         ));
@@ -256,7 +264,7 @@ impl SigVerifier {
         let (votes_result, certs_result) = self.thread_pool.join(
             || {
                 verify_and_send_votes(
-                    extracted_msgs.votes,
+                    votes_buffer,
                     &root_bank,
                     my_pubkey,
                     &self.leader_schedule,
@@ -269,7 +277,7 @@ impl SigVerifier {
                 verify_and_send_certificates(
                     my_pubkey,
                     &mut self.verified_certs,
-                    extracted_msgs.certs,
+                    certs,
                     &root_bank,
                     &self.channels.channel_to_pool,
                     &self.ban_sender,
@@ -329,15 +337,18 @@ impl SigVerifier {
         &mut self,
         my_pubkey: &Pubkey,
         datagrams: &[Datagram],
+        votes_buffer: &mut HashMap<
+            VotePayloadToSign,
+            (Vec<UnverifiedVotePayload>, Arc<BLSPubkeyToRankMap>),
+        >,
         certificates: Vec<(Slot, UnverifiedCertificate)>,
         root_bank: &Bank,
-    ) -> ExtractedMsgs {
+    ) -> HashMap<CertificateType, Vec<CertPayload>> {
         let root_slot = root_bank.slot();
         let highest_parent_ready_slot = self.highest_parent_ready.read().unwrap().0;
         let max_vote_slot = max_admitted_vote_slot(root_slot, highest_parent_ready_slot);
         let migration_slot = self.migration_status.migration_slot();
         let mut cert_groups = HashMap::<CertificateType, Vec<CertPayload>>::new();
-        let mut votes = HashMap::new();
         let mut num_pkts = 0u64;
         let my_shred_version = self.cluster_info.my_shred_version();
         for Datagram {
@@ -365,7 +376,7 @@ impl SigVerifier {
                         migration_slot,
                         max_vote_slot,
                         root_bank,
-                        &mut votes,
+                        votes_buffer,
                         unverified_vote,
                     );
                 }
@@ -417,10 +428,7 @@ impl SigVerifier {
             self.add_certificate_to_group(&mut cert_groups, certificate, sender_identity_pubkey);
         }
         self.stats.num_pkts += num_pkts;
-        ExtractedMsgs {
-            certs: cert_groups,
-            votes,
-        }
+        cert_groups
     }
 
     fn extract_and_filter_vote(
@@ -834,6 +842,7 @@ mod tests {
             .verify_and_send_inputs(
                 &ctx.verifier.cluster_info.id(),
                 &[],
+                &mut HashMap::new(),
                 vec![(slot, certificate.clone())],
             )
             .unwrap();
@@ -844,6 +853,7 @@ mod tests {
             .verify_and_send_inputs(
                 &ctx.verifier.cluster_info.id(),
                 &[],
+                &mut HashMap::new(),
                 vec![(slot, certificate)],
             )
             .unwrap();
@@ -870,14 +880,16 @@ mod tests {
             Bank::new_from_parent(ctx.verifier.sharable_banks.root(), SlotLeader::default(), 5);
         ctx.verifier.migration_status.enable_alpenglow_for_tests();
 
-        let extracted_msgs = ctx.verifier.extract_and_filter_msgs(
+        let mut votes_buffer = HashMap::new();
+        let certs = ctx.verifier.extract_and_filter_msgs(
             &ctx.verifier.cluster_info.id(),
             &[],
+            &mut votes_buffer,
             vec![(slot, certificate)],
             &root_bank,
         );
-        assert!(extracted_msgs.certs.is_empty());
-        assert!(extracted_msgs.votes.is_empty());
+        assert!(certs.is_empty());
+        assert!(votes_buffer.is_empty());
         assert_eq!(ctx.verifier.stats.num_old_certs_received.0, 1);
     }
 

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -100,8 +100,8 @@ fn verify_vote_batch(
     ban_sender: &BanSender,
     thread_pool: &ThreadPool,
     rank_map: &BLSPubkeyToRankMap,
-    vote_payload_to_sign: VotePayloadToSign,
-    unverified_votes: Vec<UnverifiedVotePayload>,
+    vote_payload_to_sign: &VotePayloadToSign,
+    unverified_votes: &[UnverifiedVotePayload],
 ) -> (VoteVerificationStats, ProcessedVotes) {
     let max_validators = rank_map.len();
     let (verified_votes, vote_verification_stats) = verify_votes(
@@ -122,7 +122,7 @@ fn verify_vote_batch(
 ///
 /// Any vote that fails fallback individual signature verification will have its sender banlisted.
 pub(super) fn verify_and_send_votes(
-    unverified_votes: HashMap<
+    unverified_votes: &HashMap<
         VotePayloadToSign,
         (Vec<UnverifiedVotePayload>, Arc<BLSPubkeyToRankMap>),
     >,
@@ -144,7 +144,7 @@ pub(super) fn verify_and_send_votes(
 
     let par_result = thread_pool.install(|| {
         unverified_votes
-            .into_par_iter()
+            .par_iter()
             .fold(
                 ParResult::default,
                 |mut par_result, (vote_payload_to_sign, (unverified_votes, rank_map))| {
@@ -155,7 +155,7 @@ pub(super) fn verify_and_send_votes(
                         leader_schedule,
                         ban_sender,
                         thread_pool,
-                        &rank_map,
+                        rank_map,
                         vote_payload_to_sign,
                         unverified_votes,
                     );
@@ -289,15 +289,15 @@ fn send_msgs(
 /// Sig verifies `unverified_votes` and returns a `Vec` of votes that passed verification.
 fn verify_votes(
     max_validators: usize,
-    vote_payload_to_sign: VotePayloadToSign,
-    unverified_votes: Vec<UnverifiedVotePayload>,
+    vote_payload_to_sign: &VotePayloadToSign,
+    unverified_votes: &[UnverifiedVotePayload],
     ban_sender: &BanSender,
     thread_pool: &ThreadPool,
 ) -> (Vec<VerifiedVotePayload>, VoteVerificationStats) {
     let mut stats = VoteVerificationStats::default();
 
     // no need to do optimistic verification when batch size == 1.
-    if let [unverified_vote] = unverified_votes.as_slice() {
+    if let [unverified_vote] = unverified_votes {
         let ((verification_result, sender_identity_pubkey), time_us) = measure_us!({
             let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
             let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
@@ -323,7 +323,7 @@ fn verify_votes(
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
     let res = verify_votes_optimistic(
         vote_payload_to_sign,
-        &unverified_votes,
+        unverified_votes,
         &mut stats,
         thread_pool,
     );
@@ -336,12 +336,12 @@ fn verify_votes(
                 .add_sample(unverified_votes.len() as u64);
             let vote_aggregate = VoteAggregate::new_from_verified_votes(
                 max_validators,
-                vote_payload_to_sign,
+                *vote_payload_to_sign,
                 unverified_votes.iter().map(|v| (v.rank, v.stake)),
                 signature,
             );
             let sender_vote_account_pubkeys = unverified_votes
-                .into_iter()
+                .iter()
                 .map(|v| v.sender_vote_account_pubkey)
                 .collect();
             (
@@ -400,7 +400,7 @@ fn ban_invalid_vote_sender(
 /// path.
 #[must_use]
 fn verify_votes_optimistic(
-    vote_payload_to_sign: VotePayloadToSign,
+    vote_payload_to_sign: &VotePayloadToSign,
     unverified_votes: &[UnverifiedVotePayload],
     stats: &mut VoteVerificationStats,
     thread_pool: &ThreadPool,
@@ -468,14 +468,14 @@ fn aggregate_signatures(votes: &[UnverifiedVotePayload]) -> Result<SignatureProj
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn aggregate_pubkeys_by_payload(
-    vote_payload_to_sign: VotePayloadToSign,
+    vote_payload_to_sign: &VotePayloadToSign,
     votes: &[UnverifiedVotePayload],
 ) -> (
     PreparedHashedMessage,
     Result<PopVerified<PubkeyProjective>, BlsError>,
 ) {
     debug_assert!(current_thread_index().is_some());
-    let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
+    let serialized_vote = wincode::serialize(vote_payload_to_sign).unwrap();
     let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
     // converting aggregate pubkey to `PopVerified` is safe here
     // since the pubkeys are all PoP verified in the vote account
@@ -493,7 +493,7 @@ fn aggregate_pubkeys_by_payload(
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn verify_individual_votes(
     max_validators: usize,
-    unverified_votes: Vec<UnverifiedVotePayload>,
+    unverified_votes: &[UnverifiedVotePayload],
     prepared_hash_msg: PreparedHashedMessage,
     thread_pool: &ThreadPool,
 ) -> (Vec<VerifiedVotePayload>, Vec<(Pubkey, BlsError)>) {


### PR DESCRIPTION
#### Problem

bls-sigverify is allocating memory for a `HashMap` in each iteration of its `run` loop and bls-vote-sigverify is subsequently freeing this memory.  This is putting a lot of load on the memory subsystem.


#### Summary of Changes

This PR updates the code so that we are reusing the `HashMap` buffer.  The `HashMap` is passed as a reference to bls-vote-sigverify and bls-sigverify allocates it just once.

We are still reallocating the memory for the `Vec` in the `HashMap`.  In a subsequent PR, we will introduce an arena for the `Vec` to eliminate those reallocations as well.


#### Testing

No new tests added