### PR TITLE
ledger-tool: warn when a snapshot archive already exists for the target slot

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -103,6 +103,7 @@ signal-hook = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 solana-bls-signatures = { workspace = true }
+solana-hash = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -185,6 +185,25 @@ impl FromStr for GraphVoteAccountMode {
     }
 }
 
+/// Returns true if a full (or incremental, per `is_incremental`) snapshot archive already
+/// exists for `slot` in `snapshot_archives_dir`. A snapshot archive filename encodes the
+/// accounts hash, so an existing archive for `slot` is not overwritten by a new one with a
+/// different hash; both remain on disk. See:
+/// https://github.com/anza-xyz/agave/issues/15164
+fn snapshot_archive_exists_for_slot(
+    snapshot_archives_dir: &Path,
+    slot: Slot,
+    is_incremental: bool,
+) -> bool {
+    if is_incremental {
+        agave_snapshots::paths::incremental_snapshot_archives_iter(snapshot_archives_dir)
+            .any(|info| info.slot() == slot)
+    } else {
+        agave_snapshots::paths::full_snapshot_archives_iter(snapshot_archives_dir)
+            .any(|info| info.slot() == slot)
+    }
+}
+
 struct GraphConfig {
     include_all_votes: bool,
     vote_account_mode: GraphVoteAccountMode,
@@ -2176,6 +2195,32 @@ fn main() {
                         None,
                     );
 
+                    // This is easy to hit when following a coordinated-restart runbook (e.g. a
+                    // hard fork) that asks for a snapshot at a slot the validator already
+                    // snapshotted on its own.
+                    if snapshot_archive_exists_for_slot(
+                        &output_directory,
+                        snapshot_slot,
+                        is_incremental,
+                    ) {
+                        warn!(
+                            "A {snapshot_type_str}snapshot archive for slot {snapshot_slot} \
+                             already exists in {}; the new archive will not replace it, and which \
+                             one a validator loads at startup depends on their accounts hashes, \
+                             not on which was created most recently.",
+                            output_directory.display(),
+                        );
+                    }
+                    if let Some(starting_snapshot_hashes) = starting_snapshot_hashes
+                        && starting_snapshot_hashes.full.0.0 == snapshot_slot
+                    {
+                        warn!(
+                            "Snapshot slot {snapshot_slot} is the same slot the ledger was loaded \
+                             from; the new snapshot will be generated from that same base state \
+                             rather than a distinct, more recent one.",
+                        );
+                    }
+
                     let mut bank = bank_forks
                         .read()
                         .unwrap()
@@ -3324,4 +3369,54 @@ fn main() {
     };
     measure_total_execution_time.stop();
     info!("{measure_total_execution_time}");
+}
+
+#[cfg(test)]
+mod snapshot_archive_exists_for_slot_tests {
+    use {super::*, solana_hash::Hash, std::fs::File};
+
+    fn touch_full_snapshot_archive(dir: &Path, slot: Slot, hash: Hash) {
+        File::create(dir.join(format!("snapshot-{slot}-{hash}.tar.zst"))).unwrap();
+    }
+
+    fn touch_incremental_snapshot_archive(dir: &Path, base_slot: Slot, slot: Slot, hash: Hash) {
+        File::create(dir.join(format!(
+            "incremental-snapshot-{base_slot}-{slot}-{hash}.tar.zst"
+        )))
+        .unwrap();
+    }
+
+    #[test]
+    fn detects_existing_full_snapshot_archive_at_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!snapshot_archive_exists_for_slot(dir.path(), 100, false));
+
+        touch_full_snapshot_archive(dir.path(), 100, Hash::default());
+        assert!(snapshot_archive_exists_for_slot(dir.path(), 100, false));
+        // A full snapshot at a different slot must not match.
+        assert!(!snapshot_archive_exists_for_slot(dir.path(), 200, false));
+        // Looking for an *incremental* snapshot at the same slot must not match a full one.
+        assert!(!snapshot_archive_exists_for_slot(dir.path(), 100, true));
+    }
+
+    #[test]
+    fn detects_existing_incremental_snapshot_archive_at_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!snapshot_archive_exists_for_slot(dir.path(), 150, true));
+
+        touch_incremental_snapshot_archive(dir.path(), 100, 150, Hash::default());
+        assert!(snapshot_archive_exists_for_slot(dir.path(), 150, true));
+        assert!(!snapshot_archive_exists_for_slot(dir.path(), 150, false));
+    }
+
+    /// Regression test for https://github.com/anza-xyz/agave/issues/15164: a snapshot archive
+    /// filename encodes the accounts hash, so a newly created archive for a restart slot does
+    /// not overwrite a pre-existing archive for that same slot with a different hash. Detection
+    /// must find the pre-existing archive regardless of which hash it was made with.
+    #[test]
+    fn detects_existing_archive_with_a_different_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        touch_full_snapshot_archive(dir.path(), 100, Hash::new_from_array([7; 32]));
+        assert!(snapshot_archive_exists_for_slot(dir.path(), 100, false));
+    }
 }


### PR DESCRIPTION
#### Problem

`ledger-tool create-snapshot` does not overwrite an existing snapshot archive for the
target slot, because the archive filename encodes the accounts hash
(`snapshot-<slot>-<hash>.tar.zst`). If an archive for that slot already exists with a
different hash, the new one is written alongside it instead, and the two are now
indistinguishable by recency to `get_highest_full_snapshot_archive_info` /
`get_highest_incremental_snapshot_archive_info`, which order by slot only. Which of the
two a validator loads at startup then depends on their accounts hashes, not on which was
created most recently.

This is easy to hit when following a coordinated-restart runbook (e.g. a hard fork) that
asks an operator to create a snapshot at a slot their validator had already snapshotted
on its own before the restart was announced, as reported in #15164.

#### Summary of Changes

- Warn (do not block or delete) when a full/incremental snapshot archive already exists
  for the requested `--snapshot-slot` in the output directory.
- Warn when `--snapshot-slot` is the same slot the ledger was loaded from, i.e. the new
  snapshot will be generated from that same base state rather than a distinct one.

Per the discussion on #15164, a warning was preferred over silently deleting the existing
archive; this keeps `create-snapshot` non-destructive while surfacing the ambiguity to the
operator so they can decide (e.g. remove the stale archive themselves) before restarting.

#### Testing

- `cargo test -p agave-ledger-tool snapshot_archive_exists_for_slot_tests`: 3 new unit
  tests for the added `snapshot_archive_exists_for_slot` helper (full snapshot match,
  incremental snapshot match, and a match against an archive with a different hash).
- `cargo check -p agave-ledger-tool`, `cargo clippy -p agave-ledger-tool --all-targets`,
  `cargo +nightly fmt --check` (from `ledger-tool/`): clean.

Part of #15164
