### PR TITLE
tpu-client-next: make it rtt adjusted

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -32,7 +32,7 @@ use {
         connection_workers_scheduler::{
             BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
-        leader_updater::LeaderUpdater,
+        leader_updater::{LeaderUpdater, SlotEstimate},
     },
     solana_transaction::sanitized::MessageHash,
     solana_transaction_error::TransportError,
@@ -504,8 +504,13 @@ impl ForwardingClient for VoteClient {
 }
 
 impl LeaderUpdater for ForwardAddressGetter {
-    fn next_leaders(&mut self, lookahead_slots: usize, leaders: &mut Vec<SocketAddr>) {
+    fn next_leaders(
+        &mut self,
+        lookahead_slots: usize,
+        leaders: &mut Vec<SocketAddr>,
+    ) -> Option<SlotEstimate> {
         self.non_vote_forwarding_addresses(lookahead_slots as u64, leaders);
+        None
     }
 }
 
@@ -562,6 +567,8 @@ impl TpuClientNextClient {
             num_connections: NonZeroUsize::new(128).unwrap(),
             worker_channel_size: WORKER_CHANNEL_CAPACITY,
             max_reconnect_attempts: 4,
+            skip_current_leader_if_late: false,
+            slot_update_latency: 0,
             // Send to the next leader only, but verify that connections exist
             // for the leaders of the next `4 * NUM_CONSECUTIVE_SLOTS`.
             leaders_fanout: Fanout {

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -5,7 +5,8 @@ use {
     solana_measure::measure::Measure,
     solana_tls_utils::NotifyKeyUpdate,
     solana_tpu_client_next::{
-        Client, ClientBuilder, ClientError, TransactionSender, leader_updater::LeaderUpdater,
+        Client, ClientBuilder, ClientError, TransactionSender,
+        leader_updater::{LeaderUpdater, SlotEstimate},
     },
     std::{
         net::{SocketAddr, UdpSocket},
@@ -188,7 +189,11 @@ impl<T> LeaderUpdater for SendTransactionServiceLeaderUpdater<T>
 where
     T: TpuInfoWithSendStatic,
 {
-    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+    fn next_leaders(
+        &mut self,
+        lookahead_leaders: usize,
+        leaders: &mut Vec<SocketAddr>,
+    ) -> Option<SlotEstimate> {
         if let Some(tpu_peers) = &self.tpu_peers {
             leaders.extend_from_slice(tpu_peers);
         }
@@ -203,5 +208,6 @@ where
         } else {
             leaders.push(self.my_tpu_address);
         }
+        None
     }
 }

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -85,6 +85,8 @@ pub struct ClientBuilder {
     sender_channel_size: usize,
     worker_channel_size: Option<usize>,
     max_reconnect_attempts: usize,
+    skip_current_leader_if_late: bool,
+    slot_update_latency: u64,
     broadcaster: Box<dyn WorkersBroadcaster>,
     report_fn: Option<ReportFn>,
     cancel_scheduler: CancellationToken,
@@ -107,6 +109,8 @@ impl ClientBuilder {
             // By default, use the same size for the worker channel.
             worker_channel_size: None,
             max_reconnect_attempts: 2,
+            skip_current_leader_if_late: true,
+            slot_update_latency: 50,
             broadcaster: Box::new(NonblockingBroadcaster),
             report_fn: None,
             cancel_scheduler: CancellationToken::new(),
@@ -183,6 +187,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Enable or disable skipping the current leader when a transaction is expected to arrive
+    /// after its leader window ends. Enabled by default.
+    pub fn skip_current_leader_if_late(mut self, enabled: bool) -> Self {
+        self.skip_current_leader_if_late = enabled;
+        self
+    }
+
+    /// Set the assumed delay between slot progress and receiving the corresponding slot update.
+    pub fn slot_update_latency(mut self, latency: u64) -> Self {
+        self.slot_update_latency = latency;
+        self
+    }
+
     /// Set the initial congestion window size in bytes.
     ///
     /// If not set, defaults to INITIAL_CONGESTION_WINDOW.
@@ -220,6 +237,8 @@ impl ClientBuilder {
             num_connections: self.num_connections,
             worker_channel_size: self.worker_channel_size.unwrap_or(self.sender_channel_size),
             max_reconnect_attempts: self.max_reconnect_attempts,
+            skip_current_leader_if_late: self.skip_current_leader_if_late,
+            slot_update_latency: self.slot_update_latency,
             // We open connection to one more leader in advance, which time-wise means ~1.6s
             leaders_fanout: Fanout {
                 connect: self.leader_send_fanout.saturating_add(1),

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -16,7 +16,10 @@ use {
     solana_tls_utils::socket_addr_to_quic_server_name,
     std::{
         net::SocketAddr,
-        sync::{Arc, atomic::Ordering},
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
     },
     tokio::{
         sync::mpsc,
@@ -24,6 +27,8 @@ use {
     },
     tokio_util::sync::CancellationToken,
 };
+
+pub(crate) const RTT_UNSET: u64 = u64::MAX;
 
 /// The maximum connection handshake timeout for QUIC connections.
 /// This is set to 2 seconds, which was the earlier shorter connection idle timeout
@@ -80,6 +85,7 @@ pub(crate) struct ConnectionWorker {
     last_congestion_events: u64,
     max_reconnect_attempts: usize,
     send_transaction_stats: Arc<SendTransactionStats>,
+    rtt_ms: Arc<AtomicU64>,
     handshake_timeout: Duration,
     cancel: CancellationToken,
 }
@@ -99,6 +105,7 @@ impl ConnectionWorker {
         transaction_receiver: mpsc::Receiver<WireTransaction>,
         max_reconnect_attempts: usize,
         send_transaction_stats: Arc<SendTransactionStats>,
+        rtt_ms: Arc<AtomicU64>,
         handshake_timeout: Duration,
     ) -> (Self, CancellationToken) {
         let cancel = CancellationToken::new();
@@ -110,6 +117,7 @@ impl ConnectionWorker {
             last_congestion_events: 0,
             max_reconnect_attempts,
             send_transaction_stats,
+            rtt_ms,
             handshake_timeout,
             cancel: cancel.clone(),
         };
@@ -195,6 +203,7 @@ impl ConnectionWorker {
     /// the type of closure, records statistics, and determines whether to
     /// attempt reconnection based on the error type.
     fn handle_connection_closed(&mut self, close_reason: ConnectionError) {
+        self.rtt_ms.store(RTT_UNSET, Ordering::Relaxed);
         match &close_reason {
             ConnectionError::ConnectionClosed(close) => {
                 debug!(
@@ -264,18 +273,27 @@ impl ConnectionWorker {
                 self.peer
             );
             record_error(error, &self.send_transaction_stats);
+            self.rtt_ms.store(RTT_UNSET, Ordering::Relaxed);
             self.connection = ConnectionState::Retry(1);
             // Exit early since connection is likely broken
             return;
         } else {
-            let events = connection.stats().path.congestion_events;
+            let (congestion_events, rtt_ms) = {
+                let connection_stats = connection.stats();
+                (
+                    connection_stats.path.congestion_events,
+                    connection_stats.path.rtt.as_millis() as u64,
+                )
+            };
             self.send_transaction_stats
                 .transport_congestion_events
                 .fetch_add(
-                    events.saturating_sub(self.last_congestion_events),
+                    congestion_events.saturating_sub(self.last_congestion_events),
                     Ordering::Relaxed,
                 );
-            self.last_congestion_events = events;
+            self.last_congestion_events = congestion_events;
+
+            self.rtt_ms.store(rtt_ms, Ordering::Relaxed);
 
             self.send_transaction_stats
                 .successfully_sent
@@ -311,6 +329,8 @@ impl ConnectionWorker {
                 match res {
                     Ok(Ok(connection)) => {
                         self.last_congestion_events = 0;
+                        let rtt = connection.stats().path.rtt;
+                        self.rtt_ms.store(rtt.as_millis() as u64, Ordering::Relaxed);
                         self.connection = ConnectionState::Active(connection);
                     }
                     Ok(Err(err)) => {

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -6,11 +6,11 @@ use {
     crate::{
         QuicError, WireTransaction,
         logging::{debug, error, trace, warn},
+        node_address_service::recent_leader_slots::MS_PER_SLOT,
         quic_networking::send_data_over_stream,
         send_transaction_stats::record_error,
     },
     quinn::{ConnectError, Connection, ConnectionError, Endpoint},
-    solana_clock::DEFAULT_MS_PER_SLOT,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_measure::measure::Measure,
     solana_tls_utils::socket_addr_to_quic_server_name,
@@ -38,7 +38,7 @@ pub(crate) const DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::
 /// Interval between retry attempts for creating a new connection. This value is
 /// a best-effort estimate, based on current network conditions.
 const RETRY_SLEEP_INTERVAL: Duration =
-    Duration::from_millis(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64 * DEFAULT_MS_PER_SLOT);
+    Duration::from_millis(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64 * MS_PER_SLOT);
 
 /// [`ConnectionState`] represents the current state of a quic connection.
 ///

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -16,6 +16,7 @@ use {
     itertools::Itertools,
     quinn::{ClientConfig, Endpoint},
     solana_keypair::Keypair,
+    solana_time_utils::timestamp,
     std::{
         net::{SocketAddr, UdpSocket},
         num::NonZeroUsize,
@@ -93,6 +94,13 @@ pub struct ConnectionWorkersSchedulerConfig {
     /// The maximum number of reconnection attempts allowed in case of
     /// connection failure.
     pub max_reconnect_attempts: usize,
+
+    /// Whether to skip the current leader when a transaction is expected to arrive after its
+    /// leader window ends.
+    pub skip_current_leader_if_late: bool,
+
+    /// Assumed delay between slot progress and receiving the corresponding slot update in ms.
+    pub slot_update_latency: u64,
 
     /// Configures the number of leaders to connect to and send transactions to.
     pub leaders_fanout: Fanout,
@@ -211,6 +219,8 @@ impl ConnectionWorkersScheduler {
             num_connections,
             worker_channel_size,
             max_reconnect_attempts,
+            skip_current_leader_if_late,
+            slot_update_latency,
             leaders_fanout,
             override_initial_congestion_window: initial_congestion_window,
         }: ConnectionWorkersSchedulerConfig,
@@ -276,7 +286,8 @@ impl ConnectionWorkersScheduler {
             };
 
             next_leaders.clear();
-            leader_updater.next_leaders(leaders_fanout.connect, &mut next_leaders);
+            let leader_window_timing =
+                leader_updater.next_leaders(leaders_fanout.connect, &mut next_leaders);
             select_unique_leaders(&next_leaders, leaders_fanout.connect, &mut connect_leaders);
 
             // add future leaders to the cache to hide the latency of opening the connection.
@@ -293,7 +304,19 @@ impl ConnectionWorkersScheduler {
                 }
             }
 
-            select_unique_leaders(&next_leaders, leaders_fanout.send, &mut send_leaders);
+            if next_leaders.len() > 1
+                && should_skip_current_leader(
+                    skip_current_leader_if_late,
+                    leader_window_timing.and_then(|estimate| estimate.leader_window_end_ms),
+                    next_leaders.first().and_then(|peer| workers.rtt_ms(peer)),
+                    timestamp(),
+                    slot_update_latency,
+                )
+            {
+                select_unique_leaders(&next_leaders[1..], leaders_fanout.send, &mut send_leaders);
+            } else {
+                select_unique_leaders(&next_leaders, leaders_fanout.send, &mut send_leaders);
+            }
 
             if let Err(error) = broadcaster
                 .send_to_workers(&mut workers, &send_leaders, transaction)
@@ -373,4 +396,27 @@ fn select_unique_leaders(
 ) {
     selected_leaders.clear();
     selected_leaders.extend(leaders.iter().take(max_leaders).copied().unique());
+}
+
+/// Returns whether the current leader window has expired or estimated arrival is at or past its end.
+/// Without RTT, only an already expired window is skipped; without timing, it is retained.
+fn should_skip_current_leader(
+    enabled: bool,
+    leader_window_end_ms: Option<u64>,
+    rtt_ms: Option<u64>,
+    now_ms: u64,
+    slot_update_latency_ms: u64,
+) -> bool {
+    if !enabled {
+        return false;
+    }
+    let Some(leader_window_end_ms) = leader_window_end_ms else {
+        return false;
+    };
+    let remaining_ms = leader_window_end_ms.saturating_sub(now_ms);
+    remaining_ms == 0
+        || rtt_ms.is_some_and(|rtt_ms| {
+            let delivery_ms = rtt_ms.div_ceil(2).saturating_add(slot_update_latency_ms);
+            remaining_ms <= delivery_ms
+        })
 }

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -4,6 +4,7 @@
 //! updates, hiding the details of how leaders are retrieved and which
 //! structures are used.
 use {
+    solana_clock::Slot,
     std::{fmt, net::SocketAddr},
     thiserror::Error,
 };
@@ -22,7 +23,22 @@ pub trait LeaderUpdater: Send {
     /// If the current leader estimation is incorrect and transactions are sent to
     /// only one estimated leader, there is a risk of losing all the transactions,
     /// depending on the forwarding policy.
-    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>);
+    ///
+    /// Returns the current slot estimate, or `None` if the provider cannot supply one.
+    /// The estimate's window-end timestamp may independently be unknown.
+    fn next_leaders(
+        &mut self,
+        lookahead_leaders: usize,
+        leaders: &mut Vec<SocketAddr>,
+    ) -> Option<SlotEstimate>;
+}
+
+/// Estimated current slot and the end timestamp of its leader window.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SlotEstimate {
+    pub slot: Slot,
+    /// Estimated window end in milliseconds since the Unix epoch; `None` when unknown.
+    pub leader_window_end_ms: Option<u64>,
 }
 
 /// Error type for [`LeaderUpdater`].
@@ -57,7 +73,12 @@ struct PinnedLeaderUpdater {
 
 #[cfg(feature = "dev-context-only-utils")]
 impl LeaderUpdater for PinnedLeaderUpdater {
-    fn next_leaders(&mut self, _lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+    fn next_leaders(
+        &mut self,
+        _lookahead_leaders: usize,
+        leaders: &mut Vec<SocketAddr>,
+    ) -> Option<SlotEstimate> {
         leaders.extend_from_slice(&self.address);
+        None
     }
 }

--- a/tpu-client-next/src/node_address_service.rs
+++ b/tpu-client-next/src/node_address_service.rs
@@ -73,14 +73,13 @@
 //!
 use {
     crate::{
-        leader_updater::LeaderUpdater,
+        leader_updater::{LeaderUpdater, SlotEstimate},
         node_address_service::{
             leader_tpu_cache_service::{Error as LeaderTpuCacheServiceError, LeaderUpdateReceiver},
             slot_update_service::Error as SlotUpdateServiceError,
         },
     },
     futures::StreamExt,
-    solana_clock::Slot,
     std::{net::SocketAddr, sync::Arc},
     thiserror::Error,
     tokio::join,
@@ -173,15 +172,19 @@ impl NodeAddressService {
 
 impl NodeAddressProvider {
     /// Returns the estimated current slot.
-    pub fn estimated_current_slot(&self) -> Slot {
+    pub fn estimated_current_slot(&self) -> SlotEstimate {
         self.slot_receiver.slot()
     }
 }
 
 impl LeaderUpdater for NodeAddressProvider {
-    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+    fn next_leaders(
+        &mut self,
+        lookahead_leaders: usize,
+        leaders: &mut Vec<SocketAddr>,
+    ) -> Option<SlotEstimate> {
         self.leaders_receiver
-            .next_leaders(lookahead_leaders, leaders);
+            .next_leaders(lookahead_leaders, leaders)
     }
 }
 

--- a/tpu-client-next/src/node_address_service/leader_tpu_cache_service.rs
+++ b/tpu-client-next/src/node_address_service/leader_tpu_cache_service.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{
+        leader_updater::SlotEstimate,
         logging::{debug, error, info, warn},
         node_address_service::SlotReceiver,
     },
@@ -44,7 +45,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            lookahead_leaders: 1,
+            lookahead_leaders: 2,
             refresh_nodes_info_every: Duration::from_secs(5 * 60),
             max_consecutive_failures: 10,
         }
@@ -71,24 +72,20 @@ impl LeaderUpdateReceiver {
         &self,
         num_lookahead_leaders: usize,
         lookahead_leaders: &mut Vec<SocketAddr>,
-    ) {
+    ) -> Option<SlotEstimate> {
         let tpu_info = self.receiver.borrow();
-        let num_lookahead_leaders = if tpu_info.extend {
-            num_lookahead_leaders.saturating_add(1)
-        } else {
-            num_lookahead_leaders
-        };
         lookahead_leaders.extend(tpu_info.leaders.iter().take(num_lookahead_leaders).copied());
+        tpu_info.slot_estimate
     }
 }
 
 /// [`NodesTpuInfo`] holds the TPU addresses of the nodes scheduled to be leaders for upcoming
-/// slots. The `extend` flag indicates whether the list of leaders was extended by one to account
-/// for the case when the current slot is the last slot in a leader's consecutive slots.
+/// slots.
 #[derive(Clone)]
 struct NodesTpuInfo {
     leaders: Vec<SocketAddr>,
-    extend: bool,
+    /// Present only when the first candidate belongs to the estimated current window.
+    slot_estimate: Option<SlotEstimate>,
 }
 
 impl LeaderTpuCacheService {
@@ -105,11 +102,10 @@ impl LeaderTpuCacheService {
             config.max_consecutive_failures,
         )
         .await?;
-        let current_slot = slot_receiver.slot();
-        let lookahead_leaders =
-            adjust_lookahead(current_slot, &slot_leaders, config.lookahead_leaders);
-        let leaders = leader_sockets(
-            current_slot,
+        let slot_estimate = slot_receiver.slot();
+        let lookahead_leaders = config.lookahead_leaders;
+        let (leaders, first_leader_in_current_window) = leader_sockets(
+            slot_estimate.slot,
             lookahead_leaders,
             &slot_leaders,
             &leader_tpu_map,
@@ -117,7 +113,7 @@ impl LeaderTpuCacheService {
 
         let (leaders_sender, leaders_receiver) = watch::channel(NodesTpuInfo {
             leaders,
-            extend: config.lookahead_leaders != lookahead_leaders,
+            slot_estimate: first_leader_in_current_window.then_some(slot_estimate),
         });
 
         let handle = tokio::spawn(Self::run_loop(
@@ -182,26 +178,23 @@ impl LeaderTpuCacheService {
                         break;
                     }
 
-                    let estimated_current_slot = slot_receiver.slot();
+                    let slot_estimate = slot_receiver.slot();
                     update_leader_info(
-                        estimated_current_slot,
+                        slot_estimate.slot,
                         cluster_info.as_ref(),
                         &mut epoch_info,
                         &mut slot_leaders,
                         &mut num_consecutive_failures,
                         config.max_consecutive_failures,
                     ).await?;
-                    let current_slot = slot_receiver.slot();
-                    let lookahead_leaders = adjust_lookahead(
-                        current_slot,
-                        &slot_leaders,
-                        config.lookahead_leaders,
-                    );
-                    let leaders = leader_sockets(current_slot, lookahead_leaders, &slot_leaders, &leader_tpu_map);
+                    let slot_estimate = slot_receiver.slot();
+                    let lookahead_leaders =
+                        config.lookahead_leaders;
+                    let (leaders, first_leader_in_current_window) = leader_sockets(slot_estimate.slot, lookahead_leaders, &slot_leaders, &leader_tpu_map);
 
                     if let Err(e) = leaders_sender.send(NodesTpuInfo {
                         leaders,
-                        extend: config.lookahead_leaders != lookahead_leaders
+                        slot_estimate: first_leader_in_current_window.then_some(slot_estimate)
                     }) {
                         warn!("Unexpectedly dropped leaders_sender: {e}");
                         return Err(Error::ChannelClosed);
@@ -290,6 +283,7 @@ async fn update_leader_info(
 
 /// Get the TPU sockets for slots starting from `first_slot` and until `first_slot +
 /// lookahead_leaders * NUM_CONSECUTIVE_LEADER_SLOTS`.
+/// Also returns whether the first socket belongs to the window containing `first_slot`.
 ///
 /// If it returns an empty vector, it might mean that we overran the local leader schedule cache or,
 /// less probable, that there is no TPU info available for corresponding slot leaders.
@@ -298,10 +292,11 @@ fn leader_sockets(
     lookahead_leaders: u8,
     slot_leaders: &SlotLeaders,
     leader_tpu_map: &LeaderTpuMap,
-) -> Vec<SocketAddr> {
+) -> (Vec<SocketAddr>, bool) {
     let lookahead_leaders = lookahead_leaders as usize;
     let fanout_slots = lookahead_leaders.saturating_mul(NUM_CONSECUTIVE_LEADER_SLOTS.get()) as u64;
     let mut leader_sockets = Vec::with_capacity(lookahead_leaders);
+    let mut first_leader_in_current_window = false;
     // `slot_leaders.first_slot` might have been advanced since caller last read it. Take the
     // greater of the two values to ensure we are reading from the latest leader schedule.
     let current_slot = std::cmp::max(first_slot, slot_leaders.first_slot);
@@ -310,6 +305,11 @@ fn leader_sockets(
     {
         if let Some(leader) = slot_leaders.slot_leader(leader_slot) {
             if let Some(tpu_socket) = leader_tpu_map.get(leader) {
+                if leader_sockets.is_empty() {
+                    let slots_per_window = NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64;
+                    first_leader_in_current_window =
+                        leader_slot / slots_per_window == first_slot / slots_per_window;
+                }
                 leader_sockets.push(*tpu_socket);
                 debug!("Pushed leader {leader} TPU socket: {tpu_socket}");
             } else {
@@ -327,7 +327,7 @@ fn leader_sockets(
         }
     }
 
-    leader_sockets
+    (leader_sockets, first_leader_in_current_window)
 }
 
 async fn initialize_state(
@@ -346,7 +346,7 @@ async fn initialize_state(
             leader_tpu_map = LeaderTpuMap::new(cluster_info).await.ok();
         }
         if epoch_info.is_none() {
-            epoch_info = EpochInfo::new(cluster_info, slot_receiver.slot())
+            epoch_info = EpochInfo::new(cluster_info, slot_receiver.slot().slot)
                 .await
                 .ok();
         }
@@ -356,7 +356,7 @@ async fn initialize_state(
         {
             slot_leaders = SlotLeaders::new(
                 cluster_info,
-                slot_receiver.slot(),
+                slot_receiver.slot().slot,
                 epoch_info.slots_in_epoch,
             )
             .await
@@ -377,17 +377,6 @@ async fn initialize_state(
         }
     }
     Err(Error::InitializationFailed)
-}
-
-fn adjust_lookahead(slot: Slot, slot_leaders: &SlotLeaders, lookahead_leaders: u8) -> u8 {
-    if slot_leaders
-        .is_leader_last_consecutive_slot(slot)
-        .unwrap_or(true)
-    {
-        lookahead_leaders.saturating_add(1)
-    } else {
-        lookahead_leaders
-    }
 }
 
 async fn try_update<F, Fut, T>(
@@ -468,18 +457,6 @@ impl SlotLeaders {
         slot.checked_sub(self.first_slot)
             .and_then(|index| self.leaders.get(index as usize))
     }
-
-    /// Returns `Some(true)` if the given `slot` is the last slot in the leader consecutive slots.
-    fn is_leader_last_consecutive_slot(&self, slot: Slot) -> Option<bool> {
-        slot.checked_sub(self.first_slot).and_then(|index| {
-            let index = index as usize;
-            if index + 1 < self.leaders.len() {
-                Some(self.leaders[index] != self.leaders[index + 1])
-            } else {
-                None
-            }
-        })
-    }
 }
 
 #[derive(PartialEq, Debug)]
@@ -545,4 +522,132 @@ fn extract_cluster_tpu_sockets(
             Some((pubkey, socket))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deadline_matches_first_returned_leader_window() {
+        let available_leader = Pubkey::new_unique();
+        let missing_leader = Pubkey::new_unique();
+        let address: SocketAddr = "127.0.0.1:8000".parse().unwrap();
+        let leader_tpu_map = LeaderTpuMap {
+            leader_tpu_map: HashMap::from([(available_leader, address)]),
+        };
+        for (
+            name,
+            cache_first_slot,
+            scheduled_leaders,
+            lookahead,
+            expected_sockets,
+            matches_window,
+        ) in [
+            (
+                "current window available",
+                4,
+                vec![available_leader; 8],
+                2,
+                vec![address, address],
+                true,
+            ),
+            (
+                "current window missing",
+                4,
+                [vec![missing_leader; 4], vec![available_leader; 4]].concat(),
+                2,
+                vec![address],
+                false,
+            ),
+            (
+                "all addresses missing",
+                4,
+                vec![missing_leader; 8],
+                2,
+                vec![],
+                false,
+            ),
+            (
+                "cache starts in the next window with the same leader",
+                8,
+                vec![available_leader; 4],
+                1,
+                vec![address],
+                false,
+            ),
+            (
+                "cache starts later in the current window",
+                6,
+                vec![available_leader; 4],
+                1,
+                vec![address],
+                true,
+            ),
+            (
+                "no candidates requested from cache",
+                4,
+                vec![available_leader; 4],
+                0,
+                vec![],
+                false,
+            ),
+        ] {
+            let slot_leaders = SlotLeaders {
+                first_slot: cache_first_slot,
+                leaders: scheduled_leaders,
+            };
+            let (leaders, first_leader_in_current_window) =
+                leader_sockets(5, lookahead, &slot_leaders, &leader_tpu_map);
+            assert_eq!(leaders, expected_sockets, "{name}");
+            assert_eq!(first_leader_in_current_window, matches_window, "{name}");
+
+            let (_sender, receiver) = watch::channel(NodesTpuInfo {
+                leaders,
+                slot_estimate: first_leader_in_current_window.then_some(SlotEstimate {
+                    slot: 5,
+                    leader_window_end_ms: Some(10_000),
+                }),
+            });
+            let receiver = LeaderUpdateReceiver { receiver };
+            let mut candidates = Vec::new();
+            let estimate = receiver.next_leaders(1, &mut candidates);
+            assert_eq!(
+                candidates,
+                expected_sockets[..expected_sockets.len().min(1)],
+                "{name}"
+            );
+            let expected_estimate = matches_window.then_some(SlotEstimate {
+                slot: 5,
+                leader_window_end_ms: Some(10_000),
+            });
+            assert_eq!(estimate, expected_estimate, "{name}");
+
+            candidates.clear();
+            let estimate = receiver.next_leaders(0, &mut candidates);
+            assert!(candidates.is_empty(), "{name}");
+            assert_eq!(estimate, expected_estimate, "{name}");
+            assert_eq!(receiver.receiver.borrow().slot_estimate, expected_estimate);
+        }
+    }
+
+    #[test]
+    fn test_matching_window_with_unknown_deadline_keeps_slot_estimate() {
+        let address: SocketAddr = "127.0.0.1:8000".parse().unwrap();
+        let slot_estimate = SlotEstimate {
+            slot: 5,
+            leader_window_end_ms: None,
+        };
+        let (_sender, receiver) = watch::channel(NodesTpuInfo {
+            leaders: vec![address],
+            slot_estimate: Some(slot_estimate),
+        });
+        let receiver = LeaderUpdateReceiver { receiver };
+        let mut candidates = Vec::new();
+        assert_eq!(
+            receiver.next_leaders(1, &mut candidates),
+            Some(slot_estimate)
+        );
+        assert_eq!(candidates, [address]);
+    }
 }

--- a/tpu-client-next/src/node_address_service/recent_leader_slots.rs
+++ b/tpu-client-next/src/node_address_service/recent_leader_slots.rs
@@ -1,10 +1,17 @@
 //! This module provides [`RecentLeaderSlots`] to track recent leader slots.
-use {crate::node_address_service::SlotEvent, solana_clock::Slot, std::collections::VecDeque};
+use {
+    crate::{leader_updater::SlotEstimate, node_address_service::SlotEvent},
+    solana_clock::Slot,
+    solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
+    std::collections::VecDeque,
+};
 
 // 48 chosen because it's unlikely that 12 leaders in a row will miss their slots
 const MAX_SLOT_SKIP_DISTANCE: u64 = 48;
 
 const RECENT_LEADER_SLOTS_CAPACITY: usize = 48;
+
+pub(crate) const MS_PER_SLOT: u64 = 350;
 
 #[derive(Debug)]
 pub struct RecentLeaderSlots(VecDeque<SlotEvent>);
@@ -29,9 +36,47 @@ impl RecentLeaderSlots {
         self.0.push_back(slot_event);
     }
 
-    // Estimate the current slot from recent slot notifications.
+    /// Returns estimated current slot and the estimated end timestamp of its leader window.
+    pub fn estimate_slot(&self) -> SlotEstimate {
+        let (slot, estimated_duration_ms) = self.estimate_slot_and_duration_ms();
+        let slot_duration = estimated_duration_ms.unwrap_or(MS_PER_SLOT);
+
+        const SLOTS_PER_WINDOW: u64 = NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64;
+        let window_start_slot = slot.saturating_sub(slot % SLOTS_PER_WINDOW);
+
+        let previous_slot = window_start_slot.checked_sub(1);
+        let mut previous_slot_end_event = None;
+        let mut window_start_event = None;
+        for event in &self.0 {
+            match event {
+                SlotEvent::Start { slot, .. } if *slot == window_start_slot => {
+                    window_start_event = Some(event);
+                    break;
+                }
+                SlotEvent::End { slot, .. } if Some(*slot) == previous_slot => {
+                    // Keep the most recently received matching end as the fallback.
+                    previous_slot_end_event = Some(event);
+                }
+                _ => {}
+            }
+        }
+        let window_start_event = window_start_event.or(previous_slot_end_event);
+
+        let leader_window_duration = SLOTS_PER_WINDOW.checked_mul(slot_duration);
+        let leader_window_end_ms = window_start_event
+            .map(SlotEvent::timestamp)
+            .zip(leader_window_duration)
+            .and_then(|(start, duration)| start.checked_add(duration));
+
+        SlotEstimate {
+            slot,
+            leader_window_end_ms,
+        }
+    }
+
+    // Estimate the current slot and slot duration from recent slot notifications.
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn estimate_current_slot(&self) -> Slot {
+    fn estimate_slot_and_duration_ms(&self) -> (Slot, Option<u64>) {
         let mut recent_slots: Vec<SlotEvent> = self.0.iter().cloned().collect();
         assert!(
             !recent_slots.is_empty(),
@@ -57,11 +102,22 @@ impl RecentLeaderSlots {
             .expect("no reasonable slot");
 
         let slot_event = &recent_slots[idx];
-        if slot_event.is_start() {
+        let estimated_slot = if slot_event.is_start() {
             slot_event.slot()
         } else {
             slot_event.slot().saturating_add(1)
-        }
+        };
+
+        let mut start_events = recent_slots[..=idx].iter().filter(|event| event.is_start());
+        let first = start_events.next();
+        let last = start_events.next_back();
+        let duration_ms = first.zip(last).and_then(|(first, last)| {
+            let elapsed_ms = last.timestamp().checked_sub(first.timestamp())?;
+            let elapsed_slots = last.slot().checked_sub(first.slot())?;
+            let duration_ms = elapsed_ms.checked_div(elapsed_slots)?;
+            (duration_ms > 0).then_some(duration_ms)
+        });
+        (estimated_slot, duration_ms)
     }
 }
 
@@ -77,8 +133,8 @@ mod tests {
             let mut events = VecDeque::with_capacity(recent_slots.len());
 
             for slot in recent_slots {
-                events.push_back(SlotEvent::Start(slot));
-                events.push_back(SlotEvent::End(slot));
+                events.push_back(SlotEvent::Start { slot, timestamp: 0 });
+                events.push_back(SlotEvent::End { slot, timestamp: 0 });
             }
 
             Self(events)
@@ -89,48 +145,222 @@ mod tests {
     fn test_recent_leader_slots() {
         let mut recent_slots: Vec<Slot> = (1..=12).collect();
         assert_eq!(
-            RecentLeaderSlots::from(recent_slots.clone()).estimate_current_slot(),
+            RecentLeaderSlots::from(recent_slots.clone())
+                .estimate_slot_and_duration_ms()
+                .0,
             13
         );
 
         recent_slots.reverse();
         assert_eq!(
-            RecentLeaderSlots::from(recent_slots).estimate_current_slot(),
+            RecentLeaderSlots::from(recent_slots)
+                .estimate_slot_and_duration_ms()
+                .0,
             13
         );
 
         let mut recent_slots = RecentLeaderSlots::new();
-        recent_slots.record(SlotEvent::Start(13));
-        assert_eq!(recent_slots.estimate_current_slot(), 13);
-        recent_slots.record(SlotEvent::Start(14));
-        assert_eq!(recent_slots.estimate_current_slot(), 14);
-        recent_slots.record(SlotEvent::Start(15));
-        assert_eq!(recent_slots.estimate_current_slot(), 15);
+        recent_slots.record(SlotEvent::Start {
+            slot: 13,
+            timestamp: 0,
+        });
+        assert_eq!(recent_slots.estimate_slot_and_duration_ms().0, 13);
+        recent_slots.record(SlotEvent::Start {
+            slot: 14,
+            timestamp: 0,
+        });
+        assert_eq!(recent_slots.estimate_slot_and_duration_ms().0, 14);
+        recent_slots.record(SlotEvent::Start {
+            slot: 15,
+            timestamp: 0,
+        });
+        assert_eq!(recent_slots.estimate_slot_and_duration_ms().0, 15);
 
         assert_eq!(
-            RecentLeaderSlots::from(vec![0, 1 + MAX_SLOT_SKIP_DISTANCE]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![0, 1 + MAX_SLOT_SKIP_DISTANCE])
+                .estimate_slot_and_duration_ms()
+                .0,
             2 + MAX_SLOT_SKIP_DISTANCE,
         );
         assert_eq!(
-            RecentLeaderSlots::from(vec![0, 2 + MAX_SLOT_SKIP_DISTANCE]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![0, 2 + MAX_SLOT_SKIP_DISTANCE])
+                .estimate_slot_and_duration_ms()
+                .0,
             3 + MAX_SLOT_SKIP_DISTANCE,
         );
 
         assert_eq!(
-            RecentLeaderSlots::from(vec![1, 100]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![1, 100])
+                .estimate_slot_and_duration_ms()
+                .0,
             2
         );
         assert_eq!(
-            RecentLeaderSlots::from(vec![1, 2, 100]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![1, 2, 100])
+                .estimate_slot_and_duration_ms()
+                .0,
             3
         );
         assert_eq!(
-            RecentLeaderSlots::from(vec![1, 2, 3, 100]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![1, 2, 3, 100])
+                .estimate_slot_and_duration_ms()
+                .0,
             4
         );
         assert_eq!(
-            RecentLeaderSlots::from(vec![1, 2, 3, 99, 100]).estimate_current_slot(),
+            RecentLeaderSlots::from(vec![1, 2, 3, 99, 100])
+                .estimate_slot_and_duration_ms()
+                .0,
             4
         );
+    }
+
+    #[test]
+    fn test_estimate_slot_window_start_fallback() {
+        let start = |slot, timestamp| SlotEvent::Start { slot, timestamp };
+        let end = |slot, timestamp| SlotEvent::End { slot, timestamp };
+        let cases = [
+            ("missing start", vec![end(7, 1750)], Some(3350)),
+            (
+                "start arrives after end",
+                vec![end(7, 1750), start(8, 1800)],
+                Some(3400),
+            ),
+            (
+                "end arrives after start",
+                vec![start(8, 1800), end(7, 1850)],
+                Some(3400),
+            ),
+            (
+                "duplicate start preserves first observation",
+                vec![end(7, 1750), start(8, 1800), start(9, 2200), start(8, 2300)],
+                Some(3400),
+            ),
+            ("both anchors missing", vec![start(9, 2200)], None),
+        ];
+
+        for (name, events, expected_end_ms) in cases {
+            let mut recent_slots = RecentLeaderSlots::new();
+            // Start-to-start timing gives 400 ms per slot, or 1600 ms per window.
+            for event in [start(6, 1000), start(7, 1400)].into_iter().chain(events) {
+                recent_slots.record(event);
+            }
+
+            // Use End(7) only without Start(8), regardless of arrival order.
+            assert_eq!(
+                recent_slots.estimate_slot().leader_window_end_ms,
+                expected_end_ms,
+                "{name}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_estimate_slot_duration_ms() {
+        let start = |slot, timestamp| SlotEvent::Start { slot, timestamp };
+        let end = |slot, timestamp| SlotEvent::End { slot, timestamp };
+        let cases = [
+            ("one start", vec![start(1, 1000)], None),
+            ("only ends", vec![end(1, 1000), end(2, 1400)], None),
+            (
+                "one start and one end",
+                vec![start(1, 1000), end(1, 1400)],
+                None,
+            ),
+            ("duplicate slot", vec![start(1, 1000), start(1, 1400)], None),
+            (
+                "equal timestamps",
+                vec![start(1, 1000), start(2, 1000)],
+                None,
+            ),
+            (
+                "backward timestamps",
+                vec![start(1, 1400), start(2, 1000)],
+                None,
+            ),
+            (
+                "duration rounds to zero",
+                vec![start(1, 1000), start(3, 1001)],
+                None,
+            ),
+            (
+                "consecutive slots",
+                vec![start(1, 1000), start(2, 1400)],
+                Some(400),
+            ),
+            (
+                "missing notifications",
+                vec![start(1, 1000), start(5, 2600)],
+                Some(400),
+            ),
+            (
+                "out of order with uneven intervals and end timestamps ignored",
+                vec![
+                    start(3, 1800),
+                    end(3, 9999),
+                    start(1, 1000),
+                    end(1, 9999),
+                    start(2, 1600),
+                ],
+                Some(400),
+            ),
+            (
+                "future outlier",
+                vec![
+                    start(1, 1000),
+                    start(2, 1400),
+                    start(3, 1800),
+                    start(100, 99999),
+                ],
+                Some(400),
+            ),
+            (
+                "only one start survives filtering",
+                vec![start(1, 1000), start(100, 99999)],
+                None,
+            ),
+            (
+                "end events contribute to the future-slot cutoff",
+                vec![
+                    start(1, 1000),
+                    end(30, 10000),
+                    end(31, 11000),
+                    end(32, 12000),
+                    end(33, 13000),
+                    start(60, 24600),
+                ],
+                Some(400),
+            ),
+        ];
+
+        for (name, events, expected) in cases {
+            let mut recent_slots = RecentLeaderSlots::new();
+            for event in events {
+                recent_slots.record(event);
+            }
+            assert_eq!(
+                recent_slots.estimate_slot_and_duration_ms().1,
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_estimate_slot_duration_ms_after_window_eviction() {
+        let mut recent_slots = RecentLeaderSlots::new();
+        recent_slots.record(SlotEvent::Start {
+            slot: 0,
+            timestamp: 0,
+        });
+        for slot in 1..=RECENT_LEADER_SLOTS_CAPACITY as u64 {
+            recent_slots.record(SlotEvent::Start {
+                slot,
+                timestamp: 1000 + slot * 400,
+            });
+        }
+
+        // The initial sample must no longer affect the duration of the retained slots.
+        assert_eq!(recent_slots.estimate_slot_and_duration_ms().1, Some(400));
     }
 }

--- a/tpu-client-next/src/node_address_service/slot_event.rs
+++ b/tpu-client-next/src/node_address_service/slot_event.rs
@@ -7,20 +7,27 @@ use solana_clock::Slot;
 /// [`SlotEvent`] represents slot start and end events.
 #[derive(Debug, Clone)]
 pub enum SlotEvent {
-    Start(Slot),
-    End(Slot),
+    Start { slot: Slot, timestamp: u64 },
+    End { slot: Slot, timestamp: u64 },
 }
 
 impl SlotEvent {
     /// Get the slot associated with the event.
     pub fn slot(&self) -> Slot {
         match self {
-            SlotEvent::Start(slot) | SlotEvent::End(slot) => *slot,
+            SlotEvent::Start { slot, .. } | SlotEvent::End { slot, .. } => *slot,
+        }
+    }
+
+    /// Get the timestamp in milliseconds associated with the event.
+    pub fn timestamp(&self) -> u64 {
+        match self {
+            SlotEvent::Start { timestamp, .. } | SlotEvent::End { timestamp, .. } => *timestamp,
         }
     }
 
     /// Check if the event is a start event.
     pub fn is_start(&self) -> bool {
-        matches!(self, SlotEvent::Start(_))
+        matches!(self, SlotEvent::Start { .. })
     }
 }

--- a/tpu-client-next/src/node_address_service/slot_receiver.rs
+++ b/tpu-client-next/src/node_address_service/slot_receiver.rs
@@ -1,16 +1,16 @@
 //! This module provides [`SlotReceiver`] structure.
-use {solana_clock::Slot, thiserror::Error, tokio::sync::watch};
+use {crate::leader_updater::SlotEstimate, thiserror::Error, tokio::sync::watch};
 
 /// Receiver for slot updates from slot update services.
 #[derive(Clone)]
-pub struct SlotReceiver(watch::Receiver<Slot>);
+pub struct SlotReceiver(watch::Receiver<SlotEstimate>);
 
 impl SlotReceiver {
-    pub fn new(receiver: watch::Receiver<Slot>) -> Self {
+    pub fn new(receiver: watch::Receiver<SlotEstimate>) -> Self {
         Self(receiver)
     }
 
-    pub fn slot(&self) -> Slot {
+    pub fn slot(&self) -> SlotEstimate {
         *self.0.borrow()
     }
 

--- a/tpu-client-next/src/node_address_service/slot_update_service.rs
+++ b/tpu-client-next/src/node_address_service/slot_update_service.rs
@@ -2,6 +2,7 @@
 //! stream.
 use {
     crate::{
+        leader_updater::SlotEstimate,
         logging::info,
         node_address_service::{RecentLeaderSlots, SlotEvent, SlotReceiver},
     },
@@ -28,23 +29,33 @@ impl SlotUpdateService {
         cancel: CancellationToken,
     ) -> Result<(SlotReceiver, Self), Error> {
         let mut recent_slots = RecentLeaderSlots::new();
-        let (slot_sender, slot_receiver) = watch::channel(initial_current_slot);
+        let initial_slot_estimate = SlotEstimate {
+            slot: initial_current_slot,
+            leader_window_end_ms: None,
+        };
+        let (slot_sender, slot_receiver) = watch::channel(initial_slot_estimate);
         let cancel_clone = cancel.clone();
 
         let main_loop = async move {
             let mut slot_update_stream = pin!(slot_update_stream);
-            let mut cached_estimated_slot = initial_current_slot;
+            let mut cached_estimate = initial_slot_estimate;
             loop {
                 tokio::select! {
-                    Some(slot_event) = slot_update_stream.next() => {
-                        recent_slots.record(slot_event);
-                        let estimated_slots = recent_slots.estimate_current_slot();
-                        // Send update only if the estimated slot has advanced.
-                        if estimated_slots > cached_estimated_slot && slot_sender.send(estimated_slots).is_err() {
-                            info!("Stop SlotUpdateService: all slot receivers have been dropped.");
+                    slot_event = slot_update_stream.next() => {
+                        let Some(slot_event) = slot_event else {
+                            info!("Slot update stream closed, exiting slot watcher.");
                             break;
+                        };
+                        recent_slots.record(slot_event);
+                        let estimated_slot = recent_slots.estimate_slot();
+                        if should_publish(&estimated_slot, &cached_estimate)
+                        {
+                            if slot_sender.send(estimated_slot).is_err() {
+                                info!("Stop SlotUpdateService: all slot receivers have been dropped.");
+                                break;
+                            }
+                            cached_estimate = estimated_slot;
                         }
-                        cached_estimated_slot = estimated_slots;
                     }
 
                     _ = cancel.cancelled() => {
@@ -84,4 +95,54 @@ pub enum Error {
 
     #[error("Failed to initialize WebsocketSlotUpdateService.")]
     InitializationFailed,
+}
+
+/// Returns whether to publish the next estimate: the slot advances or the same slot's estimated
+/// window end changes. Ignores older slots and unchanged estimates.
+fn should_publish(current: &SlotEstimate, previous: &SlotEstimate) -> bool {
+    current.slot > previous.slot
+        || (current.slot == previous.slot
+            && current.leader_window_end_ms != previous.leader_window_end_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, futures::channel::mpsc, std::time::Duration, tokio::time::timeout};
+
+    #[tokio::test]
+    async fn test_publishes_timing_changes_for_same_slot() {
+        let (event_sender, event_receiver) = mpsc::unbounded();
+        let (mut receiver, mut service) =
+            SlotUpdateService::run(7, event_receiver, CancellationToken::new()).unwrap();
+
+        let start = |slot, timestamp| SlotEvent::Start { slot, timestamp };
+        let end = |slot, timestamp| SlotEvent::End { slot, timestamp };
+        let cases = [
+            // End(7) advances to slot 8 with fallback timing at 350 ms per slot.
+            (end(7, 1750), 8, 3150),
+            // Start(8) refines the window start without advancing the slot.
+            (start(8, 1800), 8, 3200),
+            // A delayed Start(7) refines the duration to 400 ms, still in slot 8.
+            (start(7, 1400), 8, 3400),
+            // Advancing the slot must also publish when the timing is unchanged.
+            (end(8, 2150), 9, 3400),
+        ];
+
+        for (event, slot, leader_window_end_ms) in cases {
+            event_sender.unbounded_send(event).unwrap();
+            timeout(Duration::from_secs(1), receiver.changed())
+                .await
+                .expect("slot estimate was not published")
+                .unwrap();
+            assert_eq!(
+                receiver.slot(),
+                SlotEstimate {
+                    slot,
+                    leader_window_end_ms: Some(leader_window_end_ms),
+                },
+            );
+        }
+
+        service.shutdown().await.unwrap();
+    }
 }

--- a/tpu-client-next/src/websocket_node_address_service.rs
+++ b/tpu-client-next/src/websocket_node_address_service.rs
@@ -120,9 +120,10 @@ fn websocket_slot_event_stream(
 }
 
 fn map_websocket_update_to_slot_event(update: SlotUpdate) -> Option<SlotEvent> {
+    let timestamp = solana_time_utils::timestamp();
     match update {
-        SlotUpdate::FirstShredReceived { slot, .. } => Some(SlotEvent::Start(slot)),
-        SlotUpdate::Completed { slot, .. } => Some(SlotEvent::End(slot)),
+        SlotUpdate::FirstShredReceived { slot, .. } => Some(SlotEvent::Start { slot, timestamp }),
+        SlotUpdate::Completed { slot, .. } => Some(SlotEvent::End { slot, timestamp }),
         _ => None,
     }
 }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -5,12 +5,20 @@
 use {
     crate::{
         SendTransactionStats, WireTransaction,
-        connection_worker::ConnectionWorker,
+        connection_worker::{ConnectionWorker, RTT_UNSET},
         logging::{debug, trace},
     },
     lru::LruCache,
     quinn::Endpoint,
-    std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration},
+    std::{
+        net::SocketAddr,
+        num::NonZeroUsize,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::Duration,
+    },
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::TrySendError},
@@ -23,6 +31,7 @@ use {
 /// transactions.
 pub struct WorkerInfo {
     sender: mpsc::Sender<WireTransaction>,
+    rtt_ms: Arc<AtomicU64>,
     handle: JoinHandle<()>,
     cancel: CancellationToken,
 }
@@ -30,11 +39,13 @@ pub struct WorkerInfo {
 impl WorkerInfo {
     pub fn new(
         sender: mpsc::Sender<WireTransaction>,
+        rtt_ms: Arc<AtomicU64>,
         handle: JoinHandle<()>,
         cancel: CancellationToken,
     ) -> Self {
         Self {
             sender,
+            rtt_ms,
             handle,
             cancel,
         }
@@ -75,6 +86,13 @@ impl WorkerInfo {
     fn is_active(&self) -> bool {
         !(self.cancel.is_cancelled() || self.sender.is_closed())
     }
+
+    fn rtt_ms(&self) -> Option<u64> {
+        match self.rtt_ms.load(Ordering::Relaxed) {
+            RTT_UNSET => None,
+            rtt_ms => Some(rtt_ms),
+        }
+    }
 }
 
 /// Spawns a worker to handle communication with a given peer.
@@ -89,6 +107,7 @@ pub fn spawn_worker(
     let (transaction_sender, transaction_receiver) = mpsc::channel(worker_channel_size);
     let endpoint = endpoint.clone();
     let peer = *peer;
+    let rtt_ms = Arc::new(AtomicU64::new(RTT_UNSET));
 
     let (mut worker, cancel) = ConnectionWorker::new(
         endpoint,
@@ -96,13 +115,14 @@ pub fn spawn_worker(
         transaction_receiver,
         max_reconnect_attempts,
         stats,
+        rtt_ms.clone(),
         handshake_timeout,
     );
     let handle = tokio::spawn(async move {
         worker.run().await;
     });
 
-    WorkerInfo::new(transaction_sender, handle, cancel)
+    WorkerInfo::new(transaction_sender, rtt_ms, handle, cancel)
 }
 
 /// [`WorkersCache`] manages and caches workers. It uses an LRU cache to store and
@@ -283,6 +303,10 @@ impl WorkersCache {
             .run_until_cancelled(body)
             .await
             .unwrap_or(Err(WorkersCacheError::ShutdownError))
+    }
+
+    pub(crate) fn rtt_ms(&self, peer: &SocketAddr) -> Option<u64> {
+        self.workers.peek(peer)?.rtt_ms()
     }
 
     /// Flushes the cache and asynchronously shuts down all workers. This method

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -62,6 +62,8 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
         // the speed of fastest leader.
         worker_channel_size: 100,
         max_reconnect_attempts: 4,
+        skip_current_leader_if_late: false,
+        slot_update_latency: 0,
         leaders_fanout: Fanout {
             send: 1,
             connect: 1,


### PR DESCRIPTION
#### Problem

With slot time 200ms (and, in future, 2 slots per leader window), client sending transaction over TPU is more sensitive to the leader misprediction.

We want to improve on this side to make transaction landing more predictable

#### Summary of Changes

Use RTT/2 from connection and estimate the time until the end of the leader window to make a decision if skipping the next leader.


#### Details

<img width="682" height="190" alt="Screenshot 2026-09-12 at 12 15 03" src="https://github.com/user-attachments/assets/5408576a-195b-4346-950c-10c34b09db44" />

* `L` - latency of receiving slot updates. Client receives them from somewhere and there it is lack between the moment of time when slot changed and client actually observed it.
* `t_0`, `t_1` … – time when client receives signal that the corresponding slot started. So this is observed value on client side.
* `t` – time at the given moment of time since the start of the leader window. It is again observed by client.
* `RTT/2` – half of RTT of the connection to the current Leader 1.
* `dT` – time left to the end of leader window of Leader 1.

When a client receives a transaction to send it needs to understand the target leader (1 or 2 in this example). Assuming send Fanout=1, 
* client observed slot is `X` (on the picture is `3`),
* client also knows `(t - t_0)` = time passed since `t_0`. 
* from that we compute estimated slot duration for this leader as dt = `((t_1 - t_0) + (t_2 - t_1) + …)/N`
* If `RTT/2 + L > dT = 4 * dt - t` => send to the next leader.

There are two problems:
1. `L` cannot be estimated from client prospective, so it should be provided by user,
2. The quality of the `dT` estimation might be low. There 3 reasons: shred delays, RPC problems, and malicious behaviour of shred provider (slot stretching, for example). 

The second problem shall be solved elsewhere, this PR is big enough. 

#### Testing

Tested with transaction-bench and rate-latency-tool (modified) on mainnet and testnet.
On mainnet, when client is located in tokyo, this change improves latency in the experiment significantly:

<img width="606" height="366" alt="Screenshot 2026-09-11 at 18 10 51" src="https://github.com/user-attachments/assets/99b53c71-630c-4d08-bf23-115619222186" />

<img width="609" height="370" alt="Screenshot 2026-09-11 at 18 10 55" src="https://github.com/user-attachments/assets/c092c3bb-1830-4ceb-ae6a-a637b924591a" />

Also it reduces the drop rate by the same margin. 