### PR TITLE
storage-proto: reserve tags for the BailOut and unknown error variants

### DIFF
--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -64,6 +64,10 @@ enum TransactionErrorType {
     UNBALANCED_TRANSACTION = 36;
     PROGRAM_CACHE_HIT_MAX_LIMIT = 37;
     COMMIT_CANCELLED = 38;
+    BAIL_OUT_TX = 39;
+
+    // Out of band so it never collides with a sequentially allocated variant.
+    UNKNOWN_TX = 1000;
 }
 
 message InstructionError {
@@ -131,6 +135,10 @@ enum InstructionErrorType {
     MAX_ACCOUNTS_EXCEEDED = 51;
     MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED = 52;
     BUILTIN_PROGRAMS_MUST_CONSUME_COMPUTE_UNITS = 53;
+    BAIL_OUT = 54;
+
+    // Out of band so it never collides with a sequentially allocated variant.
+    UNKNOWN = 1000;
 }
 
 message UnixTimestamp {


### PR DESCRIPTION
#### Problem
* `solana-instruction-error=3.0` and `solana-transaction-error=4.0` add a `BailOut` variant to both error enums and mark the enums `#[non_exhaustive]`, so every future variant lands the same way
* the tx_by_addr enums back BigTable's transaction-by-address index, an append-only wire format shared by every writer and reader of that table, so a tag number is permanent once anything emits it
* the tags should be claimed in their own change: the allocation gets reviewed on its own rather than buried in a crate bump, and readers that reject unknown tags can ship ahead of the first writer
* the native-to-proto conversions are infallible `From` impls, so a `#[non_exhaustive]` wildcard needs somewhere to land that is not a panic
* proto enum values are package-scoped, so the transaction-side names cannot repeat the instruction-side ones

#### Summary of Changes
* reserve `BAIL_OUT_TX = 39` / `BAIL_OUT = 54` for the new variant
* reserve `UNKNOWN_TX` / `UNKNOWN` at 1000, out of band, so the catch-all never collides with a sequentially allocated variant
* keep the `_TX` suffix convention already used by `ACCOUNT_BORROW_OUTSTANDING`
* leave the convert.rs arms out - the variants do not exist yet in the currently pinned crates

#### Testing
CI
