### PR TITLE
chore(votor): move ABI coverage off bincode to wincode only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,8 +504,6 @@ dependencies = [
  "log",
  "parking_lot 0.12.5",
  "rand 0.9.4",
- "serde",
- "serde_bytes",
  "smallvec",
  "solana-bls-signatures",
  "solana-clock",

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -28,7 +28,7 @@ fn sample_hash(rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized)) -> Ha
 }
 
 /// An alpenglow block
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(
     Clone,
     Copy,

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -69,10 +69,7 @@ pod_wrapper! {
     unsafe struct PodBLSSignature(BLSSignature);
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireVoteSignature {
     #[cfg_attr(
@@ -90,27 +87,21 @@ impl From<VoteMessage> for WireVoteSignature {
     }
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireBlockVoteMessage {
     pub(crate) block: Block,
     pub(crate) signature: WireVoteSignature,
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireSlotVoteMessage {
     pub(crate) slot: Slot,
     pub(crate) signature: WireVoteSignature,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 /// Signature on a wire cert message
@@ -135,17 +126,14 @@ impl From<Certificate> for WireCertSignature {
     }
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireSlotCertMessage {
     pub(crate) slot: Slot,
     pub(crate) signature: WireCertSignature,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 /// A wire cert message that holds a block.
@@ -156,10 +144,7 @@ pub struct WireBlockCertMessage {
     pub signature: WireCertSignature,
 }
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, AbiEnumVisitor, Serialize)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead)]
 #[wincode(tag_encoding = "u8")]
 pub(crate) enum WireConsensusMessageKind {
@@ -270,10 +255,7 @@ impl WireConsensusMessageKind {
 /// Context wrapper for the expected shred version during deserialization.
 pub struct ExpectedShredVersion(pub u16);
 
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize, SchemaRead)
-)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample, SchemaRead))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite)]
 /// First version of a wire consensus message
 pub struct WireConsensusMessageV1 {
@@ -338,16 +320,8 @@ impl WireConsensusMessageV1 {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(
-        AbiExample,
-        AbiEnumVisitor,
-        StableAbi,
-        StableAbiSample,
-        Serialize,
-        SchemaRead
-    ),
+    derive(StableAbi, StableAbiSample, SchemaRead),
     frozen_abi(
-        digest = "BuNdLfQfseGa7sL29neSwUYqrWo1AVRyTYxMGxLATzia",
         abi_digest = "ErGjoTr18hn3dvPVA7jFgK5WLwb4jgx7a39Yn8dSzB2K",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",
@@ -434,9 +408,8 @@ impl VersionedWireConsensusMessage {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize),
+    derive(StableAbi, StableAbiSample),
     frozen_abi(
-        digest = "FaLMAAzQUX8FfCZhUqETKB1xdBwQuC3pwz2mEaC6t3Gb",
         abi_digest = "2aBMTuPyDgGSYeYX1aBbXURgA4qqr92Eh9yiTeHX6qZq",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -23,8 +23,6 @@ dev-context-only-utils = [
     "solana-runtime/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dep:serde",
-    "dep:serde_bytes",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-ledger/frozen-abi",
@@ -46,8 +44,6 @@ crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
-serde = { workspace = true, optional = true }
-serde_bytes = { workspace = true, optional = true }
 smallvec = { workspace = true }
 solana-bls-signatures = { workspace = true, features = ["solana-signer-derive"] }
 solana-clock = { workspace = true }

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -34,7 +34,7 @@ impl VoteHistoryVersions {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample),
+    derive(StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "MYpTecggZfULsn6SC1bojefNFK1R5kjBZg7wE8H8dHF",
         abi_serializer = "wincode"

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "frozen-abi")]
-use serde::{Deserialize, Serialize};
 use {
     super::vote_history::*,
     log::trace,
@@ -31,10 +29,10 @@ fn vote_history_wincode_config() -> VoteHistoryWincodeConfig {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize, Deserialize),
+    derive(StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "4VVxd5brhUZgopYJ7zwAYC8J62zU2nUZSAV4kETb3m9q",
-        abi_serializer = ["bincode", "wincode"],
+        abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",
     )
 )]
@@ -87,24 +85,18 @@ impl From<SavedVoteHistory> for SavedVoteHistoryVersions {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, Serialize, Deserialize),
+    derive(StableAbi, StableAbiSample),
     frozen_abi(
-        digest = "J6vB6FWFT8CFEvxndXWes461hroo8Q5L9Wq9cv4FEzaQ",
         abi_digest = "Mhh4tHGaVTfWbkJ78sY1dDbYZHtQjXiVFBtC3BfQH5C",
-        abi_serializer = ["bincode", "wincode"],
+        abi_serializer = "wincode",
     )
 )]
 #[derive(Default, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub struct SavedVoteHistory {
     signature: Signature,
-    #[cfg_attr(feature = "frozen-abi", serde(with = "serde_bytes"))]
     data: Vec<u8>,
     #[wincode(skip)]
-    #[cfg_attr(
-        feature = "frozen-abi",
-        serde(skip),
-        stable_abi_sample(with = "Default::default()")
-    )]
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     node_pubkey: Pubkey,
 }
 


### PR DESCRIPTION
#### Problem
Votor persists and transmits everything with wincode, but both crates still carry the bincode-shaped half of frozen-abi: `AbiExample`/`AbiEnumVisitor` derives, two `digest = ` roots, and `abi_serializer = ["bincode", "wincode"]` on the vote history types. Every one of those already has a `StableAbi` + wincode `abi_digest` sibling with `test_roundtrip = "eq_and_wire"`, so the bincode side pins a format neither crate writes.

The serde derives exist only to feed the bincode digester. In `agave-votor` they are the sole reason `serde` and `serde_bytes` are dependencies at all - both are optional and enabled only by the `frozen-abi` feature. In `agave-votor-messages` most of them sit inside `cfg_attr(frozen-abi, ...)`, next to the ones that are genuinely part of the RPC surface.

#### Summary of Changes
- drop the `AbiExample`/`AbiEnumVisitor` derives and the three `digest = ` api roots
- narrow `abi_serializer` to `"wincode"`; the `abi_digest` values are unchanged, so the surviving tests pin the same bytes
- drop the frozen-abi-only serde derives and attributes, and with them votor's `serde` and `serde_bytes` deps
- votor lib tests go 152 -> 149 and votor-messages 7 -> 5, exactly the five bincode/api digest tests removed

#### Testing
`ci/test-frozen-abi.sh` over every package exposing the feature:
```    
                         packages   digest tests
      before (master)          18             74
      after                    18             69
```    
The five that go are exactly the bincode and api ones, no digest value changed:
```    
      agave-votor           SavedVoteHistory::test_api_digest
                            SavedVoteHistory::test_abi_digest_bincode
                            SavedVoteHistoryVersions::test_abi_digest_bincode
      agave-votor-messages  VotePayloadToSign::test_api_digest
                            VersionedWireConsensusMessage::test_api_digest
```    
Full lib tests move by the same five: votor 152 -> 149, votor-messages 7 -> 5.

