### PR TITLE
bls-sigverify: moves processing of verified votes out of fold/reduce

### DIFF
--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -32,7 +32,6 @@ use {
         pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature},
         signature::SignatureAffine,
     },
-    solana_clock::Slot,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_measure::{measure::Measure, measure_us},
     solana_pubkey::Pubkey,
@@ -43,14 +42,6 @@ use {
         sync::Arc,
     },
 };
-
-#[derive(Default)]
-struct ProcessedVotes {
-    reward_msg: Vec<VoteAggregate>,
-    repair_msg: HashMap<Slot, Vec<Pubkey>>,
-    vote_aggregates_for_pool: Vec<VoteAggregate>,
-    metrics_msg: Vec<ConsensusMetricsEvent>,
-}
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 struct VerifiedVotePayload {
@@ -93,30 +84,6 @@ impl UnverifiedVotePayload {
     }
 }
 
-fn verify_vote_batch(
-    root_bank: &Bank,
-    my_pubkey: &Pubkey,
-    leader_schedule: &LeaderScheduleCache,
-    ban_sender: &BanSender,
-    thread_pool: &ThreadPool,
-    rank_map: &BLSPubkeyToRankMap,
-    vote_payload_to_sign: &VotePayloadToSign,
-    unverified_votes: &[UnverifiedVotePayload],
-) -> (VoteVerificationStats, ProcessedVotes) {
-    let max_validators = rank_map.len();
-    let (verified_votes, vote_verification_stats) = verify_votes(
-        max_validators,
-        vote_payload_to_sign,
-        unverified_votes,
-        ban_sender,
-        thread_pool,
-    );
-
-    let processed_votes =
-        process_verified_votes(verified_votes, root_bank, my_pubkey, leader_schedule);
-    (vote_verification_stats, processed_votes)
-}
-
 /// Verifies votes and sends the verified votes to the consensus pool; and sends the desired subset
 /// to rewards container and repair.
 ///
@@ -149,18 +116,18 @@ pub(super) fn verify_and_send_votes(
                 ParResult::default,
                 |mut par_result, (vote_payload_to_sign, (unverified_votes, rank_map))| {
                     let num_votes_to_sigverify = unverified_votes.len();
-                    let (vote_verification_stats, processed_votes) = verify_vote_batch(
-                        root_bank,
-                        my_pubkey,
-                        leader_schedule,
-                        ban_sender,
-                        thread_pool,
-                        rank_map,
+                    let vote = Vote::from(*vote_payload_to_sign);
+                    let max_validators = rank_map.len();
+                    let (verified_votes, vote_verification_stats) = verify_votes(
+                        max_validators,
                         vote_payload_to_sign,
                         unverified_votes,
+                        ban_sender,
+                        thread_pool,
                     );
                     par_result.add(
-                        processed_votes,
+                        vote,
+                        verified_votes,
                         vote_verification_stats,
                         num_votes_to_sigverify,
                     );
@@ -172,7 +139,13 @@ pub(super) fn verify_and_send_votes(
                 left
             })
     });
-    let sender_stats = send_msgs(my_pubkey, channels, par_result.processed_votes)?;
+    let sender_stats = process_and_send_verified_votes(
+        root_bank,
+        leader_schedule,
+        my_pubkey,
+        channels,
+        par_result.verified_votes,
+    )?;
     stats.votes_to_sig_verify += par_result.num_votes_to_sigverify;
     stats
         .vote_verification_stats
@@ -186,99 +159,51 @@ pub(super) fn verify_and_send_votes(
     Ok(stats)
 }
 
