### PR TITLE
blockstore: Demote panic to error + error log

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5146,11 +5146,14 @@ impl Blockstore {
                 .tuple_windows()
                 .all(|(a, b)| a.start < a.end && a.end == b.start && b.start < b.end)
         );
-        let maybe_panic = |index: u64| {
+        let maybe_print_error = |index: u64| {
             if let Some(slot_meta) = slot_meta
                 && slot > self.lowest_cleanup_slot()
             {
-                panic!("Missing shred. slot: {slot}, index: {index}, slot meta: {slot_meta:?}");
+                error!(
+                    "A data shred is believed to be present by SlotMeta but is actually missing. \
+                     Slot: {slot}, index: {index}, slot meta: {slot_meta:?}"
+                );
             }
         };
         let Some((&Range { start, .. }, &Range { end, .. })) =
@@ -5167,7 +5170,7 @@ impl Blockstore {
                 .zip(indices)
                 .map(|(shred, index)| {
                     shred?.ok_or_else(|| {
-                        maybe_panic(index);
+                        maybe_print_error(index);
                         BlockstoreError::MissingShred(slot, index)
                     })
                 });


### PR DESCRIPTION
#### Problem
The panic log dates way back to when we didn't have synchronization figured out for this code path. We have since sured things up and have generally been aiming to replace panics with errors in Blockstore to let the caller decide what to do

#### Summary of Changes
Replace panic with error log; the code already bubbles an error up

#### Testing
CI