### PR TITLE
chore(accounts-db): digest BlockhashQueue by bytes, not by serde shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9146,8 +9146,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
  "solana-hash",
  "solana-pubkey 4.3.0",
  "solana-sha256-hasher",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -38,8 +38,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-fee-calculator/frozen-abi",
-    "solana-nonce/frozen-abi",
-    "solana-vote-program/frozen-abi",
+    "solana-hash/frozen-abi",
 ]
 
 [dependencies]

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -12,7 +12,7 @@ use {
 };
 
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct HashInfo {
     fee_calculator: FeeCalculator,
@@ -29,9 +29,8 @@ impl HashInfo {
 /// Low memory overhead, so can be cloned for every checkpoint
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample),
+    derive(StableAbi, StableAbiSample),
     frozen_abi(
-        api_digest = "6dJKUuLbK5FVbUvNf7YwaGxJDkBTWvV9vfXevAFkHR5u",
         abi_digest = "5ojmBDhhu9AjKUc1LSHhZfXF6KeicvZpKP6XdLNaFAdy",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "agave-unstable-api")]
-#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod account_info;


### PR DESCRIPTION
#### Problem
`BlockhashQueue` is the last accounts-db type still carrying an `api_digest` root and `AbiExample` derives, though its `abi_digest` already pins the bytes for both bincode and wincode, and every other dual-codec snapshot type is `abi_digest`-only. The derives also force `min_specialization` and mask a missing `solana-hash/frozen-abi` edge, borrowed from `solana-nonce` instead.

#### Summary of Changes
- drop the `AbiExample` derives on `HashInfo` and `BlockhashQueue`
- drop the `api_digest` root; `abi_digest` and both serializers stay unchanged
- drop `#![feature(min_specialization)]`
- depend on `solana-hash/frozen-abi` directly and drop the `solana-nonce` and `solana-vote-program` edges that were standing in for it

#### Testing
`ci/test-frozen-abi.sh` over every package exposing the feature:
```
                         packages       digest tests 
before (master)          18             69 
after                    18             68
```

* Only `BlockhashQueue::test_api_digest` goes; both `test_abi_digest_*` remain on the same digest value, and runtime still passes all 24 of its own.
* `api_digest` pinned serde field names, which only matters to JSON consumers; `BlockhashQueue` has none - it never appears under `rpc/`.  
