### PR TITLE
Correct the Git commit hash in incremental builds

### DIFF
--- a/version/build.rs
+++ b/version/build.rs
@@ -1,6 +1,22 @@
 use std::process::Command;
 
 fn main() {
+    // Watch both worktree-local and shared refs, including reftable storage.
+    if let Ok(output) = Command::new("git")
+        .args(["rev-parse", "--git-dir", "--git-common-dir"])
+        .output()
+        && output.status.success()
+        && let Ok(dirs) = String::from_utf8(output.stdout)
+    {
+        for dir in dirs.lines() {
+            for name in ["HEAD", "refs", "packed-refs", "reftable"] {
+                let path = std::path::Path::new(dir).join(name);
+                if path.exists() {
+                    println!("cargo:rerun-if-changed={}", path.display());
+                }
+            }
+        }
+    }
     if let Ok(git_output) = Command::new("git").args(["rev-parse", "HEAD"]).output()
         && git_output.status.success()
         && let Ok(git_commit_hash) = String::from_utf8(git_output.stdout)


### PR DESCRIPTION
#### Problem

Without `CI_COMMIT`, a validator compiled at commit B can show the hash from commit A.

If only code outside `version/` changes, Cargo can use the stored `solana-version` crate. The build script reads the hash but does not include Git refs as build inputs. Thus, Cargo can keep `AGAVE_GIT_COMMIT_HASH=A` after the next build.

| Build | Hash before this change | Hash after this change |
| --- | --- | --- |
| The first build uses commit A. | A | A |
| Only code outside `version/` changes. An incremental build uses commit B. | A (incorrect) | B (correct) |
| A clean build uses commit B, or `CI_COMMIT` is B. | B | B |

#### Changes

The build script adds `cargo:rerun-if-changed` instructions for `HEAD`, `refs`, `packed-refs`, and `reftable` in the worktree and common Git directories. Git ref changes then cause Cargo to start the script again. If a path is missing, the script adds no instruction for that path.

Other Git ref changes can also cause Cargo to compile `solana-version` again.

This change also corrects the hash for the monitor in #15176.