-/// If the vote is relevant to repair, then adds it to the [`msgs_for_repair`] so it can eventually
-/// be sent to repair.
-fn inspect_for_repair(
-    vote: &VerifiedVotePayload,
-    msgs_for_repair: &mut HashMap<Slot, Vec<Pubkey>>,
-) {
-    let vote_slot = vote.vote_aggregate.vote().slot();
-    match vote.vote_aggregate.vote() {
-        Vote::Notarize(_) | Vote::Finalize(_) | Vote::NotarizeFallback(_) => {
-            msgs_for_repair
-                .entry(vote_slot)
-                .or_default()
-                .extend(&vote.sender_vote_account_pubkeys);
-        }
-        Vote::Skip(_) | Vote::SkipFallback(_) | Vote::Genesis(_) => (),
-    }
-}
-
-/// Processes the verified votes for various downstream services.
-///
-/// In particular, collects and returns the relevant messages for the consensus pool; rewards;
-/// repair; and metrics;
-fn process_verified_votes(
-    verified_votes: Vec<VerifiedVotePayload>,
+fn process_and_send_verified_votes(
     root_bank: &Bank,
-    my_pubkey: &Pubkey,
     leader_schedule: &LeaderScheduleCache,
-) -> ProcessedVotes {
-    let mut votes_for_reward = Vec::with_capacity(verified_votes.len());
-    let mut msgs_for_repair = HashMap::new();
-    let mut vote_aggregates_for_pool = Vec::with_capacity(verified_votes.len());
-    let mut votes_for_metrics = Vec::with_capacity(verified_votes.len());
-    for payload in verified_votes {
-        inspect_for_repair(&payload, &mut msgs_for_repair);
-
-        votes_for_metrics.push(ConsensusMetricsEvent::Vote {
-            ids: payload.sender_vote_account_pubkeys,
-            vote: *payload.vote_aggregate.vote(),
-        });
-        if rewards_wants_vote(
-            my_pubkey,
-            leader_schedule,
-            root_bank.slot(),
-            payload.vote_aggregate.vote(),
-        ) {
-            votes_for_reward.push(payload.vote_aggregate.clone());
-        }
-        vote_aggregates_for_pool.push(payload.vote_aggregate);
-    }
-    let msgs_for_repair = msgs_for_repair
-        .into_iter()
-        .map(|(pubkey, mut slots)| {
-            slots.sort_unstable();
-            slots.dedup();
-            (pubkey, slots)
-        })
-        .collect();
-    ProcessedVotes {
-        reward_msg: votes_for_reward,
-        repair_msg: msgs_for_repair,
-        vote_aggregates_for_pool,
-        metrics_msg: votes_for_metrics,
-    }
-}
-
-fn send_msgs(
     my_pubkey: &Pubkey,
     channels: &SigVerifierChannels,
-    processed_votes: Vec<ProcessedVotes>,
+    verified_votes: Vec<(Vote, Vec<VerifiedVotePayload>)>,
 ) -> Result<VoteSenderStats, SigVerifyVoteError> {
     let mut sender_stats = VoteSenderStats::default();
-    for vote in processed_votes {
+    for (vote, payloads) in verified_votes {
+        let (aggregates, pubkeys_grouped): (Vec<_>, Vec<_>) = payloads
+            .into_iter()
+            .map(|payload| (payload.vote_aggregate, payload.sender_vote_account_pubkeys))
+            .unzip();
+        let pubkeys = pubkeys_grouped.into_iter().flatten().collect::<Vec<_>>();
+        if rewards_wants_vote(my_pubkey, leader_schedule, root_bank.slot(), &vote) {
+            send_votes_to_rewards(
+                my_pubkey,
+                aggregates.clone(),
+                &channels.channel_to_reward,
+                &mut sender_stats,
+            );
+        }
         send_sig_verified_batch_to_pool(
             my_pubkey,
-            SigVerifiedBatch::Votes(vote.vote_aggregates_for_pool),
+            SigVerifiedBatch::Votes(aggregates),
             &channels.channel_to_pool,
             &mut sender_stats,
         )?;
-        send_votes_to_repair(
-            my_pubkey,
-            vote.repair_msg,
-            &channels.channel_to_repair,
-            &mut sender_stats,
-        );
-        send_votes_to_rewards(
-            my_pubkey,
-            vote.reward_msg,
-            &channels.channel_to_reward,
-            &mut sender_stats,
-        );
+        match vote {
+            Vote::Notarize(_) | Vote::Finalize(_) | Vote::NotarizeFallback(_) => {
+                let vote_slot = vote.slot();
+                let repair_msg = HashMap::from([(vote_slot, pubkeys.clone())]);
+                send_votes_to_repair(
+                    my_pubkey,
+                    repair_msg,
+                    &channels.channel_to_repair,
+                    &mut sender_stats,
+                );
+            }
+            Vote::Skip(_) | Vote::SkipFallback(_) | Vote::Genesis(_) => (),
+        }
+        let metrics_msg = ConsensusMetricsEvent::Vote { ids: pubkeys, vote };
         send_votes_to_metrics(
             my_pubkey,
-            vote.metrics_msg,
+            vec![metrics_msg],
             &channels.channel_to_metrics,
             &mut sender_stats,
         );
@@ -512,7 +437,7 @@ fn verify_individual_votes(
 
 #[derive(Default)]
 struct ParResult {
-    processed_votes: Vec<ProcessedVotes>,
+    verified_votes: Vec<(Vote, Vec<VerifiedVotePayload>)>,
     verification_stats: VoteVerificationStats,
     num_votes_to_sigverify: Saturating<usize>,
 }
@@ -520,22 +445,25 @@ struct ParResult {
 impl ParResult {
     fn add(
         &mut self,
-        processed_votes: ProcessedVotes,
+        vote: Vote,
+        verified_votes: Vec<VerifiedVotePayload>,
         verification_stats: VoteVerificationStats,
         num_votes_to_sigverify: usize,
     ) {
-        self.processed_votes.push(processed_votes);
+        if !verified_votes.is_empty() {
+            self.verified_votes.push((vote, verified_votes));
+        }
         self.verification_stats.merge(verification_stats);
         self.num_votes_to_sigverify += num_votes_to_sigverify;
     }
 
     fn merge(&mut self, other: Self) {
         let Self {
-            mut processed_votes,
+            mut verified_votes,
             verification_stats,
             num_votes_to_sigverify,
         } = other;
-        self.processed_votes.append(&mut processed_votes);
+        self.verified_votes.append(&mut verified_votes);
         self.verification_stats.merge(verification_stats);
         self.num_votes_to_sigverify += num_votes_to_sigverify;
     }


### PR DESCRIPTION
#### Problem

Currently vote-sigverify aggregates the batches of votes that it verifies into a single `ProcessedVotes` which is then processed to send msgs to downstream services.

This aggregation incurs reallocations in sigverify which we would like to eliminate.


#### Summary of Changes

- This PR moves the creation of `ProcessedVotes` out of the fold/reduce stage effectively removing it.
- Now we are able to "process" the votes and send them on the channels in the same shot.  This gives us opportunities to reduce reallocations.  Note that we couldn't send inside the fold/reduce stage as that will cause a lot of contentions for the locks on the channels.
- Subsequent PRs will update the downstream services so we can send them individual elements from the HashMap or the Vec instead which will reduce the amount of stress we are putting on the memory subsystem.  We will of course make sure that the downstream services can still keep up.


#### Testing

I compared this code to the top of agave master on the invalidator cluster.  I did not see us blocking / dropping msgs on any of the channels downstream.  I also did not notice any perf changes.  This is not surprising as we did not really reduce reallocations yet.  
