### PR TITLE
Remove the AccountsDb foreground threadpool

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -81,7 +81,6 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
-    solana_rayon_threadlimit::get_thread_count,
     std::{
         borrow::Cow,
         boxed::Box,
@@ -103,7 +102,6 @@ use {
 // when the accounts write cache exceeds this many bytes, we will flush it
 // this can be specified on the command line, too (--accounts-db-write-cache-limit)
 const WRITE_CACHE_LIMIT_BYTES_DEFAULT: u64 = 15_000_000_000;
-const SCAN_SLOT_PAR_ITER_THRESHOLD: usize = 4000;
 
 const DEFAULT_NUM_DIRS: u32 = 4;
 
@@ -803,8 +801,6 @@ pub struct AccountsDb {
     #[allow(dead_code)]
     pub temp_paths: Option<Vec<TempDir>>,
 
-    /// Thread pool for foreground tasks, e.g. transaction processing
-    pub thread_pool_foreground: ThreadPool,
     /// Thread pool for background tasks, e.g. AccountsBackgroundService and flush/clean/shrink
     pub thread_pool_background: ThreadPool,
 
@@ -899,10 +895,6 @@ pub fn quarter_thread_count() -> usize {
     std::cmp::max(2, num_cpus::get() / 4)
 }
 
-pub fn default_num_foreground_threads() -> usize {
-    get_thread_count()
-}
-
 impl AccountsDb {
     // The default high and low watermark sizes for the accounts read cache.
     // If the cache size exceeds MAX_SIZE_HI, it'll evict entries until the size is <= MAX_SIZE_LO.
@@ -957,20 +949,6 @@ impl AccountsDb {
             .read_cache_num_shards
             .unwrap_or(Self::DEFAULT_READ_ONLY_CACHE_NUM_SHARDS);
 
-        // Increase the stack for foreground threads
-        // rayon needs a lot of stack
-        const ACCOUNTS_STACK_SIZE: usize = 8 * 1024 * 1024;
-        let num_foreground_threads = accounts_db_config
-            .num_foreground_threads
-            .map(Into::into)
-            .unwrap_or_else(default_num_foreground_threads);
-        let thread_pool_foreground = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_foreground_threads)
-            .thread_name(|i| format!("solAcctsDbFg{i:02}"))
-            .stack_size(ACCOUNTS_STACK_SIZE)
-            .build()
-            .expect("new rayon threadpool");
-
         let num_background_threads = accounts_db_config
             .num_background_threads
             .map(Into::into)
@@ -1010,7 +988,6 @@ impl AccountsDb {
             partitioned_epoch_rewards_config: accounts_db_config.partitioned_epoch_rewards_config,
             verify_index: accounts_db_config.verify_index,
             scan_filter_for_shrinking: accounts_db_config.scan_filter_for_shrinking,
-            thread_pool_foreground,
             thread_pool_background,
             active_stats: ActiveStats::default(),
             storage: AccountStorage::default(),
@@ -2741,29 +2718,16 @@ impl AccountsDb {
         if let Some(slot_cache) = self.accounts_cache.slot_cache(slot) {
             // If we see the slot in the cache, then all the account information
             // is in this cached slot
-            if slot_cache.len() > SCAN_SLOT_PAR_ITER_THRESHOLD {
-                ScanStorageResult::Cached(self.thread_pool_foreground.install(|| {
-                    slot_cache
-                        .par_iter()
-                        .filter_map(|cached_account| {
-                            cache_map_func(&LoadedAccount::Cached(Cow::Borrowed(
-                                cached_account.value(),
-                            )))
-                        })
-                        .collect()
-                }))
-            } else {
-                ScanStorageResult::Cached(
-                    slot_cache
-                        .iter()
-                        .filter_map(|cached_account| {
-                            cache_map_func(&LoadedAccount::Cached(Cow::Borrowed(
-                                cached_account.value(),
-                            )))
-                        })
-                        .collect(),
-                )
-            }
+            ScanStorageResult::Cached(
+                slot_cache
+                    .iter()
+                    .filter_map(|cached_account| {
+                        cache_map_func(&LoadedAccount::Cached(Cow::Borrowed(
+                            cached_account.value(),
+                        )))
+                    })
+                    .collect(),
+            )
         } else {
             let mut retval = B::default();
             // If the slot is not in the cache, then all the account information must have

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -40,8 +40,6 @@ pub struct AccountsDbConfig {
     pub scan_filter_for_shrinking: ScanFilter,
     /// Number of threads for background operations (`thread_pool_background')
     pub num_background_threads: Option<NonZeroUsize>,
-    /// Number of threads for foreground operations (`thread_pool_foreground`)
-    pub num_foreground_threads: Option<NonZeroUsize>,
     pub accounts_file_provider: AccountsFileProvider,
 }
 
@@ -62,7 +60,6 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     num_background_threads: None,
-    num_foreground_threads: None,
     accounts_file_provider: AccountsFileProvider::AppendVec,
 };
 
@@ -83,6 +80,5 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     partitioned_epoch_rewards_config: DEFAULT_PARTITIONED_EPOCH_REWARDS_CONFIG,
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
     num_background_threads: None,
-    num_foreground_threads: None,
     accounts_file_provider: AccountsFileProvider::AppendVec,
 };

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -384,7 +384,6 @@ pub fn get_accounts_db_config(
         partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
         scan_filter_for_shrinking,
         num_background_threads: None,
-        num_foreground_threads: None,
         accounts_file_provider: AccountsFileProvider::AppendVec,
     }
 }

--- a/runtime/src/conformance/mod.rs
+++ b/runtime/src/conformance/mod.rs
@@ -76,7 +76,6 @@ pub(crate) fn new_accounts_db_config_for_tests_single_threaded() -> AccountsDbCo
     let single_thread = NonZeroUsize::new(1).unwrap();
     AccountsDbConfig {
         num_background_threads: Some(single_thread),
-        num_foreground_threads: Some(single_thread),
         read_cache_num_shards: Some(2),
         skip_initial_hash_calc: true,
         ..ACCOUNTS_DB_CONFIG_FOR_TESTING
@@ -92,7 +91,6 @@ mod tests {
         let accounts = new_accounts_for_tests_single_threaded();
         let accounts_db = &accounts.accounts_db;
         assert!(accounts_db.skip_initial_hash_calc);
-        assert_eq!(accounts_db.thread_pool_foreground.current_num_threads(), 1);
         assert_eq!(accounts_db.thread_pool_background.current_num_threads(), 1);
     }
 
@@ -108,6 +106,5 @@ mod tests {
         assert!(!config.verify_index);
         assert_eq!(config.read_cache_num_shards, Some(2));
         assert_eq!(config.num_background_threads, Some(one));
-        assert_eq!(config.num_foreground_threads, Some(one));
     }
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -164,6 +164,15 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         replaced_by: "accounts-db-write-cache-limit",
     );
     add_arg!(
+        // deprecated in v4.4.0
+        Arg::with_name("accounts_db_foreground_threads")
+            .long("accounts-db-foreground-threads")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .validator(is_parsable::<usize>)
+            .help("No-op; AccountsDb no longer uses a foreground thread pool"),
+    );
+    add_arg!(
         // deprecated in v4.3.0
         Arg::with_name("disable_banking_trace")
             .long("disable-banking-trace")

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -12,7 +12,6 @@ use {
 // Need this struct to provide &str whose lifetime matches that of the CLAP Arg's
 pub struct DefaultThreadArgs {
     pub accounts_db_background_threads: String,
-    pub accounts_db_foreground_threads: String,
     pub accounts_index_flush_threads: String,
     pub block_production_num_workers: String,
     pub ip_echo_server_threads: String,
@@ -33,8 +32,6 @@ impl Default for DefaultThreadArgs {
     fn default() -> Self {
         Self {
             accounts_db_background_threads: AccountsDbBackgroundThreadsArg::bounded_default()
-                .to_string(),
-            accounts_db_foreground_threads: AccountsDbForegroundThreadsArg::bounded_default()
                 .to_string(),
             accounts_index_flush_threads: AccountsIndexFlushThreadsArg::bounded_default()
                 .to_string(),
@@ -63,7 +60,6 @@ impl Default for DefaultThreadArgs {
 pub fn thread_args<'a>(defaults: &DefaultThreadArgs) -> Vec<Arg<'_, 'a>> {
     vec![
         new_thread_arg::<AccountsDbBackgroundThreadsArg>(&defaults.accounts_db_background_threads),
-        new_thread_arg::<AccountsDbForegroundThreadsArg>(&defaults.accounts_db_foreground_threads),
         new_thread_arg::<AccountsIndexFlushThreadsArg>(&defaults.accounts_index_flush_threads),
         new_thread_arg::<BlockProductionNumWorkersArg>(&defaults.block_production_num_workers),
         new_thread_arg::<IpEchoServerThreadsArg>(&defaults.ip_echo_server_threads),
@@ -98,7 +94,6 @@ pub(crate) fn new_thread_arg<'a, T: ThreadArg>(default: &str) -> Arg<'_, 'a> {
 
 pub struct NumThreadConfig {
     pub accounts_db_background_threads: NonZeroUsize,
-    pub accounts_db_foreground_threads: NonZeroUsize,
     pub accounts_index_flush_threads: NonZeroUsize,
     pub block_production_num_workers: NonZeroUsize,
     pub ip_echo_server_threads: NonZeroUsize,
@@ -120,11 +115,6 @@ pub fn parse_num_threads_args(matches: &ArgMatches) -> NumThreadConfig {
         accounts_db_background_threads: value_t_or_exit!(
             matches,
             AccountsDbBackgroundThreadsArg::NAME,
-            NonZeroUsize
-        ),
-        accounts_db_foreground_threads: value_t_or_exit!(
-            matches,
-            AccountsDbForegroundThreadsArg::NAME,
             NonZeroUsize
         ),
         accounts_index_flush_threads: value_t_or_exit!(
@@ -228,18 +218,6 @@ impl ThreadArg for AccountsDbBackgroundThreadsArg {
 
     fn default() -> usize {
         accounts_db::quarter_thread_count()
-    }
-}
-
-struct AccountsDbForegroundThreadsArg;
-impl ThreadArg for AccountsDbForegroundThreadsArg {
-    const NAME: &'static str = "accounts_db_foreground_threads";
-    const LONG_NAME: &'static str = "accounts-db-foreground-threads";
-    const HELP: &'static str =
-        "Number of threads to use for AccountsDb foreground tasks, e.g. transaction processing";
-
-    fn default() -> usize {
-        accounts_db::default_num_foreground_threads()
     }
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -113,7 +113,6 @@ pub fn execute(
 
     let cli::thread_args::NumThreadConfig {
         accounts_db_background_threads,
-        accounts_db_foreground_threads,
         accounts_index_flush_threads,
         block_production_num_workers,
         ip_echo_server_threads,
@@ -723,7 +722,6 @@ pub fn execute(
         partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
-        num_foreground_threads: Some(accounts_db_foreground_threads),
         accounts_file_provider: AccountsFileProvider::AppendVec,
     };
 


### PR DESCRIPTION
#### Problem
AccountsDB foreground threadpool only has one remaining usage in scan_account_storage. scan_account_storage is only called in the event of debug or rpc (get_program_accounts), and only uses the thread_pool if the number of accounts is in a slot is > 4000. In practice > 4000 accounts in a single slot is unlikely

I tested on a validator running get_accounts_for_bank_hash_details on every slot. I forced both parallel and serial: 
Mean data: 
<img width="895" height="241" alt="image" src="https://github.com/user-attachments/assets/99d916c0-4d12-43e9-92f6-8c68824d688d" />
The mean is about the same, but the variation is much higher when doing parallel scans.

This is more obvious in the max :
<img width="895" height="241" alt="image" src="https://github.com/user-attachments/assets/888d0d42-bb9b-441d-9890-d166c5af6b50" />

The min is better for parallel scans
<img width="895" height="241" alt="image" src="https://github.com/user-attachments/assets/eb42a177-91da-4f93-b028-485864e493e5" />

But saving 50us in the fastest case, while losing 15ms in the slowest case seems like a terrible trade off. 

#### Summary of Changes
- Remove the usage of foreground threadpool in scan_account_storage

#### Testing
- Validated that deprecation was done correctly, and will not stop a validator from booting. 
```
[90m[[0m2026-09-11T20:29:18.316335165Z [33mWARN [0m agave_validator::cli[90m][0m --accounts-db-foreground-threads is deprecated.
```
Fixes #
